### PR TITLE
feat: Prep SQLite backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ apps/*/dist
 dist
 build
 coverage
+.cliparr-data
 *.tsbuildinfo
 
 .git

--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,18 @@ APP_URL="http://localhost:3000"
 # PORT: Express server port.
 PORT="3000"
 
+# CLIPARR_DATA_DIR: Directory where Cliparr stores its required SQLite database.
+# Docker uses /data and should mount it as a persistent volume.
+CLIPARR_DATA_DIR="./.cliparr-data"
+
 # PLEX_CLIENT_IDENTIFIER: Optional stable Plex client ID.
 # If omitted, Cliparr creates one at server startup.
 # PLEX_CLIENT_IDENTIFIER="cliparr-local"
 
 # CLIPARR_API_URL: Optional frontend dev proxy target when running Vite separately.
 # CLIPARR_API_URL="http://localhost:3000"
+
+# CLIPARR_FRONTEND_URL: Optional frontend dev server URL used by the API server
+# when redirecting auth callback routes in development.
+# Defaults to http://localhost:5173.
+# CLIPARR_FRONTEND_URL="http://localhost:5173"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 build/
 dist/
 coverage/
+.cliparr-data/
 .DS_Store
 *.log
 *.tsbuildinfo

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+auto-install-peers=false
+peerDependencyRules.ignoreMissing[]=mssql
+peerDependencyRules.ignoreMissing[]=@types/mssql

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Run the development server:
 pnpm dev
 ```
 
+Open the app at http://localhost:5173. The API server runs on http://localhost:3000 and redirects auth callback pages back to the Vite frontend during development.
+
 Before opening a pull request, run:
 
 ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 
 FROM base AS build
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/server/package.json apps/server/package.json
 COPY apps/frontend/package.json apps/frontend/package.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,18 @@ FROM node:24-slim AS runner
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV CLIPARR_DATA_DIR=/data
 
 WORKDIR /app
 
 COPY --from=build --chown=node:node /prod/apps/server ./apps/server
 COPY --from=build --chown=node:node /app/apps/frontend/dist ./apps/frontend/dist
 
+RUN mkdir -p /data && chown node:node /data
+
 USER node
+
+VOLUME ["/data"]
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,20 @@ Built with [Mediabunny](https://mediabunny.dev/) and [`react-timeline-editor`](h
 The easiest way to run Cliparr is using the official image from the GitHub Container Registry:
 
 ```sh
-docker run --rm -p 3000:3000 -e APP_URL=http://localhost:3000 ghcr.io/techsquidtv/cliparr:latest
+docker run --rm -p 3000:3000 \
+  -e APP_URL=http://localhost:3000 \
+  -v cliparr-data:/data \
+  ghcr.io/techsquidtv/cliparr:latest
+```
+
+Cliparr requires SQLite storage for configured media sources and provider tokens. The container stores that database under `/data`, so mount it as a volume.
+
+### Docker Compose
+
+For local Docker usage, Compose will build the image and mount the database volume for you:
+
+```sh
+docker compose up --build
 ```
 
 ### Local Build
@@ -35,7 +48,10 @@ docker build -t cliparr .
 And run it:
 
 ```sh
-docker run --rm -p 3000:3000 -e APP_URL=http://localhost:3000 cliparr
+docker run --rm -p 3000:3000 \
+  -e APP_URL=http://localhost:3000 \
+  -v cliparr-data:/data \
+  cliparr
 ```
 
 

--- a/apps/server/drizzle.config.ts
+++ b/apps/server/drizzle.config.ts
@@ -1,0 +1,15 @@
+import "dotenv/config";
+import path from "path";
+import { defineConfig } from "drizzle-kit";
+
+const configuredDataDir = process.env.CLIPARR_DATA_DIR?.trim();
+const dataDir = configuredDataDir ? path.resolve(configuredDataDir) : path.resolve(process.cwd(), "../../.cliparr-data");
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: path.join(dataDir, "cliparr.sqlite"),
+  },
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,19 +7,21 @@
     "dev": "node --watch-path=./src --import tsx ./src/server.ts",
     "build": "tsc -p tsconfig.build.json",
     "lint": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate",
     "preview": "NODE_ENV=production tsx src/server.ts",
     "start": "NODE_ENV=production node dist/server.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "dotenv": "^17.4.2",
+    "drizzle-orm": "1.0.0-beta.21",
     "express": "^5.2.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
+    "drizzle-kit": "1.0.0-beta.21",
     "tsx": "^4.21.0",
-    "typescript": "~6.0.2",
-    "vite": "^8.0.8"
+    "typescript": "~6.0.2"
   }
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -40,7 +40,14 @@ export async function createApp() {
   if (process.env.NODE_ENV !== "production") {
     const frontendUrl = new URL(process.env.CLIPARR_FRONTEND_URL ?? DEFAULT_DEV_FRONTEND_URL);
     app.get(/^(?!\/api(?:\/|$)).*/, (req, res) => {
-      res.redirect(307, new URL(req.originalUrl, frontendUrl).toString());
+      const redirectUrl = new URL(frontendUrl);
+      const safePath = req.path.replace(/^\/+/, "/");
+      const queryIndex = req.originalUrl.indexOf("?");
+
+      redirectUrl.pathname = safePath;
+      redirectUrl.search = queryIndex >= 0 ? req.originalUrl.slice(queryIndex) : "";
+
+      res.redirect(307, redirectUrl.toString());
     });
   } else {
     const distPath = path.join(frontendRoot, "dist");
@@ -54,4 +61,3 @@ export async function createApp() {
 
   return { app };
 }
-

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,16 +1,21 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
+import { checkDatabaseHealth, initializeDatabase } from "./db/database.js";
 import { errorHandler, notFoundHandler } from "./http/errors.js";
 import { mediaRouter } from "./routes/media.js";
 import { providersRouter } from "./routes/providers.js";
 import { sessionRouter } from "./routes/session.js";
+import { sourcesRouter } from "./routes/sources.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");
 const frontendRoot = path.join(workspaceRoot, "apps/frontend");
+const DEFAULT_DEV_FRONTEND_URL = "http://localhost:5173";
 
 export async function createApp() {
+  initializeDatabase();
+
   const app = express();
 
   app.disable("x-powered-by");
@@ -22,31 +27,31 @@ export async function createApp() {
   });
 
   app.get("/api/health", (_req, res) => {
-    res.json({ status: "ok" });
+    checkDatabaseHealth();
+    res.json({ status: "ok", database: "ok" });
   });
 
   app.use("/api/providers", providersRouter);
   app.use("/api/session", sessionRouter);
+  app.use("/api/sources", sourcesRouter);
   app.use("/api/media", mediaRouter);
   app.use("/api", notFoundHandler);
 
   if (process.env.NODE_ENV !== "production") {
-    const { createServer: createViteServer } = await import("vite");
-    const vite = await createViteServer({
-      root: frontendRoot,
-      server: { middlewareMode: true },
-      appType: "spa",
+    const frontendUrl = new URL(process.env.CLIPARR_FRONTEND_URL ?? DEFAULT_DEV_FRONTEND_URL);
+    app.get(/^(?!\/api(?:\/|$)).*/, (req, res) => {
+      res.redirect(307, new URL(req.originalUrl, frontendUrl).toString());
     });
-    app.use(vite.middlewares);
   } else {
     const distPath = path.join(frontendRoot, "dist");
     app.use(express.static(distPath));
-    app.get("/{*path}", (_req, res) => {
+    app.get(/^(?!\/api(?:\/|$)).*/, (_req, res) => {
       res.sendFile(path.join(distPath, "index.html"));
     });
   }
 
   app.use(errorHandler);
 
-  return app;
+  return { app };
 }
+

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -1,0 +1,80 @@
+import fs from "fs";
+import path from "path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "url";
+import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
+import { runMigrations } from "./migrations.js";
+import * as schema from "./schema.js";
+
+const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
+const DEFAULT_DEVELOPMENT_DATA_DIR = ".cliparr-data";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(__dirname, "../../../..");
+
+export type CliparrDatabase = NodeSQLiteDatabase<typeof schema>;
+
+let sqlite: DatabaseSync | undefined;
+let database: CliparrDatabase | undefined;
+let databasePath: string | undefined;
+let dataDir: string | undefined;
+
+function resolveDataDir() {
+  const configuredDataDir = process.env.CLIPARR_DATA_DIR?.trim();
+  if (configuredDataDir) {
+    return path.resolve(configuredDataDir);
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("CLIPARR_DATA_DIR is required in production so the SQLite database has a persistent home.");
+  }
+
+  return path.join(workspaceRoot, DEFAULT_DEVELOPMENT_DATA_DIR);
+}
+
+export function initializeDatabase() {
+  if (database) {
+    return database;
+  }
+
+  dataDir = resolveDataDir();
+  fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+
+  databasePath = path.join(dataDir, DEFAULT_DATABASE_FILE);
+  sqlite = new DatabaseSync(databasePath);
+  sqlite.exec(`
+    PRAGMA foreign_keys = ON;
+    PRAGMA journal_mode = WAL;
+    PRAGMA busy_timeout = 5000;
+  `);
+  runMigrations(sqlite);
+  database = drizzle({ client: sqlite, schema });
+
+  return database;
+}
+
+export function getDatabase() {
+  if (!database) {
+    throw new Error("Database has not been initialized.");
+  }
+
+  return database;
+}
+
+export function getSqliteClient() {
+  if (!sqlite) {
+    throw new Error("Database has not been initialized.");
+  }
+
+  return sqlite;
+}
+
+export function getDatabaseInfo() {
+  return {
+    dataDir,
+    databasePath,
+  };
+}
+
+export function checkDatabaseHealth() {
+  getSqliteClient().prepare("SELECT 1 AS ok").get();
+}

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -18,6 +18,16 @@ let database: CliparrDatabase | undefined;
 let databasePath: string | undefined;
 let dataDir: string | undefined;
 
+function enforcePermissions(targetPath: string, mode: number) {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch (err) {
+    if (process.platform !== "win32") {
+      console.warn(`Could not set permissions on ${targetPath}:`, err);
+    }
+  }
+}
+
 function resolveDataDir() {
   const configuredDataDir = process.env.CLIPARR_DATA_DIR?.trim();
   if (configuredDataDir) {
@@ -38,9 +48,11 @@ export function initializeDatabase() {
 
   dataDir = resolveDataDir();
   fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  enforcePermissions(dataDir, 0o700);
 
   databasePath = path.join(dataDir, DEFAULT_DATABASE_FILE);
   sqlite = new DatabaseSync(databasePath);
+  enforcePermissions(databasePath, 0o600);
   sqlite.exec(`
     PRAGMA foreign_keys = ON;
     PRAGMA journal_mode = WAL;
@@ -66,6 +78,14 @@ export function getSqliteClient() {
   }
 
   return sqlite;
+}
+
+export function closeDatabase() {
+  if (sqlite) {
+    sqlite.close();
+    sqlite = undefined;
+    database = undefined;
+  }
 }
 
 export function getDatabaseInfo() {

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from "crypto";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { getDatabase } from "./database.js";
+import { mediaSources, type MediaSourceRow } from "./schema.js";
+
+export interface MediaSource {
+  id: string;
+  providerId: string;
+  providerAccountId?: string;
+  externalId?: string;
+  name: string;
+  enabled: boolean;
+  baseUrl: string;
+  connection: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  lastCheckedAt?: string;
+  lastError?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMediaSourceInput {
+  providerId: string;
+  providerAccountId?: string;
+  externalId?: string;
+  name: string;
+  enabled?: boolean;
+  baseUrl: string;
+  connection?: Record<string, unknown>;
+  credentials?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateMediaSourceInput {
+  providerAccountId?: string | null;
+  externalId?: string | null;
+  name?: string;
+  enabled?: boolean;
+  baseUrl?: string;
+  connection?: Record<string, unknown>;
+  credentials?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  lastCheckedAt?: string | null;
+  lastError?: string | null;
+}
+
+function mapMediaSource(row: MediaSourceRow): MediaSource {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    providerAccountId: row.providerAccountId ?? undefined,
+    externalId: row.externalId ?? undefined,
+    name: row.name,
+    enabled: row.enabled,
+    baseUrl: row.baseUrl,
+    connection: row.connection,
+    credentials: row.credentials,
+    metadata: row.metadata,
+    lastCheckedAt: row.lastCheckedAt ?? undefined,
+    lastError: row.lastError ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createMediaSource(input: CreateMediaSourceInput) {
+  const db = getDatabase();
+  const id = randomUUID();
+
+  db.insert(mediaSources).values({
+    id,
+    providerId: input.providerId,
+    providerAccountId: input.providerAccountId ?? null,
+    externalId: input.externalId ?? null,
+    name: input.name,
+    enabled: input.enabled ?? true,
+    baseUrl: input.baseUrl,
+    connection: input.connection ?? {},
+    credentials: input.credentials ?? {},
+    metadata: input.metadata ?? {},
+  }).run();
+
+  return getMediaSource(id);
+}
+
+export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
+  getDatabase()
+    .update(mediaSources)
+    .set({
+      ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
+      ...(input.externalId !== undefined ? { externalId: input.externalId } : {}),
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+      ...(input.connection !== undefined ? { connection: input.connection } : {}),
+      ...(input.credentials !== undefined ? { credentials: input.credentials } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.lastCheckedAt !== undefined ? { lastCheckedAt: input.lastCheckedAt } : {}),
+      ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(eq(mediaSources.id, id))
+    .run();
+
+  return getMediaSource(id);
+}
+
+export function getMediaSource(id: string) {
+  const row = getDatabase()
+    .select()
+    .from(mediaSources)
+    .where(eq(mediaSources.id, id))
+    .get();
+
+  return row ? mapMediaSource(row) : undefined;
+}
+
+export function getMediaSourceByProviderExternalId(providerId: string, externalId: string) {
+  const row = getDatabase()
+    .select()
+    .from(mediaSources)
+    .where(and(eq(mediaSources.providerId, providerId), eq(mediaSources.externalId, externalId)))
+    .get();
+
+  return row ? mapMediaSource(row) : undefined;
+}
+
+export function upsertMediaSource(input: CreateMediaSourceInput) {
+  if (input.externalId) {
+    const existing = getMediaSourceByProviderExternalId(input.providerId, input.externalId);
+    if (existing) {
+      return updateMediaSource(existing.id, {
+        providerAccountId: input.providerAccountId ?? null,
+        name: input.name,
+        enabled: input.enabled ?? existing.enabled,
+        baseUrl: input.baseUrl,
+        connection: input.connection ?? existing.connection,
+        credentials: input.credentials ?? existing.credentials,
+        metadata: input.metadata ?? existing.metadata,
+      });
+    }
+  }
+
+  return createMediaSource(input);
+}
+
+export function listMediaSources(options: { enabledOnly?: boolean; providerId?: string } = {}) {
+  const db = getDatabase();
+  const orderBy = asc(mediaSources.name);
+  const enabledFilter = eq(mediaSources.enabled, true);
+
+  if (options.enabledOnly && options.providerId) {
+    return db.select().from(mediaSources)
+      .where(and(enabledFilter, eq(mediaSources.providerId, options.providerId)))
+      .orderBy(orderBy)
+      .all()
+      .map(mapMediaSource);
+  }
+
+  if (options.enabledOnly) {
+    return db.select().from(mediaSources)
+      .where(enabledFilter)
+      .orderBy(orderBy)
+      .all()
+      .map(mapMediaSource);
+  }
+
+  if (options.providerId) {
+    return db.select().from(mediaSources)
+      .where(eq(mediaSources.providerId, options.providerId))
+      .orderBy(orderBy)
+      .all()
+      .map(mapMediaSource);
+  }
+
+  return db.select().from(mediaSources).orderBy(orderBy).all().map(mapMediaSource);
+}
+
+export function updateMediaSourceHealth(id: string, input: { lastCheckedAt: string; lastError?: string }) {
+  getDatabase()
+    .update(mediaSources)
+    .set({
+      lastCheckedAt: input.lastCheckedAt,
+      lastError: input.lastError ?? null,
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(eq(mediaSources.id, id))
+    .run();
+
+  return getMediaSource(id);
+}

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -127,22 +127,42 @@ export function getMediaSourceByProviderExternalId(providerId: string, externalI
 }
 
 export function upsertMediaSource(input: CreateMediaSourceInput) {
-  if (input.externalId) {
-    const existing = getMediaSourceByProviderExternalId(input.providerId, input.externalId);
-    if (existing) {
-      return updateMediaSource(existing.id, {
-        providerAccountId: input.providerAccountId ?? null,
-        name: input.name,
-        enabled: input.enabled ?? existing.enabled,
-        baseUrl: input.baseUrl,
-        connection: input.connection ?? existing.connection,
-        credentials: input.credentials ?? existing.credentials,
-        metadata: input.metadata ?? existing.metadata,
-      });
-    }
+  if (!input.externalId) {
+    return createMediaSource(input);
   }
 
-  return createMediaSource(input);
+  const db = getDatabase();
+
+  db.insert(mediaSources)
+    .values({
+      id: randomUUID(),
+      providerId: input.providerId,
+      providerAccountId: input.providerAccountId ?? null,
+      externalId: input.externalId,
+      name: input.name,
+      enabled: input.enabled ?? true,
+      baseUrl: input.baseUrl,
+      connection: input.connection ?? {},
+      credentials: input.credentials ?? {},
+      metadata: input.metadata ?? {},
+    })
+    .onConflictDoUpdate({
+      target: [mediaSources.providerId, mediaSources.externalId],
+      targetWhere: sql`${mediaSources.externalId} IS NOT NULL`,
+      set: {
+        ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
+        name: input.name,
+        ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+        baseUrl: input.baseUrl,
+        ...(input.connection !== undefined ? { connection: input.connection } : {}),
+        ...(input.credentials !== undefined ? { credentials: input.credentials } : {}),
+        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+        updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      },
+    })
+    .run();
+
+  return getMediaSourceByProviderExternalId(input.providerId, input.externalId);
 }
 
 export function listMediaSources(options: { enabledOnly?: boolean; providerId?: string } = {}) {

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -24,6 +24,10 @@ const migrations: Migration[] = [
       CREATE INDEX provider_accounts_provider_id_idx
         ON provider_accounts(provider_id);
 
+      CREATE UNIQUE INDEX provider_accounts_provider_access_token_idx
+        ON provider_accounts(provider_id, access_token)
+        WHERE access_token IS NOT NULL;
+
       CREATE TABLE media_sources (
         id TEXT PRIMARY KEY,
         provider_id TEXT NOT NULL,
@@ -79,6 +83,63 @@ const migrations: Migration[] = [
 
       CREATE INDEX IF NOT EXISTS provider_sessions_expires_at_idx
         ON provider_sessions(expires_at);
+    `,
+  },
+  {
+    id: 3,
+    name: "ensure_provider_accounts_access_token_uniqueness",
+    sql: `
+      CREATE TEMP TABLE duplicate_provider_accounts AS
+      SELECT id, canonical_id
+      FROM (
+        SELECT
+          id,
+          FIRST_VALUE(id) OVER (
+            PARTITION BY provider_id, access_token
+            ORDER BY created_at ASC, id ASC
+          ) AS canonical_id,
+          ROW_NUMBER() OVER (
+            PARTITION BY provider_id, access_token
+            ORDER BY created_at ASC, id ASC
+          ) AS row_num
+        FROM provider_accounts
+        WHERE access_token IS NOT NULL
+      )
+      WHERE row_num > 1;
+
+      UPDATE media_sources
+      SET provider_account_id = (
+        SELECT canonical_id
+        FROM duplicate_provider_accounts
+        WHERE duplicate_provider_accounts.id = media_sources.provider_account_id
+      )
+      WHERE provider_account_id IN (
+        SELECT id
+        FROM duplicate_provider_accounts
+      );
+
+      UPDATE provider_sessions
+      SET provider_account_id = (
+        SELECT canonical_id
+        FROM duplicate_provider_accounts
+        WHERE duplicate_provider_accounts.id = provider_sessions.provider_account_id
+      )
+      WHERE provider_account_id IN (
+        SELECT id
+        FROM duplicate_provider_accounts
+      );
+
+      DELETE FROM provider_accounts
+      WHERE id IN (
+        SELECT id
+        FROM duplicate_provider_accounts
+      );
+
+      DROP TABLE duplicate_provider_accounts;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS provider_accounts_provider_access_token_idx
+        ON provider_accounts(provider_id, access_token)
+        WHERE access_token IS NOT NULL;
     `,
   },
 ];

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -1,0 +1,114 @@
+import type { DatabaseSync } from "node:sqlite";
+
+interface Migration {
+  id: number;
+  name: string;
+  sql: string;
+}
+
+const migrations: Migration[] = [
+  {
+    id: 1,
+    name: "create_provider_accounts_and_media_sources",
+    sql: `
+      CREATE TABLE provider_accounts (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT NOT NULL,
+        label TEXT NOT NULL,
+        access_token TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE INDEX provider_accounts_provider_id_idx
+        ON provider_accounts(provider_id);
+
+      CREATE TABLE media_sources (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT NOT NULL,
+        provider_account_id TEXT REFERENCES provider_accounts(id) ON DELETE SET NULL,
+        external_id TEXT,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+        base_url TEXT NOT NULL,
+        connection_json TEXT NOT NULL DEFAULT '{}',
+        credentials_json TEXT NOT NULL DEFAULT '{}',
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        last_checked_at TEXT,
+        last_error TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE INDEX media_sources_enabled_idx
+        ON media_sources(enabled);
+
+      CREATE INDEX media_sources_provider_id_idx
+        ON media_sources(provider_id);
+
+      CREATE INDEX media_sources_provider_account_id_idx
+        ON media_sources(provider_account_id);
+
+      CREATE UNIQUE INDEX media_sources_provider_external_id_idx
+        ON media_sources(provider_id, external_id)
+        WHERE external_id IS NOT NULL;
+    `,
+  },
+  {
+    id: 2,
+    name: "create_provider_sessions",
+    sql: `
+      CREATE TABLE IF NOT EXISTS provider_sessions (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT NOT NULL,
+        provider_account_id TEXT REFERENCES provider_accounts(id) ON DELETE SET NULL,
+        user_token TEXT NOT NULL,
+        resources_json TEXT NOT NULL DEFAULT '[]',
+        selected_resource_json TEXT,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS provider_sessions_provider_id_idx
+        ON provider_sessions(provider_id);
+
+      CREATE INDEX IF NOT EXISTS provider_sessions_provider_account_id_idx
+        ON provider_sessions(provider_account_id);
+
+      CREATE INDEX IF NOT EXISTS provider_sessions_expires_at_idx
+        ON provider_sessions(expires_at);
+    `,
+  },
+];
+
+export function runMigrations(db: DatabaseSync) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+  `);
+
+  const appliedRows = db.prepare("SELECT id FROM schema_migrations").all() as Array<{ id: number }>;
+  const appliedIds = new Set(appliedRows.map((row) => Number(row.id)));
+  const insertMigration = db.prepare("INSERT INTO schema_migrations (id, name) VALUES (?, ?)");
+
+  for (const migration of migrations) {
+    if (appliedIds.has(migration.id)) {
+      continue;
+    }
+
+    db.exec("BEGIN");
+    try {
+      db.exec(migration.sql);
+      insertMigration.run(migration.id, migration.name);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+  }
+}

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -89,17 +89,32 @@ export function getProviderAccountByAccessToken(providerId: string, accessToken:
 }
 
 export function upsertProviderAccountByAccessToken(input: CreateProviderAccountInput) {
-  if (input.accessToken) {
-    const existing = getProviderAccountByAccessToken(input.providerId, input.accessToken);
-    if (existing) {
-      return updateProviderAccount(existing.id, {
-        label: input.label,
-        metadata: input.metadata ?? existing.metadata,
-      });
-    }
+  if (!input.accessToken) {
+    return createProviderAccount(input);
   }
 
-  return createProviderAccount(input);
+  const db = getDatabase();
+
+  db.insert(providerAccounts)
+    .values({
+      id: randomUUID(),
+      providerId: input.providerId,
+      label: input.label,
+      accessToken: input.accessToken,
+      metadata: input.metadata ?? {},
+    })
+    .onConflictDoUpdate({
+      target: [providerAccounts.providerId, providerAccounts.accessToken],
+      targetWhere: sql`${providerAccounts.accessToken} IS NOT NULL`,
+      set: {
+        label: input.label,
+        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+        updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      },
+    })
+    .run();
+
+  return getProviderAccountByAccessToken(input.providerId, input.accessToken);
 }
 
 export function listProviderAccounts(providerId?: string) {

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { getDatabase } from "./database.js";
+import { providerAccounts, type ProviderAccountRow } from "./schema.js";
+
+export interface ProviderAccount {
+  id: string;
+  providerId: string;
+  label: string;
+  accessToken?: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateProviderAccountInput {
+  providerId: string;
+  label: string;
+  accessToken?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateProviderAccountInput {
+  label?: string;
+  accessToken?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function mapProviderAccount(row: ProviderAccountRow): ProviderAccount {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    label: row.label,
+    accessToken: row.accessToken ?? undefined,
+    metadata: row.metadata,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createProviderAccount(input: CreateProviderAccountInput) {
+  const db = getDatabase();
+  const id = randomUUID();
+
+  db.insert(providerAccounts).values({
+    id,
+    providerId: input.providerId,
+    label: input.label,
+    accessToken: input.accessToken ?? null,
+    metadata: input.metadata ?? {},
+  }).run();
+
+  return getProviderAccount(id);
+}
+
+export function updateProviderAccount(id: string, input: UpdateProviderAccountInput) {
+  getDatabase()
+    .update(providerAccounts)
+    .set({
+      ...(input.label !== undefined ? { label: input.label } : {}),
+      ...(input.accessToken !== undefined ? { accessToken: input.accessToken } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(eq(providerAccounts.id, id))
+    .run();
+
+  return getProviderAccount(id);
+}
+
+export function getProviderAccount(id: string) {
+  const row = getDatabase()
+    .select()
+    .from(providerAccounts)
+    .where(eq(providerAccounts.id, id))
+    .get();
+
+  return row ? mapProviderAccount(row) : undefined;
+}
+
+export function getProviderAccountByAccessToken(providerId: string, accessToken: string) {
+  const row = getDatabase()
+    .select()
+    .from(providerAccounts)
+    .where(and(eq(providerAccounts.providerId, providerId), eq(providerAccounts.accessToken, accessToken)))
+    .get();
+
+  return row ? mapProviderAccount(row) : undefined;
+}
+
+export function upsertProviderAccountByAccessToken(input: CreateProviderAccountInput) {
+  if (input.accessToken) {
+    const existing = getProviderAccountByAccessToken(input.providerId, input.accessToken);
+    if (existing) {
+      return updateProviderAccount(existing.id, {
+        label: input.label,
+        metadata: input.metadata ?? existing.metadata,
+      });
+    }
+  }
+
+  return createProviderAccount(input);
+}
+
+export function listProviderAccounts(providerId?: string) {
+  const db = getDatabase();
+  const rows = providerId
+    ? db.select().from(providerAccounts).where(eq(providerAccounts.providerId, providerId)).all()
+    : db.select().from(providerAccounts).all();
+
+  return rows.map(mapProviderAccount);
+}

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -1,7 +1,7 @@
 import { ApiError } from "../http/errors.js";
-import { upsertMediaSource } from "../db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
-import type { ProviderDefinition, ProviderResource, ProviderConnection } from "./types.js";
+import type { ProviderConnection, ProviderDefinition, ProviderResource } from "../providers/types.js";
+import { upsertMediaSource } from "./mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "./providerAccountsRepository.js";
 
 function connectionRank(connection: ProviderConnection) {
   if (connection.local && !connection.relay) {

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,0 +1,78 @@
+import { sql } from "drizzle-orm";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+const nowIso = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;
+
+export const schemaMigrations = sqliteTable("schema_migrations", {
+  id: integer("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  appliedAt: text("applied_at").notNull().default(nowIso),
+});
+
+export const providerAccounts = sqliteTable(
+  "provider_accounts",
+  {
+    id: text("id").primaryKey(),
+    providerId: text("provider_id").notNull(),
+    label: text("label").notNull(),
+    accessToken: text("access_token"),
+    metadata: text("metadata_json", { mode: "json" }).$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: text("created_at").notNull().default(nowIso),
+    updatedAt: text("updated_at").notNull().default(nowIso),
+  },
+  (table) => [
+    index("provider_accounts_provider_id_idx").on(table.providerId),
+  ]
+);
+
+export const mediaSources = sqliteTable(
+  "media_sources",
+  {
+    id: text("id").primaryKey(),
+    providerId: text("provider_id").notNull(),
+    providerAccountId: text("provider_account_id").references(() => providerAccounts.id, { onDelete: "set null" }),
+    externalId: text("external_id"),
+    name: text("name").notNull(),
+    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+    baseUrl: text("base_url").notNull(),
+    connection: text("connection_json", { mode: "json" }).$type<Record<string, unknown>>().notNull().default({}),
+    credentials: text("credentials_json", { mode: "json" }).$type<Record<string, unknown>>().notNull().default({}),
+    metadata: text("metadata_json", { mode: "json" }).$type<Record<string, unknown>>().notNull().default({}),
+    lastCheckedAt: text("last_checked_at"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull().default(nowIso),
+    updatedAt: text("updated_at").notNull().default(nowIso),
+  },
+  (table) => [
+    index("media_sources_enabled_idx").on(table.enabled),
+    index("media_sources_provider_id_idx").on(table.providerId),
+    index("media_sources_provider_account_id_idx").on(table.providerAccountId),
+    uniqueIndex("media_sources_provider_external_id_idx")
+      .on(table.providerId, table.externalId)
+      .where(sql`${table.externalId} IS NOT NULL`),
+  ]
+);
+
+export const providerSessions = sqliteTable(
+  "provider_sessions",
+  {
+    id: text("id").primaryKey(),
+    providerId: text("provider_id").notNull(),
+    providerAccountId: text("provider_account_id").references(() => providerAccounts.id, { onDelete: "set null" }),
+    userToken: text("user_token").notNull(),
+    resources: text("resources_json", { mode: "json" }).$type<unknown[]>().notNull().default([]),
+    selectedResource: text("selected_resource_json", { mode: "json" }).$type<unknown | null>(),
+    createdAt: integer("created_at").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+    updatedAt: text("updated_at").notNull().default(nowIso),
+  },
+  (table) => [
+    index("provider_sessions_provider_id_idx").on(table.providerId),
+    index("provider_sessions_provider_account_id_idx").on(table.providerAccountId),
+    index("provider_sessions_expires_at_idx").on(table.expiresAt),
+  ]
+);
+
+export type ProviderAccountRow = typeof providerAccounts.$inferSelect;
+export type MediaSourceRow = typeof mediaSources.$inferSelect;
+export type ProviderSessionRow = typeof providerSessions.$inferSelect;

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -22,6 +22,9 @@ export const providerAccounts = sqliteTable(
   },
   (table) => [
     index("provider_accounts_provider_id_idx").on(table.providerId),
+    uniqueIndex("provider_accounts_provider_access_token_idx")
+      .on(table.providerId, table.accessToken)
+      .where(sql`${table.accessToken} IS NOT NULL`),
   ]
 );
 

--- a/apps/server/src/providers/persistence.ts
+++ b/apps/server/src/providers/persistence.ts
@@ -1,0 +1,85 @@
+import { ApiError } from "../http/errors.js";
+import { upsertMediaSource } from "../db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
+import type { ProviderDefinition, ProviderResource, ProviderConnection } from "./types.js";
+
+function connectionRank(connection: ProviderConnection) {
+  if (connection.local && !connection.relay) {
+    return 0;
+  }
+  if (!connection.relay) {
+    return 1;
+  }
+  return 2;
+}
+
+function preferredConnection(resource: ProviderResource, selectedConnection?: ProviderConnection) {
+  if (selectedConnection) {
+    return selectedConnection;
+  }
+
+  return [...resource.connections].sort((left, right) => connectionRank(left) - connectionRank(right))[0];
+}
+
+export function persistProviderAuth(input: {
+  provider: ProviderDefinition;
+  userToken: string;
+  resources: ProviderResource[];
+}) {
+  const account = upsertProviderAccountByAccessToken({
+    providerId: input.provider.id,
+    label: `${input.provider.name} Account`,
+    accessToken: input.userToken,
+    metadata: {
+      resourceCount: input.resources.length,
+      lastAuthenticatedAt: new Date().toISOString(),
+    },
+  });
+
+  if (!account) {
+    throw new ApiError(500, "provider_account_not_saved", "Provider account could not be saved");
+  }
+
+  for (const resource of input.resources) {
+    persistProviderResource({
+      providerId: input.provider.id,
+      providerAccountId: account.id,
+      resource,
+    });
+  }
+
+  return account;
+}
+
+export function persistProviderResource(input: {
+  providerId: string;
+  providerAccountId: string;
+  resource: ProviderResource;
+  selectedConnection?: ProviderConnection;
+}) {
+  const connection = preferredConnection(input.resource, input.selectedConnection);
+  if (!connection) {
+    return undefined;
+  }
+
+  return upsertMediaSource({
+    providerId: input.providerId,
+    providerAccountId: input.providerAccountId,
+    externalId: input.resource.id,
+    name: input.resource.name,
+    enabled: true,
+    baseUrl: connection.uri,
+    connection: {
+      connections: input.resource.connections,
+      selectedConnectionId: connection.id,
+    },
+    credentials: {
+      accessToken: input.resource.accessToken,
+    },
+    metadata: {
+      product: input.resource.product,
+      platform: input.resource.platform,
+      owned: input.resource.owned,
+    },
+  });
+}

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -1,8 +1,11 @@
 import { Router } from "express";
 import { ApiError, asyncHandler } from "../http/errors.js";
+import { persistProviderAuth, persistProviderResource } from "../providers/persistence.js";
 import { getProvider, listProviders } from "../providers/registry.js";
+import type { ProviderResource } from "../providers/types.js";
 import { createProviderSession, getSessionCookieHeader } from "../session/store.js";
 import { requireProviderSession, setNoStore } from "../session/request.js";
+import { updateProviderSessionSelectedResource } from "../session/store.js";
 
 export const providersRouter = Router();
 
@@ -43,8 +46,15 @@ providersRouter.get(
       throw new ApiError(502, "provider_auth_failed", "Provider auth did not return credentials");
     }
 
+    const account = persistProviderAuth({
+      provider: provider.definition,
+      userToken: authStatus.userToken,
+      resources: authStatus.resources,
+    });
+
     const session = createProviderSession({
       providerId: provider.definition.id,
+      providerAccountId: account.id,
       userToken: authStatus.userToken,
       resources: authStatus.resources,
     });
@@ -88,7 +98,20 @@ providersRouter.post(
     }
 
     const session = requireProviderSession(req, req.params.providerId as string);
-    await provider.selectResource(session, resourceId, connectionId);
+    const selectedResource = await provider.selectResource(session, resourceId, connectionId);
+    updateProviderSessionSelectedResource(session.id, selectedResource);
+    if (session.providerAccountId) {
+      const resource = (session.resources as ProviderResource[]).find((candidate) => candidate.id === resourceId);
+      const selectedConnection = selectedResource.connections[0];
+      if (resource && selectedConnection) {
+        persistProviderResource({
+          providerId: provider.definition.id,
+          providerAccountId: session.providerAccountId,
+          resource,
+          selectedConnection,
+        });
+      }
+    }
     res.json({ session: provider.serializeSession(session) });
   })
 );

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
+import { persistProviderAuth, persistProviderResource } from "../db/providerPersistence.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
-import { persistProviderAuth, persistProviderResource } from "../providers/persistence.js";
 import { getProvider, listProviders } from "../providers/registry.js";
 import type { ProviderResource } from "../providers/types.js";
 import { createProviderSession, getSessionCookieHeader } from "../session/store.js";

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { listMediaSources } from "../db/mediaSourcesRepository.js";
+import { asyncHandler } from "../http/errors.js";
+import { setNoStore } from "../session/request.js";
+
+export const sourcesRouter = Router();
+
+sourcesRouter.get(
+  "/",
+  asyncHandler(async (_req, res) => {
+    setNoStore(res);
+    res.json({
+      sources: listMediaSources().map((source) => ({
+        id: source.id,
+        providerId: source.providerId,
+        providerAccountId: source.providerAccountId,
+        externalId: source.externalId,
+        name: source.name,
+        enabled: source.enabled,
+        baseUrl: source.baseUrl,
+        connection: source.connection,
+        metadata: source.metadata,
+        lastCheckedAt: source.lastCheckedAt,
+        lastError: source.lastError,
+        createdAt: source.createdAt,
+        updatedAt: source.updatedAt,
+      })),
+    });
+  })
+);

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,13 +1,14 @@
 import { Router } from "express";
 import { listMediaSources } from "../db/mediaSourcesRepository.js";
 import { asyncHandler } from "../http/errors.js";
-import { setNoStore } from "../session/request.js";
+import { requireSession, setNoStore } from "../session/request.js";
 
 export const sourcesRouter = Router();
 
 sourcesRouter.get(
   "/",
-  asyncHandler(async (_req, res) => {
+  asyncHandler(async (req, res) => {
+    requireSession(req);
     setNoStore(res);
     res.json({
       sources: listMediaSources().map((source) => ({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { createApp } from "./app.js";
+import { closeDatabase } from "./db/database.js";
 
 async function startServer() {
   const { app } = await createApp();
@@ -9,8 +10,25 @@ async function startServer() {
     console.log(`Server running on http://localhost:${PORT}`);
   });
 
+  let shuttingDown = false;
+  let databaseClosed = false;
+
+  const closeDatabaseOnce = () => {
+    if (databaseClosed) {
+      return;
+    }
+
+    databaseClosed = true;
+    closeDatabase();
+  };
+
   // Graceful shutdown
   const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
     console.log("Shutting down server...");
 
     // Close all connections immediately in modern Node.js to release ports faster
@@ -18,17 +36,18 @@ async function startServer() {
       (server as any).closeAllConnections();
     }
 
-
     server.close(() => {
       console.log("Server closed");
+      closeDatabaseOnce();
       process.exit(0);
     });
 
     // Force exit after 1s if things hang
     setTimeout(() => {
       console.log("Force exiting...");
+      closeDatabaseOnce();
       process.exit(1);
-    }, 1000);
+    }, 1000).unref();
   };
 
   process.on("SIGINT", shutdown);
@@ -38,4 +57,3 @@ async function startServer() {
 
 
 startServer();
-

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,12 +2,40 @@ import "dotenv/config";
 import { createApp } from "./app.js";
 
 async function startServer() {
-  const app = await createApp();
+  const { app } = await createApp();
   const PORT = Number(process.env.PORT ?? 3000);
 
-  app.listen(PORT, "0.0.0.0", () => {
+  const server = app.listen(PORT, "0.0.0.0", () => {
     console.log(`Server running on http://localhost:${PORT}`);
   });
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    console.log("Shutting down server...");
+
+    // Close all connections immediately in modern Node.js to release ports faster
+    if ("closeAllConnections" in server) {
+      (server as any).closeAllConnections();
+    }
+
+
+    server.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+
+    // Force exit after 1s if things hang
+    setTimeout(() => {
+      console.log("Force exiting...");
+      process.exit(1);
+    }, 1000);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 }
 
+
+
 startServer();
+

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getDatabase } from "../db/database.js";
 import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
 
@@ -108,6 +108,7 @@ export function updateProviderSessionSelectedResource(sessionId: string, selecte
     .update(providerSessions)
     .set({
       selectedResource,
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
     })
     .where(eq(providerSessions.id, sessionId))
     .run();

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { getDatabase } from "../db/database.js";
+import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
 
 const SESSION_COOKIE = "cliparr_session";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 12;
@@ -6,6 +9,7 @@ const SESSION_TTL_MS = 1000 * 60 * 60 * 12;
 export interface ProviderSessionRecord {
   id: string;
   providerId: string;
+  providerAccountId?: string;
   userToken: string;
   resources: unknown[];
   selectedResource?: unknown;
@@ -14,25 +18,66 @@ export interface ProviderSessionRecord {
   expiresAt: number;
 }
 
-const sessions = new Map<string, ProviderSessionRecord>();
+const mediaHandlesBySessionId = new Map<string, Map<string, unknown>>();
+
+function getMediaHandles(sessionId: string) {
+  let mediaHandles = mediaHandlesBySessionId.get(sessionId);
+  if (!mediaHandles) {
+    mediaHandles = new Map<string, unknown>();
+    mediaHandlesBySessionId.set(sessionId, mediaHandles);
+  }
+  return mediaHandles;
+}
+
+function mapProviderSession(row: ProviderSessionRow): ProviderSessionRecord {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    providerAccountId: row.providerAccountId ?? undefined,
+    userToken: row.userToken,
+    resources: row.resources,
+    selectedResource: row.selectedResource ?? undefined,
+    mediaHandles: getMediaHandles(row.id),
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+  };
+}
 
 export function createProviderSession(input: {
   providerId: string;
+  providerAccountId?: string;
   userToken: string;
   resources: unknown[];
 }) {
   const now = Date.now();
-  const session: ProviderSessionRecord = {
-    id: randomUUID(),
+  const id = randomUUID();
+  const expiresAt = now + SESSION_TTL_MS;
+
+  getDatabase()
+    .insert(providerSessions)
+    .values({
+      id,
+      providerId: input.providerId,
+      providerAccountId: input.providerAccountId ?? null,
+      userToken: input.userToken,
+      resources: input.resources,
+      selectedResource: null,
+      createdAt: now,
+      expiresAt,
+    })
+    .run();
+
+  return mapProviderSession({
+    id,
     providerId: input.providerId,
+    providerAccountId: input.providerAccountId ?? null,
     userToken: input.userToken,
     resources: input.resources,
-    mediaHandles: new Map(),
+    selectedResource: null,
     createdAt: now,
-    expiresAt: now + SESSION_TTL_MS,
-  };
-  sessions.set(session.id, session);
-  return session;
+    expiresAt,
+    updatedAt: new Date(now).toISOString(),
+  });
 }
 
 export function getProviderSession(sessionId?: string) {
@@ -40,22 +85,41 @@ export function getProviderSession(sessionId?: string) {
     return undefined;
   }
 
-  const session = sessions.get(sessionId);
-  if (!session) {
+  const row = getDatabase()
+    .select()
+    .from(providerSessions)
+    .where(eq(providerSessions.id, sessionId))
+    .get();
+
+  if (!row) {
     return undefined;
   }
 
-  if (session.expiresAt <= Date.now()) {
-    sessions.delete(sessionId);
+  if (row.expiresAt <= Date.now()) {
+    deleteProviderSession(sessionId);
     return undefined;
   }
 
-  return session;
+  return mapProviderSession(row);
+}
+
+export function updateProviderSessionSelectedResource(sessionId: string, selectedResource: unknown) {
+  getDatabase()
+    .update(providerSessions)
+    .set({
+      selectedResource,
+    })
+    .where(eq(providerSessions.id, sessionId))
+    .run();
 }
 
 export function deleteProviderSession(sessionId?: string) {
   if (sessionId) {
-    sessions.delete(sessionId);
+    getDatabase()
+      .delete(providerSessions)
+      .where(eq(providerSessions.id, sessionId))
+      .run();
+    mediaHandlesBySessionId.delete(sessionId);
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  cliparr:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      APP_URL: "http://localhost:3000"
+      PORT: "3000"
+      CLIPARR_DATA_DIR: "/data"
+    volumes:
+      - cliparr-data:/data
+    restart: unless-stopped
+
+volumes:
+  cliparr-data:

--- a/package.json
+++ b/package.json
@@ -15,12 +15,17 @@
   },
   "homepage": "https://github.com/techsquidtv/cliparr#readme",
   "scripts": {
-    "dev": "concurrently -c \"cyan,magenta\" -n \"frontend,server\" \"pnpm --filter @cliparr/frontend dev\" \"pnpm --filter @cliparr/server dev\"",
+    "dev": "concurrently -k -s first --handle-input -c \"cyan,magenta\" -n \"frontend,server\" \"pnpm --filter @cliparr/frontend dev\" \"pnpm --filter @cliparr/server dev\"",
     "build": "pnpm -r build",
     "lint": "pnpm -r lint",
     "preview": "pnpm --filter @cliparr/server preview",
     "start": "pnpm --filter @cliparr/server start",
     "clean": "pnpm -r clean"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["mssql", "@types/mssql"]
+    }
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -84,6 +84,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      drizzle-orm:
+        specifier: 1.0.0-beta.21
+        version: 1.0.0-beta.21
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -94,6 +97,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      drizzle-kit:
+        specifier: 1.0.0-beta.21
+        version: 1.0.0-beta.21
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -110,6 +116,9 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@drizzle-team/brocli@0.11.0':
+    resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
@@ -119,16 +128,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -137,16 +164,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -155,10 +200,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -167,10 +224,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -179,10 +248,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -191,10 +272,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -203,10 +296,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -215,16 +320,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -233,10 +356,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -245,11 +380,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -257,16 +404,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -293,6 +458,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
 
   '@mediabunny/aac-encoder@1.40.1':
     resolution: {integrity: sha512-QWEZgEtCycnJA81xuEP7Lo/v56+5OOdeeXZbro4IY24VHiNISZlXBJRV1R5GYIKzW0ZXVJHSAHGUw5kZDep60g==}
@@ -675,6 +844,125 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  drizzle-kit@1.0.0-beta.21:
+    resolution: {integrity: sha512-qG1vkkXPhz9GJ6RZhM/DvzL5jeDNYn35cyGeFA0+8iZQ6GTP4FhbOltNDHh/8XNmcI89b40lXJuH1PdxaA7zdQ==}
+    hasBin: true
+
+  drizzle-orm@1.0.0-beta.21:
+    resolution: {integrity: sha512-HZcIbVn5J9T/Z91Wj12Pn7Pi8/1aykS/GPJf2lXeZnEuPjxaBfQ+YAt0Sl+XI+9R/D1BpK+2fdIqbpuaTbcvqA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@effect/sql': ^0.48.5
+      '@effect/sql-pg': ^0.49.7
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@sinclair/typebox': '>=0.34.8'
+      '@sqlitecloud/drivers': '>=1.0.653'
+      '@tidbcloud/serverless': '*'
+      '@tursodatabase/database': '>=0.2.1'
+      '@tursodatabase/database-common': '>=0.2.1'
+      '@tursodatabase/database-wasm': '>=0.2.1'
+      '@types/better-sqlite3': '*'
+      '@types/mssql': ^9.1.4
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      arktype: '>=2.0.0'
+      better-sqlite3: '>=9.3.0'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      mssql: ^11.0.1
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+      typebox: '>=1.0.0'
+      valibot: '>=1.0.0-beta.7'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@effect/sql':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      '@sqlitecloud/drivers':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@tursodatabase/database':
+        optional: true
+      '@tursodatabase/database-common':
+        optional: true
+      '@tursodatabase/database-wasm':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      arktype:
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      typebox:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -704,6 +992,11 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -836,6 +1129,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1246,6 +1542,8 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@drizzle-team/brocli@0.11.0': {}
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1262,79 +1560,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -1360,6 +1736,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
 
   '@mediabunny/aac-encoder@1.40.1(mediabunny@1.40.1)':
     dependencies:
@@ -1680,6 +2060,16 @@ snapshots:
 
   dotenv@17.4.2: {}
 
+  drizzle-kit@1.0.0-beta.21:
+    dependencies:
+      '@drizzle-team/brocli': 0.11.0
+      '@js-temporal/polyfill': 0.5.1
+      esbuild: 0.25.12
+      get-tsconfig: 4.13.7
+      jiti: 2.6.1
+
+  drizzle-orm@1.0.0-beta.21: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1704,6 +2094,35 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1871,6 +2290,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  jsbi@4.3.2: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
## What this does
Moving from an in-memory state storage to a local SQLite database. This will make it easier to manage authentication with multiple systems, which will also persist through restarts. This will make it easier to add and manage multiple providers in the future, like Jellyfin, and other long term features we may add. This PR is mostly foundational. Plex access has been migrated to the SQLite db.

**Database and Persistence Integration**

* Introduced SQLite as the persistent data store for the server, with all database files stored in a configurable data directory (`CLIPARR_DATA_DIR`). In production, this is required and mapped to `/data` in Docker. The database is initialized on server startup, and migrations are run automatically. (`apps/server/src/db/database.ts`, `apps/server/drizzle.config.ts`, `apps/server/src/db/migrations.ts`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R34-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R37) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R54) [[4]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R8) [[5]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR8-R22) [[6]](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1-R3)

* Added Drizzle ORM and Drizzle Kit for type-safe database access and migrations. Updated `package.json` scripts and dependencies accordingly. (`apps/server/package.json`, [apps/server/package.jsonR10-R25](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R10-R25))

**Data Models and Repository Layer**

* Added new data models and repository modules for `ProviderAccount` and `MediaSource`, including CRUD and upsert operations, using Drizzle ORM. (`apps/server/src/db/providerAccountsRepository.ts`, [[1]](diffhunk://#diff-3111573745ea5ebd6bcc8c8820051ced054ae251b953660afa91dde9d81769f6R1-R112); `apps/server/src/db/mediaSourcesRepository.ts`, [[2]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76R1-R192)

* Defined and applied initial database schema migrations for provider accounts, media sources, and provider sessions. (`apps/server/src/db/migrations.ts`, [apps/server/src/db/migrations.tsR1-R114](diffhunk://#diff-6aa47437481dced2bc11448a4d34cd9b8c5648e58e3bc703dc1dccc24b2a22c9R1-R114))

**Server and API Improvements**

* The server now checks database health on `/api/health` and exposes new `/api/sources` routes (scaffolding for future endpoints). The app startup process is updated to ensure the database is initialized. (`apps/server/src/app.ts`, [[1]](diffhunk://#diff-cce8a19fada293c9b2fc1e6aa9abcc0c3aaa126fa3370391bb25398c7073a469R4-R18) [[2]](diffhunk://#diff-cce8a19fada293c9b2fc1e6aa9abcc0c3aaa126fa3370391bb25398c7073a469L25-R57)

**Docker and Development Environment**

* Dockerfile updated to create and mount `/data` as a persistent volume for the SQLite database, ensuring data persists across container restarts. `.dockerignore` and `.env.example` updated for new data directory. (`Dockerfile`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R34-R46); `.dockerignore`, [[2]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R8); `.env.example`, [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR8-R22)

**Documentation Updates**

* Updated `README.md` and `CONTRIBUTING.md` to document the new persistent data requirements, Docker usage (including Compose), and local development URLs. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R54); `CONTRIBUTING.md`, [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R25-R26)