### PR TITLE
feat: require app key and encrypt persisted secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Defaults to http://localhost:3000 for local development.
 APP_URL="http://localhost:3000"
 
+# APP_KEY: Required stable secret used to encrypt persisted provider credentials.
+# Generate one with: openssl rand -base64 32
+APP_KEY=""
+
 # PORT: Express server port.
 PORT="3000"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ Install dependencies:
 
 ```sh
 pnpm install
+cp .env.example .env
+# Set APP_KEY in .env with a stable random value, for example:
+# openssl rand -base64 32
 ```
 
 Run the development server:

--- a/README.md
+++ b/README.md
@@ -21,19 +21,25 @@ Built with [Mediabunny](https://mediabunny.dev/) and [`react-timeline-editor`](h
 The easiest way to run Cliparr is using the official image from the GitHub Container Registry:
 
 ```sh
+export APP_KEY="replace-with-a-stable-random-secret"
+
 docker run --rm -p 3000:3000 \
   -e APP_URL=http://localhost:3000 \
+  -e APP_KEY="$APP_KEY" \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
 ```
 
 Cliparr requires SQLite storage for configured media sources and provider tokens. The container stores that database under `/data`, so mount it as a volume.
+`APP_KEY` is required and must stay the same for a given data directory because Cliparr uses it to encrypt persisted provider credentials at rest.
 
 ### Docker Compose
 
 For local Docker usage, Compose will build the image and mount the database volume for you:
 
 ```sh
+cp .env.example .env
+# Set APP_KEY in .env before starting the stack.
 docker compose up --build
 ```
 
@@ -48,8 +54,11 @@ docker build -t cliparr .
 And run it:
 
 ```sh
+export APP_KEY="replace-with-a-stable-random-secret"
+
 docker run --rm -p 3000:3000 \
   -e APP_URL=http://localhost:3000 \
+  -e APP_KEY="$APP_KEY" \
   -v cliparr-data:/data \
   cliparr
 ```

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -6,6 +6,7 @@ import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { runMigrations } from "./migrations.js";
 import * as schema from "./schema.js";
 import { resolveConfiguredDataDir, workspaceRoot } from "../config/loadEnv.js";
+import { assertAppKeyConfigured } from "../security/secrets.js";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
 const DEFAULT_DEVELOPMENT_DATA_DIR = ".cliparr-data";
@@ -46,6 +47,7 @@ export function initializeDatabase() {
     return database;
   }
 
+  assertAppKeyConfigured();
   dataDir = resolveDataDir();
   fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
   enforcePermissions(dataDir, 0o700);

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { mediaSources, type MediaSourceRow } from "./schema.js";
+import { decryptJsonSecrets, encryptJsonSecrets } from "../security/secrets.js";
 
 export interface MediaSource {
   id: string;
@@ -54,8 +55,8 @@ function mapMediaSource(row: MediaSourceRow): MediaSource {
     name: row.name,
     enabled: row.enabled,
     baseUrl: row.baseUrl,
-    connection: row.connection,
-    credentials: row.credentials,
+    connection: decryptJsonSecrets(row.connection),
+    credentials: decryptJsonSecrets(row.credentials),
     metadata: row.metadata,
     lastCheckedAt: row.lastCheckedAt ?? undefined,
     lastError: row.lastError ?? undefined,
@@ -76,8 +77,8 @@ export function createMediaSource(input: CreateMediaSourceInput) {
     name: input.name,
     enabled: input.enabled ?? true,
     baseUrl: input.baseUrl,
-    connection: input.connection ?? {},
-    credentials: input.credentials ?? {},
+    connection: encryptJsonSecrets(input.connection ?? {}),
+    credentials: encryptJsonSecrets(input.credentials ?? {}),
     metadata: input.metadata ?? {},
   }).run();
 
@@ -93,8 +94,8 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
       ...(input.name !== undefined ? { name: input.name } : {}),
       ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
       ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
-      ...(input.connection !== undefined ? { connection: input.connection } : {}),
-      ...(input.credentials !== undefined ? { credentials: input.credentials } : {}),
+      ...(input.connection !== undefined ? { connection: encryptJsonSecrets(input.connection) } : {}),
+      ...(input.credentials !== undefined ? { credentials: encryptJsonSecrets(input.credentials) } : {}),
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       ...(input.lastCheckedAt !== undefined ? { lastCheckedAt: input.lastCheckedAt } : {}),
       ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
@@ -142,8 +143,8 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
       name: input.name,
       enabled: input.enabled ?? true,
       baseUrl: input.baseUrl,
-      connection: input.connection ?? {},
-      credentials: input.credentials ?? {},
+      connection: encryptJsonSecrets(input.connection ?? {}),
+      credentials: encryptJsonSecrets(input.credentials ?? {}),
       metadata: input.metadata ?? {},
     })
     .onConflictDoUpdate({
@@ -154,8 +155,8 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
         name: input.name,
         ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
         baseUrl: input.baseUrl,
-        ...(input.connection !== undefined ? { connection: input.connection } : {}),
-        ...(input.credentials !== undefined ? { credentials: input.credentials } : {}),
+        ...(input.connection !== undefined ? { connection: encryptJsonSecrets(input.connection) } : {}),
+        ...(input.credentials !== undefined ? { credentials: encryptJsonSecrets(input.credentials) } : {}),
         ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
         updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
       },

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -142,6 +142,20 @@ const migrations: Migration[] = [
         WHERE access_token IS NOT NULL;
     `,
   },
+  {
+    id: 4,
+    name: "add_provider_accounts_access_token_hash",
+    sql: `
+      ALTER TABLE provider_accounts
+      ADD COLUMN access_token_hash TEXT;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS provider_accounts_provider_access_token_hash_idx
+        ON provider_accounts(provider_id, access_token_hash)
+        WHERE access_token_hash IS NOT NULL;
+
+      DROP INDEX IF EXISTS provider_accounts_provider_access_token_idx;
+    `,
+  },
 ];
 
 export function runMigrations(db: DatabaseSync) {

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { providerAccounts, type ProviderAccountRow } from "./schema.js";
+import { decryptSecret, encryptSecret, hashSecret } from "../security/secrets.js";
 
 export interface ProviderAccount {
   id: string;
@@ -31,7 +32,7 @@ function mapProviderAccount(row: ProviderAccountRow): ProviderAccount {
     id: row.id,
     providerId: row.providerId,
     label: row.label,
-    accessToken: row.accessToken ?? undefined,
+    accessToken: row.accessToken ? decryptSecret(row.accessToken) : undefined,
     metadata: row.metadata,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -46,7 +47,8 @@ export function createProviderAccount(input: CreateProviderAccountInput) {
     id,
     providerId: input.providerId,
     label: input.label,
-    accessToken: input.accessToken ?? null,
+    accessToken: input.accessToken ? encryptSecret(input.accessToken) : null,
+    accessTokenHash: input.accessToken ? hashSecret(input.accessToken) : null,
     metadata: input.metadata ?? {},
   }).run();
 
@@ -58,7 +60,12 @@ export function updateProviderAccount(id: string, input: UpdateProviderAccountIn
     .update(providerAccounts)
     .set({
       ...(input.label !== undefined ? { label: input.label } : {}),
-      ...(input.accessToken !== undefined ? { accessToken: input.accessToken } : {}),
+      ...(input.accessToken !== undefined
+        ? {
+          accessToken: encryptSecret(input.accessToken),
+          accessTokenHash: hashSecret(input.accessToken),
+        }
+        : {}),
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
     })
@@ -79,18 +86,40 @@ export function getProviderAccount(id: string) {
 }
 
 export function getProviderAccountByAccessToken(providerId: string, accessToken: string) {
-  const row = getDatabase()
+  const db = getDatabase();
+  const tokenHash = hashSecret(accessToken);
+  const row = db
     .select()
     .from(providerAccounts)
-    .where(and(eq(providerAccounts.providerId, providerId), eq(providerAccounts.accessToken, accessToken)))
+    .where(and(eq(providerAccounts.providerId, providerId), eq(providerAccounts.accessTokenHash, tokenHash)))
     .get();
 
-  return row ? mapProviderAccount(row) : undefined;
+  if (row) {
+    return mapProviderAccount(row);
+  }
+
+  const fallback = db
+    .select()
+    .from(providerAccounts)
+    .where(eq(providerAccounts.providerId, providerId))
+    .all()
+    .find((candidate) => candidate.accessToken && decryptSecret(candidate.accessToken) === accessToken);
+
+  return fallback ? mapProviderAccount(fallback) : undefined;
 }
 
 export function upsertProviderAccountByAccessToken(input: CreateProviderAccountInput) {
   if (!input.accessToken) {
     return createProviderAccount(input);
+  }
+
+  const existing = getProviderAccountByAccessToken(input.providerId, input.accessToken);
+  if (existing) {
+    return updateProviderAccount(existing.id, {
+      label: input.label,
+      accessToken: input.accessToken,
+      metadata: input.metadata,
+    });
   }
 
   const db = getDatabase();
@@ -100,14 +129,17 @@ export function upsertProviderAccountByAccessToken(input: CreateProviderAccountI
       id: randomUUID(),
       providerId: input.providerId,
       label: input.label,
-      accessToken: input.accessToken,
+      accessToken: encryptSecret(input.accessToken),
+      accessTokenHash: hashSecret(input.accessToken),
       metadata: input.metadata ?? {},
     })
     .onConflictDoUpdate({
-      target: [providerAccounts.providerId, providerAccounts.accessToken],
-      targetWhere: sql`${providerAccounts.accessToken} IS NOT NULL`,
+      target: [providerAccounts.providerId, providerAccounts.accessTokenHash],
+      targetWhere: sql`${providerAccounts.accessTokenHash} IS NOT NULL`,
       set: {
         label: input.label,
+        accessToken: encryptSecret(input.accessToken),
+        accessTokenHash: hashSecret(input.accessToken),
         ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
         updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
       },

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -16,15 +16,16 @@ export const providerAccounts = sqliteTable(
     providerId: text("provider_id").notNull(),
     label: text("label").notNull(),
     accessToken: text("access_token"),
+    accessTokenHash: text("access_token_hash"),
     metadata: text("metadata_json", { mode: "json" }).$type<Record<string, unknown>>().notNull().default({}),
     createdAt: text("created_at").notNull().default(nowIso),
     updatedAt: text("updated_at").notNull().default(nowIso),
   },
   (table) => [
     index("provider_accounts_provider_id_idx").on(table.providerId),
-    uniqueIndex("provider_accounts_provider_access_token_idx")
-      .on(table.providerId, table.accessToken)
-      .where(sql`${table.accessToken} IS NOT NULL`),
+    uniqueIndex("provider_accounts_provider_access_token_hash_idx")
+      .on(table.providerId, table.accessTokenHash)
+      .where(sql`${table.accessTokenHash} IS NOT NULL`),
   ]
 );
 

--- a/apps/server/src/security/secrets.ts
+++ b/apps/server/src/security/secrets.ts
@@ -1,0 +1,121 @@
+import { createCipheriv, createDecipheriv, createHmac, randomBytes, scryptSync } from "crypto";
+
+const APP_KEY_ENV = "APP_KEY";
+const APP_KEY_MIN_LENGTH = 32;
+const ENCRYPTION_ALGORITHM = "aes-256-gcm";
+const ENCRYPTION_PREFIX = "cliparr:enc:v1";
+const ENCRYPTION_IV_BYTES = 12;
+const ENCRYPTION_KEY_BYTES = 32;
+const ENCRYPTION_SALT = "cliparr-persisted-secrets";
+const SECRET_FIELD_NAMES = new Set(["accessToken", "refreshToken", "password", "apiKey", "token"]);
+
+let encryptionKey: Buffer | undefined;
+
+function appKeyError(message: string) {
+  return new Error(`${APP_KEY_ENV} ${message}`);
+}
+
+function getConfiguredAppKey() {
+  const appKey = process.env[APP_KEY_ENV]?.trim();
+  if (!appKey) {
+    throw appKeyError("is required so Cliparr can encrypt persisted provider credentials.");
+  }
+
+  if (appKey.length < APP_KEY_MIN_LENGTH) {
+    throw appKeyError(`must be at least ${APP_KEY_MIN_LENGTH} characters long.`);
+  }
+
+  return appKey;
+}
+
+function getEncryptionKey() {
+  if (!encryptionKey) {
+    encryptionKey = scryptSync(getConfiguredAppKey(), ENCRYPTION_SALT, ENCRYPTION_KEY_BYTES);
+  }
+
+  return encryptionKey;
+}
+
+export function assertAppKeyConfigured() {
+  getEncryptionKey();
+}
+
+export function isEncryptedSecret(value: string) {
+  return value.startsWith(`${ENCRYPTION_PREFIX}:`);
+}
+
+export function encryptSecret(value: string) {
+  if (!value || isEncryptedSecret(value)) {
+    return value;
+  }
+
+  const iv = randomBytes(ENCRYPTION_IV_BYTES);
+  const cipher = createCipheriv(ENCRYPTION_ALGORITHM, getEncryptionKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return `${ENCRYPTION_PREFIX}:${iv.toString("base64url")}:${authTag.toString("base64url")}:${ciphertext.toString("base64url")}`;
+}
+
+export function decryptSecret(value: string) {
+  if (!value || !isEncryptedSecret(value)) {
+    return value;
+  }
+
+  const [, , , ivBase64, authTagBase64, ciphertextBase64] = value.split(":");
+  if (!ivBase64 || !authTagBase64 || !ciphertextBase64) {
+    throw new Error("Stored secret has an invalid encryption format.");
+  }
+
+  try {
+    const decipher = createDecipheriv(
+      ENCRYPTION_ALGORITHM,
+      getEncryptionKey(),
+      Buffer.from(ivBase64, "base64url")
+    );
+    decipher.setAuthTag(Buffer.from(authTagBase64, "base64url"));
+
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextBase64, "base64url")),
+      decipher.final(),
+    ]);
+    return plaintext.toString("utf8");
+  } catch (err) {
+    throw new Error(
+      `Stored secrets could not be decrypted. Verify ${APP_KEY_ENV} matches the key previously used for this data directory.`,
+      { cause: err }
+    );
+  }
+}
+
+export function hashSecret(value: string) {
+  return createHmac("sha256", getEncryptionKey()).update(value).digest("hex");
+}
+
+function transformSecretFields(value: unknown, transform: (secret: string) => string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => transformSecretFields(item, transform));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, childValue]) => {
+        if (SECRET_FIELD_NAMES.has(key) && typeof childValue === "string") {
+          return [key, transform(childValue)];
+        }
+
+        return [key, transformSecretFields(childValue, transform)];
+      })
+    );
+  }
+
+  return value;
+}
+
+export function encryptJsonSecrets<T>(value: T): T {
+  return transformSecretFields(value, encryptSecret) as T;
+}
+
+export function decryptJsonSecrets<T>(value: T): T {
+  return transformSecretFields(value, decryptSecret) as T;
+}

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { eq, sql } from "drizzle-orm";
 import { getDatabase } from "../db/database.js";
 import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
+import { decryptJsonSecrets, decryptSecret, encryptJsonSecrets, encryptSecret } from "../security/secrets.js";
 
 const SESSION_COOKIE = "cliparr_session";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 12;
@@ -34,9 +35,9 @@ function mapProviderSession(row: ProviderSessionRow): ProviderSessionRecord {
     id: row.id,
     providerId: row.providerId,
     providerAccountId: row.providerAccountId ?? undefined,
-    userToken: row.userToken,
-    resources: row.resources,
-    selectedResource: row.selectedResource ?? undefined,
+    userToken: decryptSecret(row.userToken),
+    resources: decryptJsonSecrets(row.resources),
+    selectedResource: row.selectedResource ? decryptJsonSecrets(row.selectedResource) : undefined,
     mediaHandles: getMediaHandles(row.id),
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
@@ -59,8 +60,8 @@ export function createProviderSession(input: {
       id,
       providerId: input.providerId,
       providerAccountId: input.providerAccountId ?? null,
-      userToken: input.userToken,
-      resources: input.resources,
+      userToken: encryptSecret(input.userToken),
+      resources: encryptJsonSecrets(input.resources),
       selectedResource: null,
       createdAt: now,
       expiresAt,
@@ -107,7 +108,7 @@ export function updateProviderSessionSelectedResource(sessionId: string, selecte
   getDatabase()
     .update(providerSessions)
     .set({
-      selectedResource,
+      selectedResource: encryptJsonSecrets(selectedResource),
       updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
     })
     .where(eq(providerSessions.id, sessionId))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "3000:3000"
     environment:
       APP_URL: "http://localhost:3000"
+      APP_KEY: "${APP_KEY:?APP_KEY is required}"
       PORT: "3000"
       CLIPARR_DATA_DIR: "/data"
     volumes:


### PR DESCRIPTION
## Summary
- require APP_KEY and add crypto helpers for persisted provider secrets
- encrypt provider account tokens, source credentials, and provider session secrets at rest while preserving reads of existing plaintext rows until they are rewritten
- add the provider account token hash migration plus docs and Docker updates for the new env var

## Testing
- pnpm lint
- pnpm build
- pnpm --filter @cliparr/server exec tsx -e "import './src/config/loadEnv.ts'; import { createApp } from './src/app.ts'; (async () => { await createApp(); console.log('app-ok'); })().catch((err) => { console.error(err); process.exit(1); });"