### PR TITLE
Polish editor workstation layout and controls

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -70,12 +70,7 @@ export default function EditorScreen({ session, onBack }: Props) {
 
     setStartTime(roundedStart);
     setEndTime(roundedEnd);
-
-    const currentPreviewTime = playbackTimeAtStartRef.current;
-    if (currentPreviewTime < roundedStart || currentPreviewTime > roundedEnd) {
-      void seekToTime(roundedStart);
-    }
-  }, [duration, playbackTimeAtStartRef, seekToTime]);
+  }, [duration]);
 
   const isValidTimelineRange = useCallback((nextStart: number, nextEnd: number) => {
     const minClipLength = Math.min(MIN_CLIP_SECONDS, duration);

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { MIN_CLIP_SECONDS, roundTimelineTime } from "./editor/EditorUtils";
 import { useEditorPlayback } from "./editor/useEditorPlayback";
 import { useEditorTimeline } from "./editor/useEditorTimeline";
@@ -11,6 +11,20 @@ import type { CurrentlyPlayingItem } from "../providers/types";
 interface Props {
   session: CurrentlyPlayingItem;
   onBack: () => void;
+}
+
+function isInteractiveKeyboardTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  return Boolean(
+    target.closest("input, textarea, select, button, [contenteditable=\"true\"], [role=\"slider\"]"),
+  );
 }
 
 export default function EditorScreen({ session, onBack }: Props) {
@@ -124,9 +138,34 @@ export default function EditorScreen({ session, onBack }: Props) {
     }
   };
 
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.code !== "Space") {
+        return;
+      }
+
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      if (isInteractiveKeyboardTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      togglePlay();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [togglePlay]);
+
   if (!session.mediaUrl) {
     return (
-      <div className="min-h-screen bg-background text-foreground p-8 flex items-center justify-center">
+      <div className="flex h-dvh items-center justify-center overflow-hidden bg-background p-8 text-foreground">
         <div className="text-center">
           <p className="text-destructive mb-4">Could not find media file for this session.</p>
           <button onClick={onBack} className="text-primary hover:underline">Go Back</button>
@@ -136,7 +175,7 @@ export default function EditorScreen({ session, onBack }: Props) {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
+    <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
       <EditorHeader
         title={session.title}
         onBack={onBack}
@@ -147,39 +186,41 @@ export default function EditorScreen({ session, onBack }: Props) {
         handleExport={handleExport}
       />
 
-      <main className="flex-1 flex flex-col items-center justify-center p-8 max-w-6xl mx-auto w-full gap-8">
-        {error && (
-          <div className="w-full bg-destructive/10 border border-destructive/20 text-destructive p-4 rounded-lg text-sm">
-            {error}
-          </div>
-        )}
+      <main className="min-h-0 flex-1 overflow-hidden p-3 sm:p-4">
+        <div className="flex h-full min-h-0 flex-col gap-3">
+          {error && (
+            <div className="border border-destructive/35 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
 
-        <EditorPreview
-          canvasRef={canvasRef}
-          playing={playing}
-          loadingPreview={loadingPreview}
-          previewStatus={previewStatus}
-          togglePlay={togglePlay}
-        />
+          <section className="flex min-h-0 flex-1 items-center justify-center overflow-hidden border border-border bg-card p-3">
+            <EditorPreview
+              canvasRef={canvasRef}
+              playing={playing}
+              loadingPreview={loadingPreview}
+              previewStatus={previewStatus}
+              togglePlay={togglePlay}
+            />
+          </section>
 
-        <div className="w-full bg-card text-card-foreground border border-border rounded-lg p-6">
-          <EditorControls
-            playing={playing}
-            loadingPreview={loadingPreview}
-            togglePlay={togglePlay}
-            currentTime={currentTime}
-            duration={duration}
-            startTime={startTime}
-            endTime={endTime}
-            muted={muted}
-            setMuted={setMuted}
-            volume={volume}
-            setVolume={setVolume}
-          />
+          <section className="shrink-0 overflow-hidden border border-border bg-card text-card-foreground">
+            <EditorControls
+              playing={playing}
+              loadingPreview={loadingPreview}
+              togglePlay={togglePlay}
+              currentTime={currentTime}
+              duration={duration}
+              startTime={startTime}
+              endTime={endTime}
+              muted={muted}
+              setMuted={setMuted}
+              volume={volume}
+              setVolume={setVolume}
+            />
 
-          <div className="space-y-4">
             {!hasDuration && (
-              <div className="bg-secondary/10 border border-secondary/20 text-secondary p-3 rounded-lg text-sm">
+              <div className="border-t border-border px-3 py-3 text-sm text-muted-foreground">
                 Waiting for media duration before clip controls can be adjusted.
               </div>
             )}
@@ -194,7 +235,6 @@ export default function EditorScreen({ session, onBack }: Props) {
                 timelineScaleCount={timelineScaleCount}
                 loadingPreview={loadingPreview}
                 playing={playing}
-                duration={duration}
                 handleTimelineScroll={handleTimelineScroll}
                 handleTimelineChange={handleTimelineChange}
                 handleTimelineWheel={handleTimelineWheel}
@@ -210,7 +250,7 @@ export default function EditorScreen({ session, onBack }: Props) {
                 }}
               />
             )}
-          </div>
+          </section>
         </div>
       </main>
     </div>

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -28,27 +28,38 @@ export function EditorControls({
   volume,
   setVolume,
 }: EditorControlsProps) {
+  const clipDuration = Math.max(0, endTime - startTime);
+  const clipMetrics = [
+    { label: "In", value: formatTime(startTime) },
+    { label: "Out", value: formatTime(endTime) },
+    { label: "Duration", value: formatTime(clipDuration), emphasized: true },
+  ];
+
   return (
-    <div className="flex items-center justify-between mb-6 gap-4">
-      <div className="flex flex-wrap items-center gap-4">
-        <button
-          onClick={togglePlay}
-          disabled={loadingPreview}
-          className="w-10 h-10 bg-secondary hover:bg-secondary/90 text-secondary-foreground disabled:opacity-50 disabled:cursor-not-allowed rounded-full flex items-center justify-center transition-colors"
-        >
-          {playing ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5 ml-0.5" />}
-        </button>
-        <div className="text-sm font-medium font-mono">
-          {formatTime(currentTime)} / {formatTime(duration)}
+    <div className="border-b border-border px-3 py-2">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={togglePlay}
+            disabled={loadingPreview}
+            aria-label={playing ? "Pause preview" : "Play preview"}
+            className="flex h-8 w-8 items-center justify-center border border-border bg-accent text-foreground transition-colors hover:bg-accent/80 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
+          </button>
+          <div className="font-mono text-sm font-semibold text-foreground">
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </div>
         </div>
+        <div className="h-5 w-px bg-border" />
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={() => setMuted((current) => !current)}
-            className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+            className="flex h-8 w-8 items-center justify-center border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             aria-label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
           >
-            {muted || volume === 0 ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
+            {muted || volume === 0 ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
           </button>
           <input
             type="range"
@@ -61,16 +72,27 @@ export function EditorControls({
               setVolume(nextVolume);
               setMuted(nextVolume === 0);
             }}
-            className="w-24 accent-primary"
+            className="w-24 accent-primary sm:w-28"
             aria-label="Preview volume"
           />
         </div>
-        <div className="text-sm font-medium font-mono">
-          Clip: {formatTime(startTime)} - {formatTime(endTime)}
+        <div className="min-w-0 flex-1" />
+        <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-right sm:gap-x-6">
+          {clipMetrics.map((metric) => (
+            <div key={metric.label} className="flex items-center gap-2">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                {metric.label}
+              </span>
+              <span
+                className={`font-mono text-sm font-semibold ${
+                  metric.emphasized ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                {metric.value}
+              </span>
+            </div>
+          ))}
         </div>
-      </div>
-      <div className="text-sm text-muted-foreground font-mono">
-        {formatTime(endTime - startTime)}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/editor/EditorHeader.tsx
+++ b/apps/frontend/src/components/editor/EditorHeader.tsx
@@ -20,24 +20,27 @@ export function EditorHeader({
   handleExport,
 }: EditorHeaderProps) {
   return (
-    <header className="flex items-center justify-between p-6 border-b border-border bg-card/50">
-      <div className="flex items-center gap-4">
+    <header className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border bg-card px-3 py-2">
+      <div className="flex items-center gap-2">
         <button
           onClick={onBack}
-          className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+          aria-label="Back"
+          className="flex h-8 w-8 items-center justify-center rounded-[2px] border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
-          <ArrowLeft className="w-5 h-5" />
+          <ArrowLeft className="h-4 w-4" />
         </button>
-        <div>
-          <h1 className="text-xl font-bold truncate max-w-md">{title}</h1>
-          <p className="text-sm text-muted-foreground">Edit Clip</p>
-        </div>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Edit
+        </span>
       </div>
-      <div className="flex items-center gap-4">
+      <div className="min-w-0 text-center text-sm font-medium text-foreground">
+        <div className="truncate">{title}</div>
+      </div>
+      <div className="flex items-center justify-self-end gap-2">
         <select
           value={resolution}
           onChange={(event) => setResolution(event.target.value as "original" | "1080" | "720")}
-          className="bg-card border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
+          className="h-8 rounded-[2px] border border-border bg-background px-2.5 text-xs font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
           disabled={exporting}
         >
           <option value="original">Original Quality</option>
@@ -47,17 +50,17 @@ export function EditorHeader({
         <button
           onClick={handleExport}
           disabled={exporting}
-          className="flex w-42 items-center justify-center gap-2 bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed text-primary-foreground px-4 py-2 rounded-lg font-medium transition-colors"
+          className="flex h-8 min-w-28 items-center justify-center gap-2 rounded-[2px] border border-primary bg-primary px-3 text-xs font-semibold uppercase tracking-[0.12em] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {exporting ? (
             <span className="flex items-center gap-2">
-              <div className="w-4 h-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
               {Math.round(progress * 100)}%
             </span>
           ) : (
             <>
-              <Download className="w-4 h-4" />
-              Export MP4
+              <Download className="h-3.5 w-3.5" />
+              Export
             </>
           )}
         </button>

--- a/apps/frontend/src/components/editor/EditorPreview.tsx
+++ b/apps/frontend/src/components/editor/EditorPreview.tsx
@@ -17,28 +17,29 @@ export function EditorPreview({
   togglePlay,
 }: EditorPreviewProps) {
   return (
-    <div className="w-full aspect-video bg-background rounded-lg overflow-hidden border border-border shadow-2xl relative group">
+    <div className="group relative aspect-video h-full max-h-full w-auto max-w-full overflow-hidden bg-black">
       <canvas
         ref={canvasRef}
-        className="w-full h-full object-contain"
+        className="h-full w-full object-contain"
         onClick={togglePlay}
       />
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
         <button
           type="button"
           onClick={(event) => {
             event.stopPropagation();
             togglePlay();
           }}
-          className={`pointer-events-auto w-16 h-16 bg-primary/90 text-primary-foreground rounded-full flex items-center justify-center backdrop-blur-sm transition-all ${
-            playing ? "opacity-0 scale-90" : "opacity-100 scale-100 group-hover:bg-primary"
+          aria-label={playing ? "Pause preview" : "Play preview"}
+          className={`pointer-events-auto flex h-11 w-11 items-center justify-center border border-white/12 bg-card/92 text-foreground transition-all ${
+            playing ? "scale-95 opacity-0" : "scale-100 opacity-100 group-hover:bg-card"
           }`}
         >
-          <Play className="w-8 h-8 ml-1" />
+          <Play className="ml-0.5 h-5 w-5" />
         </button>
       </div>
       {loadingPreview && (
-        <div className="absolute inset-0 flex items-center justify-center bg-background/70 text-sm text-muted-foreground">
+        <div className="absolute inset-0 flex items-center justify-center bg-black/72 text-sm text-muted-foreground">
           {previewStatus}
         </div>
       )}

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -85,20 +85,7 @@ export function EditorTimeline({
         onChange={handleTimelineChange}
         onActionMoving={({ start, end }) => isValidTimelineRange(start, end)}
         onActionResizing={({ start, end }) => isValidTimelineRange(start, end)}
-        onActionMoveEnd={({ start }) => {
-          void seekToTime(start);
-        }}
-        onActionResizeEnd={({ start, end, dir }) => {
-          void seekToTime(dir === "left" ? start : end);
-        }}
         onClickTimeArea={(time) => {
-          void seekToTime(time);
-          return false;
-        }}
-        onClickRow={(_, { time }) => {
-          void seekToTime(time);
-        }}
-        onClickActionOnly={(_, { time }) => {
           void seekToTime(time);
         }}
         onCursorDragStart={onCursorDragStart}

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -4,7 +4,7 @@ import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { RefObject, WheelEvent as ReactWheelEvent } from "react";
 import { Scissors } from "lucide-react";
 import { 
-  formatTime, 
+  formatTime,
   TIMELINE_START_LEFT, 
   type ClipTimelineData, 
   type ClipTimelineEffects, 
@@ -21,7 +21,6 @@ interface EditorTimelineProps {
   timelineScaleCount: number;
   loadingPreview: boolean;
   playing: boolean;
-  duration: number;
   handleTimelineScroll: (data: { scrollLeft: number }) => void;
   handleTimelineChange: (data: ClipTimelineData) => void;
   handleTimelineWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
@@ -40,7 +39,6 @@ export function EditorTimeline({
   timelineScaleCount,
   loadingPreview,
   playing,
-  duration,
   handleTimelineScroll,
   handleTimelineChange,
   handleTimelineWheel,
@@ -49,19 +47,18 @@ export function EditorTimeline({
   onCursorDragStart,
   onCursorDrag,
 }: EditorTimelineProps) {
-  const renderClipTimelineAction = useCallback((action: ClipTimelineAction) => (
-    <div className="cliparr-timeline-action-content">
-      <span className="cliparr-timeline-action-label">
-        {action.effectId === "clip" && <Scissors className="h-3.5 w-3.5" />}
-        {action.effectId === "source" ? "Full video" : "Clip"}
-      </span>
-      <span className="cliparr-timeline-action-time">
-        {action.effectId === "source"
-          ? formatTime(action.end)
-          : `${formatTime(action.start)} - ${formatTime(action.end)}`}
-      </span>
-    </div>
-  ), []);
+  const renderClipTimelineAction = useCallback((action: ClipTimelineAction) => {
+    const isSource = action.effectId === "source";
+
+    return (
+      <div className="cliparr-timeline-action-content">
+        <span className="cliparr-timeline-action-label">
+          {!isSource && <Scissors className="h-3.5 w-3.5" />}
+          {isSource ? "Source" : "Selection"}
+        </span>
+      </div>
+    );
+  }, []);
 
   return (
     <div
@@ -69,10 +66,6 @@ export function EditorTimeline({
       className="cliparr-timeline"
       onWheelCapture={handleTimelineWheel}
     >
-      <div className="mb-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-        <span>Full video</span>
-        <span className="font-mono">0:00 - {formatTime(duration)}</span>
-      </div>
       <Timeline
         ref={timelineRef}
         editorData={timelineData}

--- a/apps/frontend/src/components/editor/EditorUtils.ts
+++ b/apps/frontend/src/components/editor/EditorUtils.ts
@@ -4,8 +4,8 @@ import type { ComponentProps } from "react";
 export const MIN_CLIP_SECONDS = 0.1;
 export const TIMELINE_START_LEFT = 24;
 const MAX_TIMELINE_ZOOM_SCALE_COUNT = 2000;
-export const TIMELINE_ZOOM_WHEEL_STEP = 24;
-const TIMELINE_ZOOM_WIDTH_MULTIPLIERS = [0.72, 0.84, 0.96, 1.08, 1.2] as const;
+export const TIMELINE_ZOOM_WHEEL_STEP = 80;
+const TIMELINE_ZOOM_WIDTH_MULTIPLIERS = [0.64, 0.72, 0.8, 0.88, 0.96, 1.04, 1.12, 1.2] as const;
 
 export type TimelineZoomPreset = {
   scale: number;
@@ -135,6 +135,22 @@ export function getClosestTimelineZoomIndex(levels: readonly TimelineZoomLevel[]
     const nextScaleDistance = Math.abs(level.scale - targetScale.scale);
     return nextScaleDistance < closestScaleDistance ? index : closestIndex;
   }, 0);
+}
+
+export function getFittingTimelineZoomIndex(
+  levels: readonly TimelineZoomLevel[],
+  duration: number,
+  viewportWidth: number,
+) {
+  const fittingIndex = levels.findIndex((level) => (
+    getTimelineMaxScrollLeft(duration, level.scale, level.scaleWidth, viewportWidth) <= 0
+  ));
+
+  if (fittingIndex !== -1) {
+    return fittingIndex;
+  }
+
+  return Math.max(levels.length - 1, 0);
 }
 
 export function timelinePixelToTime(pixel: number, scale: number, scaleWidth: number, startLeft: number) {

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -346,9 +346,11 @@ export function useEditorPlayback({
       return;
     }
 
+    const clipStart = clampTime(startTimeRef.current);
     const clipEnd = Math.min(endTimeRef.current || durationRef.current, durationRef.current);
-    if (getPlaybackTime() >= clipEnd) {
-      playbackTimeAtStartRef.current = clampTime(startTimeRef.current);
+    const playbackTime = getPlaybackTime();
+    if (playbackTime < clipStart || playbackTime >= clipEnd) {
+      playbackTimeAtStartRef.current = clipStart;
       setCurrentTime(playbackTimeAtStartRef.current);
       await startVideoIterator();
     }

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -3,6 +3,7 @@ import type { TimelineState } from "@xzdarcy/react-timeline-editor";
 import { 
   getTimelineZoomLevels, 
   getClosestTimelineZoomIndex, 
+  getFittingTimelineZoomIndex,
   timelineScaleForDuration, 
   getTimelineZoomLevel, 
   roundTimelineTime, 
@@ -40,11 +41,13 @@ export function useEditorTimeline({
   const timelineScrollLeftRef = useRef(0);
   const pendingTimelineScrollLeftRef = useRef<number | null>(null);
   const timelineWheelDeltaRef = useRef(0);
+  const hasUserAdjustedTimelineZoomRef = useRef(false);
+  const [timelineViewportWidth, setTimelineViewportWidth] = useState(0);
 
   const hasDuration = duration > 0;
   
   const timelineEffects = useMemo<ClipTimelineEffects>(() => ({
-    source: { id: "source", name: "Full video" },
+    source: { id: "source", name: "Source" },
     clip: { id: "clip", name: "Clip" },
   }), []);
 
@@ -54,6 +57,17 @@ export function useEditorTimeline({
     () => getClosestTimelineZoomIndex(availableTimelineZoomLevels, defaultTimelineScale),
     [availableTimelineZoomLevels, defaultTimelineScale],
   );
+  const fitTimelineZoomIndex = useMemo(() => {
+    if (timelineViewportWidth <= 0) {
+      return defaultTimelineZoomIndex;
+    }
+
+    return getFittingTimelineZoomIndex(
+      availableTimelineZoomLevels,
+      duration,
+      timelineViewportWidth,
+    );
+  }, [availableTimelineZoomLevels, defaultTimelineZoomIndex, duration, timelineViewportWidth]);
 
   const [timelineZoomIndex, setTimelineZoomIndex] = useState(defaultTimelineZoomIndex);
   const timelineZoomIndexRef = useRef(timelineZoomIndex);
@@ -122,13 +136,48 @@ export function useEditorTimeline({
   }, [timelineZoomIndex]);
 
   useEffect(() => {
+    const timelineWheelRegion = timelineWheelRegionRef.current;
+    if (!timelineWheelRegion) return;
+
+    const updateViewportWidth = () => {
+      setTimelineViewportWidth(timelineWheelRegion.clientWidth || 0);
+    };
+
+    updateViewportWidth();
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateViewportWidth();
+    });
+
+    resizeObserver.observe(timelineWheelRegion);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
     setTimelineZoomIndex(defaultTimelineZoomIndex);
     timelineZoomIndexRef.current = defaultTimelineZoomIndex;
     timelineScrollLeftRef.current = 0;
     timelineWheelDeltaRef.current = 0;
+    hasUserAdjustedTimelineZoomRef.current = false;
     timelineRef.current?.setScrollLeft(0);
     pendingTimelineScrollLeftRef.current = 0;
   }, [defaultTimelineZoomIndex, sessionId]);
+
+  useEffect(() => {
+    if (!hasDuration || timelineViewportWidth <= 0 || hasUserAdjustedTimelineZoomRef.current) {
+      return;
+    }
+
+    setTimelineZoomIndex(fitTimelineZoomIndex);
+    timelineZoomIndexRef.current = fitTimelineZoomIndex;
+    timelineScrollLeftRef.current = 0;
+    timelineWheelDeltaRef.current = 0;
+    timelineRef.current?.setScrollLeft(0);
+    pendingTimelineScrollLeftRef.current = 0;
+  }, [fitTimelineZoomIndex, hasDuration, timelineViewportWidth]);
 
   useEffect(() => {
     const pendingScrollLeft = pendingTimelineScrollLeftRef.current;
@@ -196,8 +245,8 @@ export function useEditorTimeline({
     }
 
     timelineWheelDeltaRef.current += normalizedDeltaY;
-    const zoomDelta = Math.trunc(timelineWheelDeltaRef.current / TIMELINE_ZOOM_WHEEL_STEP);
-    if (zoomDelta === 0) return;
+    const accumulatedZoomDelta = Math.trunc(timelineWheelDeltaRef.current / TIMELINE_ZOOM_WHEEL_STEP);
+    if (accumulatedZoomDelta === 0) return;
 
     const currentZoomIndex = timelineZoomIndexRef.current;
     const currentTimelineScale = getTimelineZoomLevel(
@@ -206,7 +255,8 @@ export function useEditorTimeline({
       activeTimelineScale,
     );
     const currentScrollLeft = pendingTimelineScrollLeftRef.current ?? timelineScrollLeftRef.current;
-    timelineWheelDeltaRef.current -= zoomDelta * TIMELINE_ZOOM_WHEEL_STEP;
+    const zoomDelta = Math.sign(accumulatedZoomDelta);
+    timelineWheelDeltaRef.current = 0;
     const nextZoomIndex = Math.min(
       availableTimelineZoomLevels.length - 1,
       Math.max(0, currentZoomIndex + zoomDelta),
@@ -252,6 +302,7 @@ export function useEditorTimeline({
     pendingTimelineScrollLeftRef.current = nextScrollLeft;
     timelineScrollLeftRef.current = nextScrollLeft;
     timelineZoomIndexRef.current = nextZoomIndex;
+    hasUserAdjustedTimelineZoomRef.current = true;
 
     startTransition(() => {
       setTimelineZoomIndex(nextZoomIndex);

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -39,7 +39,7 @@
   --font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
   --font-serif: IBM Plex Serif, ui-serif, serif;
   --font-mono: IBM Plex Mono, ui-monospace, monospace;
-  --radius: 0.325rem;
+  --radius: 0.25rem;
   --shadow-x: 0px;
   --shadow-y: 0px;
   --shadow-blur: 3px;
@@ -59,24 +59,24 @@
 }
 
 .dark {
-  --background: oklch(0.1591 0 0);
+  --background: oklch(0.145 0 0);
   --foreground: oklch(0.8576 0 0);
-  --card: oklch(0.1822 0 0);
+  --card: oklch(0.176 0 0);
   --card-foreground: oklch(0.8576 0 0);
-  --popover: oklch(0.3211 0 0);
+  --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.8576 0 0);
   --primary: oklch(0.6753 0.1208 82.7652);
   --primary-foreground: oklch(0.2178 0 0);
   --secondary: oklch(0.929 0.0439 85.2366);
   --secondary-foreground: oklch(0.2178 0 0);
-  --muted: oklch(0.252 0 0);
+  --muted: oklch(0.215 0 0);
   --muted-foreground: oklch(0.6268 0 0);
-  --accent: oklch(0.3211 0 0);
+  --accent: oklch(0.238 0 0);
   --accent-foreground: oklch(1 0 0);
   --destructive: oklch(0.5783 0.2301 28.5639);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.1822 0 0);
-  --input: oklch(0.4495 0 0);
+  --border: oklch(0.285 0 0);
+  --input: oklch(0.245 0 0);
   --ring: oklch(0.594 0.0443 196.0233);
   --chart-1: oklch(0.594 0.0443 196.0233);
   --chart-2: oklch(0.7214 0.1337 49.9802);
@@ -87,14 +87,14 @@
   --sidebar-foreground: oklch(0.8576 0 0);
   --sidebar-primary: oklch(0.6753 0.1208 82.7652);
   --sidebar-primary-foreground: oklch(0.2178 0 0);
-  --sidebar-accent: oklch(0.3211 0 0);
+  --sidebar-accent: oklch(0.286 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-border: oklch(0.1822 0 0);
+  --sidebar-border: oklch(0.292 0 0);
   --sidebar-ring: oklch(0.594 0.0443 196.0233);
   --font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
   --font-serif: IBM Plex Serif, ui-serif, serif;
   --font-mono: IBM Plex Mono, ui-monospace, monospace;
-  --radius: 0.325rem;
+  --radius: 0.25rem;
   --shadow-x: 0px;
   --shadow-y: 0px;
   --shadow-blur: 3px;
@@ -184,21 +184,21 @@
 
   .cliparr-timeline .timeline-editor {
     width: 100%;
-    height: 152px;
-    min-height: 152px;
+    height: 154px;
+    min-height: 154px;
     overflow: hidden;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--background);
+    border: none;
+    border-radius: 0;
+    background: var(--card);
     color: var(--foreground);
     font-family: var(--font-sans);
-    box-shadow: var(--shadow-sm);
+    box-shadow: none;
   }
 
   .cliparr-timeline .timeline-editor-time-area {
-    height: 36px;
+    height: 32px;
     border-bottom: 1px solid var(--border);
-    background: var(--card);
+    background: color-mix(in oklch, var(--muted) 72%, var(--card));
   }
 
   .cliparr-timeline .timeline-editor-time-unit {
@@ -206,36 +206,42 @@
   }
 
   .cliparr-timeline .timeline-editor-time-unit-scale {
-    top: 8px;
+    top: 7px;
     color: var(--muted-foreground);
     font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
   }
 
   .cliparr-timeline .timeline-editor-edit-area {
     margin-top: 0;
-    background: var(--background);
+    background: var(--card);
   }
 
   .cliparr-timeline .timeline-editor-edit-row {
     background-image:
-      linear-gradient(var(--background), var(--background)),
-      linear-gradient(90deg, color-mix(in oklch, var(--muted-foreground) 18%, transparent) 1px, transparent 0);
+      linear-gradient(
+        color-mix(in oklch, var(--card) 82%, var(--background)),
+        color-mix(in oklch, var(--card) 82%, var(--background))
+      ),
+      linear-gradient(90deg, color-mix(in oklch, var(--muted-foreground) 12%, transparent) 1px, transparent 0);
   }
 
   .cliparr-timeline .timeline-editor-action {
     overflow: hidden;
-    border: 1px solid color-mix(in oklch, var(--primary) 72%, var(--foreground));
-    border-radius: var(--radius);
-    background: var(--primary);
-    color: var(--primary-foreground);
-    box-shadow: 0 8px 18px color-mix(in oklch, var(--primary) 22%, transparent);
+    border: 1px solid color-mix(in oklch, var(--ring) 72%, var(--foreground));
+    border-radius: 2px;
+    background: color-mix(in oklch, var(--ring) 44%, var(--background));
+    color: var(--foreground);
+    box-shadow: none;
   }
 
   .cliparr-timeline .timeline-editor-action-effect-source {
     top: 7px !important;
     height: 18px !important;
-    border-color: color-mix(in oklch, var(--border) 78%, var(--foreground));
-    background: color-mix(in oklch, var(--muted) 72%, var(--background));
+    border-color: color-mix(in oklch, var(--border) 84%, var(--foreground));
+    background: color-mix(in oklch, var(--muted) 82%, var(--card));
     color: var(--muted-foreground);
     box-shadow: none;
   }
@@ -248,14 +254,14 @@
   .cliparr-timeline .timeline-editor-action .timeline-editor-action-left-stretch,
   .cliparr-timeline .timeline-editor-action .timeline-editor-action-right-stretch {
     width: 12px;
-    border-radius: var(--radius);
-    background: color-mix(in oklch, var(--primary-foreground) 10%, transparent);
+    border-radius: 0;
+    background: color-mix(in oklch, var(--foreground) 10%, transparent);
   }
 
   .cliparr-timeline .timeline-editor-action .timeline-editor-action-left-stretch::after,
   .cliparr-timeline .timeline-editor-action .timeline-editor-action-right-stretch::after {
-    border-left-color: color-mix(in oklch, var(--primary-foreground) 35%, transparent);
-    border-right-color: color-mix(in oklch, var(--primary-foreground) 35%, transparent);
+    border-left-color: color-mix(in oklch, var(--foreground) 34%, transparent);
+    border-right-color: color-mix(in oklch, var(--foreground) 34%, transparent);
   }
 
   .cliparr-timeline-action-content {
@@ -266,7 +272,7 @@
     justify-content: space-between;
     gap: 10px;
     overflow: hidden;
-    padding: 0 14px;
+    padding: 0 12px;
     white-space: nowrap;
   }
 
@@ -276,8 +282,10 @@
     align-items: center;
     gap: 6px;
     overflow: hidden;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     text-overflow: ellipsis;
   }
 
@@ -285,18 +293,19 @@
     flex: 0 0 auto;
     color: color-mix(in oklch, currentColor 86%, transparent);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: 12px;
+    font-weight: 600;
   }
 
   .cliparr-timeline .timeline-editor-cursor {
-    top: 36px;
-    height: calc(100% - 36px);
-    border-right-color: var(--primary);
-    border-left-color: var(--primary);
+    top: 32px;
+    height: calc(100% - 32px);
+    border-right-color: var(--ring);
+    border-left-color: var(--ring);
   }
 
   .cliparr-timeline .timeline-editor-cursor-top path {
-    fill: var(--primary);
+    fill: var(--ring);
   }
 
   .cliparr-timeline .timeline-editor-drag-line {


### PR DESCRIPTION
## Summary
- flatten the editor into a sharper Adobe-style workstation layout
- tighten monitor and trim panel sizing so the editor fits the viewport
- improve timeline zoom defaults and add spacebar playback control

## Testing
- pnpm --filter @cliparr/frontend lint