### PR TITLE
Update Jellyfin bootstrap for health checks and wizard completion

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,7 @@ services:
       media-seed:
         condition: service_completed_successfully
       jellyfin:
-        condition: service_started
+        condition: service_healthy
     command:
       - /bin/sh
       - -lc

--- a/docker/bootstrap-jellyfin.sh
+++ b/docker/bootstrap-jellyfin.sh
@@ -39,19 +39,33 @@ wait_for_public_info() {
   return 1
 }
 
-wait_for_startup_api() {
+startup_completed_from_public_info() {
+  printf '%s' "$1" | jq -r '.StartupWizardCompleted // false'
+}
+
+wait_for_startup_ready_or_completed() {
+  initial_public_info="$1"
+  public_info="$initial_public_info"
   attempt=0
 
   while [ "$attempt" -lt 60 ]; do
+    startup_completed="$(startup_completed_from_public_info "$public_info")"
+    if [ "$startup_completed" = "true" ]; then
+      printf '%s' "$public_info"
+      return 0
+    fi
+
     if curl -fsS "$JELLYFIN_BASE_URL/Startup/User" \
       -H "Authorization: $(jellyfin_auth_header)" \
       -H "Accept: application/json" \
       >/dev/null 2>&1; then
+      printf '%s' "$public_info"
       return 0
     fi
 
     attempt=$((attempt + 1))
     sleep 2
+    public_info="$(wait_for_public_info)"
   done
 
   echo "Timed out waiting for Jellyfin startup endpoints." >&2
@@ -112,11 +126,11 @@ login_jellyfin() {
 }
 
 public_info="$(wait_for_public_info)"
-startup_completed="$(printf '%s' "$public_info" | jq -r '.StartupWizardCompleted // false')"
+public_info="$(wait_for_startup_ready_or_completed "$public_info")"
+startup_completed="$(startup_completed_from_public_info "$public_info")"
 
 if [ "$startup_completed" != "true" ]; then
   echo "Completing Jellyfin startup wizard."
-  wait_for_startup_api
 
   post_jellyfin_with_retries \
     "/Startup/User" \


### PR DESCRIPTION
This pull request improves the reliability of the Jellyfin service startup process in the development environment by ensuring that dependent services wait until Jellyfin is fully healthy or its startup wizard is completed before proceeding. The changes update both the Docker Compose configuration and the bootstrap script to better handle Jellyfin's startup state.

**Service health checks:**

* Changed the `jellyfin` service condition in `docker-compose.dev.yml` from `service_started` to `service_healthy`, ensuring that dependent services only start once Jellyfin passes its health check.

**Bootstrap script improvements:**

* Added a new function `startup_completed_from_public_info` and replaced the previous wait logic with `wait_for_startup_ready_or_completed`, which waits until either the startup wizard is completed or the `/Startup/User` endpoint is available. This makes the startup process more robust and less prone to race conditions.
* Updated the login process in `login_jellyfin()` to use the improved waiting mechanism, ensuring the script only proceeds once Jellyfin is truly ready.