### PR TITLE
Harden server URL validation and require provider account ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ CLIPARR_DATA_DIR="./.cliparr-data"
 # when redirecting auth callback routes in development.
 # Defaults to http://localhost:5173.
 # CLIPARR_FRONTEND_URL="http://localhost:5173"
+
+# CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS: Optional. Set to true only if your
+# Jellyfin server is intentionally reachable from the Cliparr host via
+# localhost/127.0.0.1 and you trust who can reach Cliparr.
+# CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS="false"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ volumes:
 | `APP_KEY` | **Required** secret for credential encryption. | - |
 | `PORT` | Internal port for the Express server. | `3000` |
 | `CLIPARR_DATA_DIR` | Directory for SQLite storage. | `/data` |
+| `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to `localhost`/loopback. Use only for trusted self-hosted setups. | `false` |
 
 ## Development
 

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -34,7 +34,6 @@ export interface CreateMediaSourceInput {
 }
 
 export interface UpdateMediaSourceInput {
-  providerAccountId?: string;
   externalId?: string | null;
   name?: string;
   enabled?: boolean;
@@ -110,7 +109,6 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
   getDatabase()
     .update(mediaSources)
     .set({
-      ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
       ...(input.externalId !== undefined ? { externalId: input.externalId } : {}),
       ...(input.name !== undefined ? { name: input.name } : {}),
       ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
@@ -200,7 +198,6 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
       target: [mediaSources.providerId, mediaSources.providerAccountId, mediaSources.externalId],
       targetWhere: sql`${mediaSources.externalId} IS NOT NULL AND ${mediaSources.providerAccountId} IS NOT NULL`,
       set: {
-        ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
         name: input.name,
         ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
         baseUrl: input.baseUrl,
@@ -261,7 +258,6 @@ export function updateMediaSourceForAccount(id: string, providerAccountId: strin
   getDatabase()
     .update(mediaSources)
     .set({
-      ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
       ...(input.externalId !== undefined ? { externalId: input.externalId } : {}),
       ...(input.name !== undefined ? { name: input.name } : {}),
       ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql, type SQL } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { mediaSources, type MediaSourceRow } from "./schema.js";
 import { decryptJsonSecrets, encryptJsonSecrets } from "../security/secrets.js";
@@ -7,7 +7,7 @@ import { decryptJsonSecrets, encryptJsonSecrets } from "../security/secrets.js";
 export interface MediaSource {
   id: string;
   providerId: string;
-  providerAccountId?: string;
+  providerAccountId: string;
   externalId?: string;
   name: string;
   enabled: boolean;
@@ -23,7 +23,7 @@ export interface MediaSource {
 
 export interface CreateMediaSourceInput {
   providerId: string;
-  providerAccountId?: string;
+  providerAccountId: string;
   externalId?: string;
   name: string;
   enabled?: boolean;
@@ -34,7 +34,7 @@ export interface CreateMediaSourceInput {
 }
 
 export interface UpdateMediaSourceInput {
-  providerAccountId?: string | null;
+  providerAccountId?: string;
   externalId?: string | null;
   name?: string;
   enabled?: boolean;
@@ -50,7 +50,7 @@ function mapMediaSource(row: MediaSourceRow): MediaSource {
   return {
     id: row.id,
     providerId: row.providerId,
-    providerAccountId: row.providerAccountId ?? undefined,
+    providerAccountId: row.providerAccountId,
     externalId: row.externalId ?? undefined,
     name: row.name,
     enabled: row.enabled,
@@ -65,6 +65,27 @@ function mapMediaSource(row: MediaSourceRow): MediaSource {
   };
 }
 
+function getMediaSourceWhere(where: SQL<unknown>) {
+  const row = getDatabase()
+    .select()
+    .from(mediaSources)
+    .where(where)
+    .get();
+
+  return row ? mapMediaSource(row) : undefined;
+}
+
+function listMediaSourcesWhere(where?: SQL<unknown>) {
+  const query = getDatabase()
+    .select()
+    .from(mediaSources);
+  const rows = where
+    ? query.where(where).orderBy(asc(mediaSources.name)).all()
+    : query.orderBy(asc(mediaSources.name)).all();
+
+  return rows.map(mapMediaSource);
+}
+
 export function createMediaSource(input: CreateMediaSourceInput) {
   const db = getDatabase();
   const id = randomUUID();
@@ -72,7 +93,7 @@ export function createMediaSource(input: CreateMediaSourceInput) {
   db.insert(mediaSources).values({
     id,
     providerId: input.providerId,
-    providerAccountId: input.providerAccountId ?? null,
+    providerAccountId: input.providerAccountId,
     externalId: input.externalId ?? null,
     name: input.name,
     enabled: input.enabled ?? true,
@@ -108,13 +129,16 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
 }
 
 export function getMediaSource(id: string) {
-  const row = getDatabase()
-    .select()
-    .from(mediaSources)
-    .where(eq(mediaSources.id, id))
-    .get();
+  return getMediaSourceWhere(eq(mediaSources.id, id));
+}
 
-  return row ? mapMediaSource(row) : undefined;
+export function getMediaSourceForAccount(id: string, providerAccountId: string) {
+  const where = and(
+    eq(mediaSources.id, id),
+    eq(mediaSources.providerAccountId, providerAccountId)
+  );
+
+  return where ? getMediaSourceWhere(where) : undefined;
 }
 
 export function deleteMediaSource(id: string) {
@@ -126,14 +150,30 @@ export function deleteMediaSource(id: string) {
   return result.changes > 0;
 }
 
-export function getMediaSourceByProviderExternalId(providerId: string, externalId: string) {
-  const row = getDatabase()
-    .select()
-    .from(mediaSources)
-    .where(and(eq(mediaSources.providerId, providerId), eq(mediaSources.externalId, externalId)))
-    .get();
+export function deleteMediaSourceForAccount(id: string, providerAccountId: string) {
+  const result = getDatabase()
+    .delete(mediaSources)
+    .where(and(
+      eq(mediaSources.id, id),
+      eq(mediaSources.providerAccountId, providerAccountId)
+    ))
+    .run();
 
-  return row ? mapMediaSource(row) : undefined;
+  return result.changes > 0;
+}
+
+export function getMediaSourceByProviderExternalId(
+  providerId: string,
+  providerAccountId: string,
+  externalId: string
+) {
+  const where = and(
+    eq(mediaSources.providerId, providerId),
+    eq(mediaSources.providerAccountId, providerAccountId),
+    eq(mediaSources.externalId, externalId)
+  );
+
+  return where ? getMediaSourceWhere(where) : undefined;
 }
 
 export function upsertMediaSource(input: CreateMediaSourceInput) {
@@ -147,7 +187,7 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
     .values({
       id: randomUUID(),
       providerId: input.providerId,
-      providerAccountId: input.providerAccountId ?? null,
+      providerAccountId: input.providerAccountId,
       externalId: input.externalId,
       name: input.name,
       enabled: input.enabled ?? true,
@@ -157,8 +197,8 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
       metadata: input.metadata ?? {},
     })
     .onConflictDoUpdate({
-      target: [mediaSources.providerId, mediaSources.externalId],
-      targetWhere: sql`${mediaSources.externalId} IS NOT NULL`,
+      target: [mediaSources.providerId, mediaSources.providerAccountId, mediaSources.externalId],
+      targetWhere: sql`${mediaSources.externalId} IS NOT NULL AND ${mediaSources.providerAccountId} IS NOT NULL`,
       set: {
         ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
         name: input.name,
@@ -172,39 +212,35 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
     })
     .run();
 
-  return getMediaSourceByProviderExternalId(input.providerId, input.externalId);
+  return getMediaSourceByProviderExternalId(input.providerId, input.providerAccountId, input.externalId);
 }
 
-export function listMediaSources(options: { enabledOnly?: boolean; providerId?: string } = {}) {
-  const db = getDatabase();
-  const orderBy = asc(mediaSources.name);
-  const enabledFilter = eq(mediaSources.enabled, true);
-
-  if (options.enabledOnly && options.providerId) {
-    return db.select().from(mediaSources)
-      .where(and(enabledFilter, eq(mediaSources.providerId, options.providerId)))
-      .orderBy(orderBy)
-      .all()
-      .map(mapMediaSource);
-  }
+export function listMediaSources(options: {
+  enabledOnly?: boolean;
+  providerId?: string;
+  providerAccountId?: string;
+} = {}) {
+  const filters: SQL<unknown>[] = [];
 
   if (options.enabledOnly) {
-    return db.select().from(mediaSources)
-      .where(enabledFilter)
-      .orderBy(orderBy)
-      .all()
-      .map(mapMediaSource);
+    filters.push(eq(mediaSources.enabled, true));
   }
 
   if (options.providerId) {
-    return db.select().from(mediaSources)
-      .where(eq(mediaSources.providerId, options.providerId))
-      .orderBy(orderBy)
-      .all()
-      .map(mapMediaSource);
+    filters.push(eq(mediaSources.providerId, options.providerId));
   }
 
-  return db.select().from(mediaSources).orderBy(orderBy).all().map(mapMediaSource);
+  if (options.providerAccountId) {
+    filters.push(eq(mediaSources.providerAccountId, options.providerAccountId));
+  }
+
+  const where = filters.length === 0
+    ? undefined
+    : filters.length === 1
+      ? filters[0]
+      : and(...filters);
+
+  return listMediaSourcesWhere(where);
 }
 
 export function updateMediaSourceHealth(id: string, input: { lastCheckedAt: string; lastError?: string }) {
@@ -219,4 +255,50 @@ export function updateMediaSourceHealth(id: string, input: { lastCheckedAt: stri
     .run();
 
   return getMediaSource(id);
+}
+
+export function updateMediaSourceForAccount(id: string, providerAccountId: string, input: UpdateMediaSourceInput) {
+  getDatabase()
+    .update(mediaSources)
+    .set({
+      ...(input.providerAccountId !== undefined ? { providerAccountId: input.providerAccountId } : {}),
+      ...(input.externalId !== undefined ? { externalId: input.externalId } : {}),
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+      ...(input.connection !== undefined ? { connection: encryptJsonSecrets(input.connection) } : {}),
+      ...(input.credentials !== undefined ? { credentials: encryptJsonSecrets(input.credentials) } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.lastCheckedAt !== undefined ? { lastCheckedAt: input.lastCheckedAt } : {}),
+      ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(and(
+      eq(mediaSources.id, id),
+      eq(mediaSources.providerAccountId, providerAccountId)
+    ))
+    .run();
+
+  return getMediaSourceForAccount(id, providerAccountId);
+}
+
+export function updateMediaSourceHealthForAccount(
+  id: string,
+  providerAccountId: string,
+  input: { lastCheckedAt: string; lastError?: string }
+) {
+  getDatabase()
+    .update(mediaSources)
+    .set({
+      lastCheckedAt: input.lastCheckedAt,
+      lastError: input.lastError ?? null,
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(and(
+      eq(mediaSources.id, id),
+      eq(mediaSources.providerAccountId, providerAccountId)
+    ))
+    .run();
+
+  return getMediaSourceForAccount(id, providerAccountId);
 }

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -196,7 +196,6 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
     })
     .onConflictDoUpdate({
       target: [mediaSources.providerId, mediaSources.providerAccountId, mediaSources.externalId],
-      targetWhere: sql`${mediaSources.externalId} IS NOT NULL AND ${mediaSources.providerAccountId} IS NOT NULL`,
       set: {
         name: input.name,
         ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -199,6 +199,133 @@ const migrations: Migration[] = [
         ON provider_sessions(expires_at);
     `,
   },
+  {
+    id: 6,
+    name: "scope_media_sources_external_ids_by_provider_account",
+    sql: `
+      DROP INDEX IF EXISTS media_sources_provider_external_id_idx;
+
+      CREATE UNIQUE INDEX media_sources_provider_external_id_idx
+        ON media_sources(provider_id, provider_account_id, external_id)
+        WHERE external_id IS NOT NULL AND provider_account_id IS NOT NULL;
+    `,
+  },
+  {
+    id: 7,
+    name: "require_provider_account_ownership",
+    sql: `
+      CREATE TABLE media_sources_next (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT NOT NULL,
+        provider_account_id TEXT NOT NULL REFERENCES provider_accounts(id) ON DELETE CASCADE,
+        external_id TEXT,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+        base_url TEXT NOT NULL,
+        connection_json TEXT NOT NULL DEFAULT '{}',
+        credentials_json TEXT NOT NULL DEFAULT '{}',
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        last_checked_at TEXT,
+        last_error TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      INSERT INTO media_sources_next (
+        id,
+        provider_id,
+        provider_account_id,
+        external_id,
+        name,
+        enabled,
+        base_url,
+        connection_json,
+        credentials_json,
+        metadata_json,
+        last_checked_at,
+        last_error,
+        created_at,
+        updated_at
+      )
+      SELECT
+        id,
+        provider_id,
+        provider_account_id,
+        external_id,
+        name,
+        enabled,
+        base_url,
+        connection_json,
+        credentials_json,
+        metadata_json,
+        last_checked_at,
+        last_error,
+        created_at,
+        updated_at
+      FROM media_sources
+      WHERE provider_account_id IS NOT NULL;
+
+      DROP TABLE media_sources;
+
+      ALTER TABLE media_sources_next RENAME TO media_sources;
+
+      CREATE INDEX media_sources_enabled_idx
+        ON media_sources(enabled);
+
+      CREATE INDEX media_sources_provider_id_idx
+        ON media_sources(provider_id);
+
+      CREATE INDEX media_sources_provider_account_id_idx
+        ON media_sources(provider_account_id);
+
+      CREATE UNIQUE INDEX media_sources_provider_external_id_idx
+        ON media_sources(provider_id, provider_account_id, external_id)
+        WHERE external_id IS NOT NULL;
+
+      CREATE TABLE provider_sessions_next (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT NOT NULL,
+        provider_account_id TEXT NOT NULL REFERENCES provider_accounts(id) ON DELETE CASCADE,
+        user_token TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      INSERT INTO provider_sessions_next (
+        id,
+        provider_id,
+        provider_account_id,
+        user_token,
+        created_at,
+        expires_at,
+        updated_at
+      )
+      SELECT
+        id,
+        provider_id,
+        provider_account_id,
+        user_token,
+        created_at,
+        expires_at,
+        updated_at
+      FROM provider_sessions
+      WHERE provider_account_id IS NOT NULL;
+
+      DROP TABLE provider_sessions;
+
+      ALTER TABLE provider_sessions_next RENAME TO provider_sessions;
+
+      CREATE INDEX provider_sessions_provider_id_idx
+        ON provider_sessions(provider_id);
+
+      CREATE INDEX provider_sessions_provider_account_id_idx
+        ON provider_sessions(provider_account_id);
+
+      CREATE INDEX provider_sessions_expires_at_idx
+        ON provider_sessions(expires_at);
+    `,
+  },
 ];
 
 export function runMigrations(db: DatabaseSync) {

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -326,6 +326,16 @@ const migrations: Migration[] = [
         ON provider_sessions(expires_at);
     `,
   },
+  {
+    id: 8,
+    name: "make_media_source_external_id_uniqueness_unconditional",
+    sql: `
+      DROP INDEX IF EXISTS media_sources_provider_external_id_idx;
+
+      CREATE UNIQUE INDEX media_sources_provider_external_id_idx
+        ON media_sources(provider_id, provider_account_id, external_id);
+    `,
+  },
 ];
 
 export function runMigrations(db: DatabaseSync) {

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -41,7 +41,10 @@ export function persistProviderAuth(input: {
   }
 
   const activeResourceIds = new Set(input.resources.map((resource) => resource.id));
-  const staleSources = listMediaSources({ providerId: input.provider.id }).filter((source) =>
+  const staleSources = listMediaSources({
+    providerId: input.provider.id,
+    providerAccountId: account.id,
+  }).filter((source) =>
     source.providerAccountId === account.id
     && typeof source.externalId === "string"
     && !activeResourceIds.has(source.externalId)

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -45,8 +45,7 @@ export function persistProviderAuth(input: {
     providerId: input.provider.id,
     providerAccountId: account.id,
   }).filter((source) =>
-    source.providerAccountId === account.id
-    && typeof source.externalId === "string"
+    typeof source.externalId === "string"
     && !activeResourceIds.has(source.externalId)
     && source.enabled
   );

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -34,7 +34,7 @@ export const mediaSources = sqliteTable(
   {
     id: text("id").primaryKey(),
     providerId: text("provider_id").notNull(),
-    providerAccountId: text("provider_account_id").references(() => providerAccounts.id, { onDelete: "set null" }),
+    providerAccountId: text("provider_account_id").notNull().references(() => providerAccounts.id, { onDelete: "cascade" }),
     externalId: text("external_id"),
     name: text("name").notNull(),
     enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
@@ -52,8 +52,8 @@ export const mediaSources = sqliteTable(
     index("media_sources_provider_id_idx").on(table.providerId),
     index("media_sources_provider_account_id_idx").on(table.providerAccountId),
     uniqueIndex("media_sources_provider_external_id_idx")
-      .on(table.providerId, table.externalId)
-      .where(sql`${table.externalId} IS NOT NULL`),
+      .on(table.providerId, table.providerAccountId, table.externalId)
+      .where(sql`${table.externalId} IS NOT NULL AND ${table.providerAccountId} IS NOT NULL`),
   ]
 );
 
@@ -62,7 +62,7 @@ export const providerSessions = sqliteTable(
   {
     id: text("id").primaryKey(),
     providerId: text("provider_id").notNull(),
-    providerAccountId: text("provider_account_id").references(() => providerAccounts.id, { onDelete: "set null" }),
+    providerAccountId: text("provider_account_id").notNull().references(() => providerAccounts.id, { onDelete: "cascade" }),
     userToken: text("user_token").notNull(),
     createdAt: integer("created_at").notNull(),
     expiresAt: integer("expires_at").notNull(),

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -52,8 +52,7 @@ export const mediaSources = sqliteTable(
     index("media_sources_provider_id_idx").on(table.providerId),
     index("media_sources_provider_account_id_idx").on(table.providerAccountId),
     uniqueIndex("media_sources_provider_external_id_idx")
-      .on(table.providerId, table.providerAccountId, table.externalId)
-      .where(sql`${table.externalId} IS NOT NULL AND ${table.providerAccountId} IS NOT NULL`),
+      .on(table.providerId, table.providerAccountId, table.externalId),
   ]
 );
 

--- a/apps/server/src/providers/jellyfin/provider.ts
+++ b/apps/server/src/providers/jellyfin/provider.ts
@@ -132,7 +132,7 @@ function normalizeBaseUrl(url: string) {
 
 function isLoopbackHost(hostname: string) {
   const host = normalizeHostname(hostname);
-  return host === "localhost" || host === "::1" || host === "[::1]" || host.startsWith("127.");
+  return host === "localhost" || host === "::1" || host.startsWith("127.");
 }
 
 function normalizeIpCandidate(value: string) {
@@ -182,7 +182,11 @@ async function resolveHostnameAddresses(hostname: string) {
 
     return uniqueStrings(records.map((record) => normalizeIpCandidate(record.address)));
   } catch {
-    return [];
+    throw new ApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl hostname could not be resolved for security validation"
+    );
   }
 }
 

--- a/apps/server/src/providers/jellyfin/provider.ts
+++ b/apps/server/src/providers/jellyfin/provider.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "crypto";
+import { lookup } from "dns/promises";
+import { isIP } from "net";
 import { Readable } from "stream";
 import type { Request, Response } from "express";
 import type { MediaSource } from "../../db/mediaSourcesRepository.js";
@@ -18,6 +20,12 @@ const JELLYFIN_VERSION = process.env.npm_package_version ?? "0.0.0";
 const JELLYFIN_REQUEST_TIMEOUT_MS = 5000;
 const CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS = 5000;
 const JELLYFIN_DEV_BASE_URL = stringValue(process.env.CLIPARR_DEV_JELLYFIN_URL);
+const ALLOW_LOOPBACK_JELLYFIN_URLS = booleanEnv(process.env.CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS);
+const DISALLOWED_JELLYFIN_HOSTNAMES = new Set([
+  "metadata",
+  "metadata.azure.internal",
+  "metadata.google.internal",
+]);
 
 interface JellyfinSourceContext {
   sourceId: string;
@@ -47,6 +55,11 @@ function numberValue(value: unknown) {
 
 function booleanValue(value: unknown) {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function booleanEnv(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
 function asArray<T>(value: T | T[] | null | undefined): T[] {
@@ -118,8 +131,106 @@ function normalizeBaseUrl(url: string) {
 }
 
 function isLoopbackHost(hostname: string) {
-  const host = hostname.toLowerCase();
+  const host = normalizeHostname(hostname);
   return host === "localhost" || host === "::1" || host === "[::1]" || host.startsWith("127.");
+}
+
+function normalizeIpCandidate(value: string) {
+  const normalized = value.toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+
+  return normalized.startsWith("::ffff:") ? normalized.slice(7) : normalized;
+}
+
+function normalizeHostname(value: string) {
+  return normalizeIpCandidate(value.trim()).replace(/\.+$/, "");
+}
+
+function isUnspecifiedHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  return host === "0.0.0.0" || host === "::";
+}
+
+function isLinkLocalHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  return host.startsWith("169.254.") || /^fe[89ab][0-9a-f]:/i.test(host);
+}
+
+function isMulticastHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  if (/^ff[0-9a-f]{2}:/i.test(host)) {
+    return true;
+  }
+
+  const firstOctet = Number(host.split(".")[0]);
+  return Number.isInteger(firstOctet) && firstOctet >= 224 && firstOctet <= 239;
+}
+
+async function resolveHostnameAddresses(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  if (isIP(normalized)) {
+    return [];
+  }
+
+  try {
+    const records = await lookup(normalized, {
+      all: true,
+      verbatim: true,
+    });
+
+    return uniqueStrings(records.map((record) => normalizeIpCandidate(record.address)));
+  } catch {
+    return [];
+  }
+}
+
+function assertAllowedResolvedAddress(address: string) {
+  if (isUnspecifiedHost(address) || isLinkLocalHost(address) || isMulticastHost(address)) {
+    throw new ApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl resolved to an unsafe address"
+    );
+  }
+
+  if (isLoopbackHost(address) && !ALLOW_LOOPBACK_JELLYFIN_URLS && !JELLYFIN_DEV_BASE_URL) {
+    throw new ApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "For security, localhost Jellyfin URLs are disabled unless CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS is enabled"
+    );
+  }
+}
+
+async function assertAllowedJellyfinServerUrl(url: string) {
+  const parsed = assertHttpUrl(url.trim());
+  const hostname = normalizeHostname(parsed.hostname);
+
+  if (DISALLOWED_JELLYFIN_HOSTNAMES.has(hostname)) {
+    throw new ApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl must point at your Jellyfin server, not a cloud metadata hostname"
+    );
+  }
+
+  if (isUnspecifiedHost(hostname) || isLinkLocalHost(hostname) || isMulticastHost(hostname)) {
+    throw new ApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl must point at your Jellyfin server, not an unspecified, link-local, or multicast host"
+    );
+  }
+
+  assertAllowedResolvedAddress(hostname);
+
+  for (const address of await resolveHostnameAddresses(hostname)) {
+    assertAllowedResolvedAddress(address);
+  }
+
+  return parsed;
 }
 
 function resolveJellyfinBaseUrl(url: string) {
@@ -253,6 +364,7 @@ async function jellyfinFetch(
     timeoutMs?: number;
     errorCode?: string;
     failureMessage?: string;
+    exposeFailureDetail?: boolean;
   } = {}
 ) {
   const controller = new AbortController();
@@ -272,17 +384,21 @@ async function jellyfinFetch(
     });
 
     if (!response.ok && response.status !== 206) {
+      const failureMessage = options.failureMessage ?? "Jellyfin request failed";
+      const exposeFailureDetail = options.exposeFailureDetail ?? true;
       const detail = (await response.text().catch(() => ""))
         .slice(0, 400)
         .replace(/\s+/g, " ")
         .trim();
 
       throw new ApiError(
-        response.status,
+        !exposeFailureDetail && response.status !== 401 ? 502 : response.status,
         options.errorCode ?? "jellyfin_request_failed",
-        detail
-          ? `${options.failureMessage ?? "Jellyfin request failed"}: ${detail}`
-          : `${options.failureMessage ?? "Jellyfin request failed"}: ${response.status} ${response.statusText}`
+        !exposeFailureDetail
+          ? failureMessage
+          : detail
+            ? `${failureMessage}: ${detail}`
+            : `${failureMessage}: ${response.status} ${response.statusText}`
       );
     }
 
@@ -312,7 +428,9 @@ async function jellyfinFetch(
     throw new ApiError(
       502,
       options.errorCode ?? "jellyfin_request_failed",
-      `${options.failureMessage ?? "Jellyfin request failed"}: ${errorMessage(err)}`
+      options.exposeFailureDetail === false
+        ? options.failureMessage ?? "Jellyfin request failed"
+        : `${options.failureMessage ?? "Jellyfin request failed"}: ${errorMessage(err)}`
     );
   } finally {
     clearTimeout(timeout);
@@ -330,6 +448,7 @@ async function jellyfinJson<T>(
     body?: string;
     errorCode?: string;
     failureMessage?: string;
+    exposeFailureDetail?: boolean;
   } = {}
 ) {
   const url = buildJellyfinUrl(baseUrl, path);
@@ -361,7 +480,7 @@ async function jellyfinJson<T>(
   }
 }
 
-function parseCredentialsInput(body: unknown) {
+async function parseCredentialsInput(body: unknown) {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new ApiError(
       400,
@@ -387,7 +506,7 @@ function parseCredentialsInput(body: unknown) {
   }
 
   return {
-    serverUrl: resolveJellyfinBaseUrl(serverUrl),
+    serverUrl: resolveJellyfinBaseUrl((await assertAllowedJellyfinServerUrl(serverUrl)).toString()),
     username,
     password: record.password,
   };
@@ -883,12 +1002,13 @@ export const jellyfinProvider: ProviderImplementation = {
   },
 
   async authenticateWithCredentials(body) {
-    const { serverUrl, username, password } = parseCredentialsInput(body);
+    const { serverUrl, username, password } = await parseCredentialsInput(body);
     const publicInfo = await jellyfinJson<any>(serverUrl, "/System/Info/Public", {
       deviceId: JELLYFIN_DEVICE_ID,
       timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
       errorCode: "jellyfin_server_unreachable",
       failureMessage: "Could not reach that Jellyfin server",
+      exposeFailureDetail: false,
     });
 
     let authResult: any;
@@ -903,6 +1023,7 @@ export const jellyfinProvider: ProviderImplementation = {
         }),
         errorCode: "jellyfin_auth_failed",
         failureMessage: "Jellyfin sign-in failed",
+        exposeFailureDetail: false,
       });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {

--- a/apps/server/src/providers/plex/provider.ts
+++ b/apps/server/src/providers/plex/provider.ts
@@ -15,6 +15,7 @@ import type { ProviderSessionRecord } from "../../session/store.js";
 const PLEX_PRODUCT = "Cliparr";
 const PLEX_CLIENT_IDENTIFIER = process.env.PLEX_CLIENT_IDENTIFIER ?? `cliparr-${randomUUID()}`;
 const AUTH_TTL_MS = 1000 * 60 * 10;
+const MAX_PENDING_AUTH_REQUESTS = 512;
 const DEFAULT_APP_URL = "http://localhost:3000";
 const PLEX_AUTH_COMPLETE_PATH = "/auth/plex/complete";
 const CONNECTION_PROBE_TIMEOUT_MS = 2500;
@@ -52,6 +53,14 @@ interface PlexSourceContext {
   sourceId: string;
   baseUrl: string;
   token: string;
+}
+
+function pruneExpiredAuthRequests(now = Date.now()) {
+  for (const [authId, authRequest] of authRequests.entries()) {
+    if (authRequest.expiresAt <= now) {
+      authRequests.delete(authId);
+    }
+  }
 }
 
 function getPlexAuthCompleteUrl() {
@@ -878,6 +887,11 @@ export const plexProvider: ProviderImplementation = {
   },
 
   async startAuth() {
+    pruneExpiredAuthRequests();
+    if (authRequests.size >= MAX_PENDING_AUTH_REQUESTS) {
+      throw new ApiError(503, "plex_auth_busy", "Too many pending Plex sign-ins. Wait a moment and try again.");
+    }
+
     const response = await plexFetch("https://plex.tv/api/v2/pins?strong=true", {
       method: "POST",
     });
@@ -912,6 +926,7 @@ export const plexProvider: ProviderImplementation = {
   },
 
   async pollAuth(authId) {
+    pruneExpiredAuthRequests();
     const authRequest = authRequests.get(authId);
     if (!authRequest) {
       return { status: "expired" as const };

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -3,7 +3,7 @@ import { listMediaSources } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getProvider } from "../providers/registry.js";
 import type { CurrentlyPlayingEntry, SourcePlaybackError, ViewerPlaybackGroup } from "../providers/types.js";
-import { requireSession, setNoStore } from "../session/request.js";
+import { requireAccountSession, setNoStore } from "../session/request.js";
 import { pruneSessionMediaHandles } from "../session/store.js";
 
 export const mediaRouter = Router();
@@ -56,10 +56,13 @@ mediaRouter.get(
   "/currently-playing",
   asyncHandler(async (req, res) => {
     setNoStore(res);
-    const session = requireSession(req);
+    const session = requireAccountSession(req);
     pruneSessionMediaHandles(session);
     const sourceErrors: SourcePlaybackError[] = [];
-    const sources = listMediaSources({ enabledOnly: true })
+    const sources = listMediaSources({
+      enabledOnly: true,
+      providerAccountId: session.providerAccountId,
+    })
       .flatMap((source) => {
         const provider = getProvider(source.providerId);
         if (!provider) {
@@ -121,7 +124,7 @@ mediaRouter.get(
   "/:handleId",
   asyncHandler(async (req, res) => {
     setNoStore(res);
-    const session = requireSession(req);
+    const session = requireAccountSession(req);
     pruneSessionMediaHandles(session);
     const handle = session.mediaHandles.get(req.params.handleId as string);
     if (!handle) {

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,16 +1,16 @@
 import { Router } from "express";
 import {
-  deleteMediaSource,
-  getMediaSource,
   listMediaSources,
-  updateMediaSource,
-  updateMediaSourceHealth,
+  getMediaSourceForAccount,
+  deleteMediaSourceForAccount,
+  updateMediaSourceForAccount,
+  updateMediaSourceHealthForAccount,
   type MediaSource,
   type UpdateMediaSourceInput,
 } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getProvider } from "../providers/registry.js";
-import { requireSession, setNoStore } from "../session/request.js";
+import { requireAccountSession, setNoStore } from "../session/request.js";
 
 export const sourcesRouter = Router();
 
@@ -29,8 +29,8 @@ function serializeSource(source: MediaSource) {
   };
 }
 
-function requireMediaSource(sourceId: string) {
-  const source = getMediaSource(sourceId);
+function requireMediaSource(session: ReturnType<typeof requireAccountSession>, sourceId: string) {
+  const source = getMediaSourceForAccount(sourceId, session.providerAccountId);
   if (!source) {
     throw new ApiError(404, "source_not_found", "Source was not found");
   }
@@ -77,10 +77,10 @@ function parseSourceUpdate(body: unknown): UpdateMediaSourceInput {
 sourcesRouter.get(
   "/",
   asyncHandler(async (req, res) => {
-    requireSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
     res.json({
-      sources: listMediaSources().map(serializeSource),
+      sources: listMediaSources({ providerAccountId: session.providerAccountId }).map(serializeSource),
     });
   })
 );
@@ -88,9 +88,9 @@ sourcesRouter.get(
 sourcesRouter.get(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(session, req.params.id as string);
     res.json({ source: serializeSource(source) });
   })
 );
@@ -98,10 +98,14 @@ sourcesRouter.get(
 sourcesRouter.patch(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    requireMediaSource(req.params.id as string);
-    const source = updateMediaSource(req.params.id as string, parseSourceUpdate(req.body));
+    requireMediaSource(session, req.params.id as string);
+    const source = updateMediaSourceForAccount(
+      req.params.id as string,
+      session.providerAccountId,
+      parseSourceUpdate(req.body)
+    );
     if (!source) {
       throw new ApiError(404, "source_not_found", "Source was not found");
     }
@@ -112,11 +116,11 @@ sourcesRouter.patch(
 sourcesRouter.delete(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(session, req.params.id as string);
 
-    const deleted = deleteMediaSource(source.id);
+    const deleted = deleteMediaSourceForAccount(source.id, session.providerAccountId);
     if (!deleted) {
       throw new ApiError(404, "source_not_found", "Source was not found");
     }
@@ -128,10 +132,10 @@ sourcesRouter.delete(
 sourcesRouter.post(
   "/:id/check",
   asyncHandler(async (req, res) => {
-    requireSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
 
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(session, req.params.id as string);
     const provider = getProvider(source.providerId);
     if (!provider) {
       throw new ApiError(500, "provider_not_registered", "Source provider is not registered");
@@ -141,7 +145,7 @@ sourcesRouter.post(
     const result = await provider.checkSource(source);
 
     if (!result.ok) {
-      const updatedSource = updateMediaSourceHealth(source.id, {
+      const updatedSource = updateMediaSourceHealthForAccount(source.id, session.providerAccountId, {
         lastCheckedAt: checkedAt,
         lastError: result.message,
       });
@@ -160,7 +164,7 @@ sourcesRouter.post(
       return;
     }
 
-    const updatedSource = updateMediaSource(source.id, {
+    const updatedSource = updateMediaSourceForAccount(source.id, session.providerAccountId, {
       ...(result.name !== undefined ? { name: result.name } : {}),
       ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
       ...(result.connection !== undefined ? { connection: result.connection } : {}),

--- a/apps/server/src/session/request.ts
+++ b/apps/server/src/session/request.ts
@@ -19,6 +19,10 @@ export function requireSession(req: Request): ProviderSessionRecord {
   return session;
 }
 
+export function requireAccountSession(req: Request): ProviderSessionRecord {
+  return requireSession(req);
+}
+
 export function requireProviderSession(req: Request, providerId: string) {
   const session = requireSession(req);
   if (session.providerId !== providerId) {

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -12,7 +12,7 @@ const MEDIA_HANDLE_IDLE_TTL_MS = 1000 * 60 * 15;
 export interface ProviderSessionRecord {
   id: string;
   providerId: string;
-  providerAccountId?: string;
+  providerAccountId: string;
   userToken: string;
   mediaHandles: Map<string, MediaHandle>;
   createdAt: number;
@@ -34,7 +34,7 @@ function mapProviderSession(row: ProviderSessionRow): ProviderSessionRecord {
   return {
     id: row.id,
     providerId: row.providerId,
-    providerAccountId: row.providerAccountId ?? undefined,
+    providerAccountId: row.providerAccountId,
     userToken: decryptSecret(row.userToken),
     mediaHandles: getMediaHandles(row.id),
     createdAt: row.createdAt,
@@ -44,7 +44,7 @@ function mapProviderSession(row: ProviderSessionRow): ProviderSessionRecord {
 
 export function createProviderSession(input: {
   providerId: string;
-  providerAccountId?: string;
+  providerAccountId: string;
   userToken: string;
 }) {
   const now = Date.now();
@@ -56,7 +56,7 @@ export function createProviderSession(input: {
     .values({
       id,
       providerId: input.providerId,
-      providerAccountId: input.providerAccountId ?? null,
+      providerAccountId: input.providerAccountId,
       userToken: encryptSecret(input.userToken),
       createdAt: now,
       expiresAt,
@@ -66,7 +66,7 @@ export function createProviderSession(input: {
   return mapProviderSession({
     id,
     providerId: input.providerId,
-    providerAccountId: input.providerAccountId ?? null,
+    providerAccountId: input.providerAccountId,
     userToken: input.userToken,
     createdAt: now,
     expiresAt,


### PR DESCRIPTION
This pull request introduces significant changes to how media sources are managed and scoped to provider accounts, improves database schema constraints, and adds a new environment variable for enhanced Jellyfin security. The main focus is on ensuring that all media sources and provider sessions are strictly associated with a provider account, improving data integrity and multi-user isolation. Additionally, the codebase now enforces unique constraints per account and provides new helper functions for account-scoped operations.

**Database and Data Model Changes:**

* Media sources and provider sessions are now required to have a `providerAccountId` (no longer optional), and all related queries and mutations are updated to scope by account. This ensures that resources are isolated per provider account and cannot be accessed across accounts. [[1]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L26-R26) [[2]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L37-R37) [[3]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L53-R53) [[4]](diffhunk://#diff-944f4581d449dd2e666c41961d4705da7b63d4f188b63198574262b1ee3bc396L37-R37) [[5]](diffhunk://#diff-944f4581d449dd2e666c41961d4705da7b63d4f188b63198574262b1ee3bc396L65-R65)
* The unique index on media sources is updated to include `providerAccountId`, enforcing uniqueness of `externalId` per provider account, and corresponding database migrations are added. [[1]](diffhunk://#diff-6aa47437481dced2bc11448a4d34cd9b8c5648e58e3bc703dc1dccc24b2a22c9R192-R318) [[2]](diffhunk://#diff-944f4581d449dd2e666c41961d4705da7b63d4f188b63198574262b1ee3bc396L55-R56)
* New helper functions are added to `mediaSourcesRepository.ts` for account-scoped CRUD operations (e.g., `getMediaSourceForAccount`, `deleteMediaSourceForAccount`, `updateMediaSourceForAccount`, etc.), and all relevant logic is updated to use these. [[1]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76R68-R96) [[2]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L111-R141) [[3]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L129-R176) [[4]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76R259-R304)

**Provider Logic and Security:**

* The Jellyfin provider now loads a new environment variable `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS`, which controls whether loopback/localhost Jellyfin URLs are allowed, adding a security layer for deployments. The variable is documented in `.env.example` and `README.md`. [[1]](diffhunk://#diff-d5e998cbedb2579bbe658660c86f4f65dfbc1fc56f3e449f58efaa3ad84dbb92R23-R28) [[2]](diffhunk://#diff-d5e998cbedb2579bbe658660c86f4f65dfbc1fc56f3e449f58efaa3ad84dbb92R60-R64) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR32-R36) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76)

**Code Quality and Consistency:**

* All queries and upsert logic for media sources are updated to require and use `providerAccountId`, ensuring consistent and correct scoping throughout the codebase. [[1]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L150-R190) [[2]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L160-R201) [[3]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L175-R243) [[4]](diffhunk://#diff-109a358331c725b8c179e31e87af9577e402d583ea58b83e9ce71ffc771e5978L44-R47)

These changes collectively improve data isolation, enforce stricter data integrity, and add an additional security option for Jellyfin deployments.