### PR TITLE
Add audio track selection and export functionality

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -57,6 +57,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     startTime,
     endTime,
     sessionId: session.id,
+    selectedAudioTrack: session.selectedAudioTrack,
   });
 
   const updateClipRange = useCallback((nextStart: number, nextEnd: number) => {
@@ -114,6 +115,7 @@ export default function EditorScreen({ session, onBack }: Props) {
         startTime,
         endTime,
         resolution,
+        selectedAudioTrack: session.selectedAudioTrack,
         metadata: session.exportMetadata,
         onProgress: setProgress,
       });

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { AudioBufferSink, CanvasSink, Input, WrappedAudioBuffer, WrappedCanvas } from "mediabunny";
 import { ensureMediabunnyCodecs } from "../../lib/mediabunnyCodecs";
+import { selectPreferredAudioTrack } from "../../lib/selectPreferredAudioTrack";
+import type { PlaybackAudioSelection } from "../../providers/types";
 import { errorMessage, isAc3FamilyCodec, themeValue } from "./EditorUtils";
 
 interface UseEditorPlaybackProps {
@@ -9,6 +11,7 @@ interface UseEditorPlaybackProps {
   startTime: number;
   endTime: number;
   sessionId: string;
+  selectedAudioTrack?: PlaybackAudioSelection;
 }
 
 type WindowWithWebkitAudioContext = Window & {
@@ -25,6 +28,7 @@ export function useEditorPlayback({
   startTime,
   endTime,
   sessionId,
+  selectedAudioTrack,
 }: UseEditorPlaybackProps) {
   const [duration, setDuration] = useState(() => Math.max(initialDuration, 0));
   const [currentTime, setCurrentTime] = useState(0);
@@ -442,7 +446,8 @@ export function useEditorPlayback({
 
         const computedDuration = await input.computeDuration();
         let videoTrack = await input.getPrimaryVideoTrack();
-        let audioTrack = await input.getPrimaryAudioTrack();
+        const audioTracks = await input.getAudioTracks();
+        let audioTrack = selectPreferredAudioTrack(audioTracks, selectedAudioTrack);
         const warnings: string[] = [];
 
         if (videoTrack) {
@@ -528,7 +533,15 @@ export function useEditorPlayback({
       cancelled = true;
       disposePreview();
     };
-  }, [mediaUrl, initialDuration, sessionId, disposePreview, startRenderLoop, startVideoIterator]);
+  }, [
+    mediaUrl,
+    initialDuration,
+    selectedAudioTrack,
+    sessionId,
+    disposePreview,
+    startRenderLoop,
+    startVideoIterator,
+  ]);
 
   return {
     canvasRef,

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -10,13 +10,15 @@ import {
 } from "mediabunny";
 import type { ConversionOptions, DiscardedTrack, InputTrack, MetadataTags } from "mediabunny";
 import { ensureMediabunnyCodecs } from "./mediabunnyCodecs";
-import type { MediaExportMetadata } from "../providers/types";
+import { selectPreferredAudioTrack } from "./selectPreferredAudioTrack";
+import type { MediaExportMetadata, PlaybackAudioSelection } from "../providers/types";
 
 interface ExportClipOptions {
   mediaUrl: string;
   startTime: number;
   endTime: number;
   resolution: "original" | "1080" | "720";
+  selectedAudioTrack?: PlaybackAudioSelection;
   metadata?: MediaExportMetadata;
   onProgress: (progress: number) => void;
 }
@@ -416,6 +418,7 @@ export async function exportClip({
   startTime,
   endTime,
   resolution,
+  selectedAudioTrack,
   metadata,
   onProgress,
 }: ExportClipOptions) {
@@ -429,6 +432,7 @@ export async function exportClip({
   try {
     const sourceAudioTracks = await input.getAudioTracks();
     const sourceVideoTracks = await input.getVideoTracks();
+    const preferredAudioTrack = selectPreferredAudioTrack(sourceAudioTracks, selectedAudioTrack);
     const sourceHasAudio = sourceAudioTracks.length > 0;
     const outputHeight = resolution === "original" ? sourceVideoTracks[0]?.displayHeight : parseInt(resolution, 10);
 
@@ -439,15 +443,22 @@ export async function exportClip({
       target,
     });
 
+    const baseAudioOptions = {
+      codec: "aac",
+      forceTranscode: true,
+      numberOfChannels: 2,
+      bitrate: 160_000,
+    } as const;
+
     const conversionOptions: ConversionOptions = {
       input,
       output,
-      audio: {
-        codec: "aac",
-        forceTranscode: true,
-        numberOfChannels: 2,
-        bitrate: 160_000,
-      },
+      audio: preferredAudioTrack
+        ? (track) => ({
+          ...baseAudioOptions,
+          discard: track.id !== preferredAudioTrack.id,
+        })
+        : baseAudioOptions,
       trim: {
         start: startTime,
         end: endTime,

--- a/apps/frontend/src/lib/selectPreferredAudioTrack.ts
+++ b/apps/frontend/src/lib/selectPreferredAudioTrack.ts
@@ -1,0 +1,55 @@
+import type { InputAudioTrack } from "mediabunny";
+import type { PlaybackAudioSelection } from "../providers/types";
+
+function normalizedText(value: string | null | undefined) {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
+export function selectPreferredAudioTrack(
+  audioTracks: readonly InputAudioTrack[],
+  selectedAudioTrack?: PlaybackAudioSelection
+): InputAudioTrack | null {
+  const fallbackTrack: InputAudioTrack | null = audioTracks[0] ?? null;
+  if (!selectedAudioTrack) {
+    return fallbackTrack;
+  }
+
+  if (selectedAudioTrack.trackNumber !== undefined) {
+    const matchingTrack = audioTracks.find((track) => track.number === selectedAudioTrack.trackNumber);
+    if (matchingTrack) {
+      return matchingTrack;
+    }
+  }
+
+  const selectedLanguageCode = normalizedText(selectedAudioTrack.languageCode);
+  const selectedTitle = normalizedText(selectedAudioTrack.title);
+
+  if (selectedLanguageCode && selectedTitle) {
+    const exactMatch = audioTracks.find((track) =>
+      normalizedText(track.languageCode) === selectedLanguageCode
+      && normalizedText(track.name) === selectedTitle
+    );
+    if (exactMatch) {
+      return exactMatch;
+    }
+  }
+
+  if (selectedTitle) {
+    const matchingTitleTrack = audioTracks.find((track) => normalizedText(track.name) === selectedTitle);
+    if (matchingTitleTrack) {
+      return matchingTitleTrack;
+    }
+  }
+
+  if (selectedLanguageCode) {
+    const matchingLanguageTracks = audioTracks.filter((track) =>
+      normalizedText(track.languageCode) === selectedLanguageCode
+    );
+    if (matchingLanguageTracks.length === 1) {
+      return matchingLanguageTracks[0];
+    }
+  }
+
+  return fallbackTrack;
+}

--- a/apps/frontend/src/providers/types.ts
+++ b/apps/frontend/src/providers/types.ts
@@ -66,6 +66,12 @@ export interface MediaExportMetadata {
   imageUrl?: string;
 }
 
+export interface PlaybackAudioSelection {
+  trackNumber?: number;
+  languageCode?: string;
+  title?: string;
+}
+
 export interface PlaybackViewer {
   id: string;
   providerId: string;
@@ -91,6 +97,7 @@ export interface CurrentlyPlayingItem {
   thumbUrl?: string;
   mediaUrl?: string;
   previewUrl?: string;
+  selectedAudioTrack?: PlaybackAudioSelection;
   exportMetadata?: MediaExportMetadata;
 }
 

--- a/apps/server/src/providers/jellyfin/provider.ts
+++ b/apps/server/src/providers/jellyfin/provider.ts
@@ -10,6 +10,7 @@ import type {
   CurrentlyPlayingEntry,
   MediaExportMetadata,
   MediaHandle,
+  PlaybackAudioSelection,
   ProviderImplementation,
   ProviderResource,
 } from "../types.js";
@@ -682,6 +683,76 @@ function currentMediaSourceId(sessionInfo: any, item: any) {
     ?? stringValue(asArray(sessionInfo?.NowPlayingItem?.MediaSources)[0]?.Id);
 }
 
+function currentMediaSource(sessionInfo: any, item: any, mediaSourceId: string | undefined) {
+  const itemMediaSources = asArray(item?.MediaSources);
+  const sessionMediaSources = asArray(sessionInfo?.NowPlayingItem?.MediaSources);
+  const mediaSources = [...itemMediaSources, ...sessionMediaSources];
+
+  if (mediaSourceId) {
+    const matchingMediaSource = mediaSources.find((mediaSource) => stringValue(mediaSource?.Id) === mediaSourceId);
+    if (matchingMediaSource) {
+      return matchingMediaSource;
+    }
+  }
+
+  return mediaSources[0];
+}
+
+function isAudioMediaStream(stream: any) {
+  return String(stream?.Type ?? "").toLowerCase() === "audio";
+}
+
+function jellyfinAudioTrackTitle(stream: any) {
+  return stringValue(stream?.Title)
+    ?? stringValue(stream?.DisplayTitle);
+}
+
+function deriveSelectedAudioTrack(
+  sessionInfo: any,
+  item: any,
+  mediaSourceId: string | undefined
+): PlaybackAudioSelection | undefined {
+  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId);
+  if (!mediaSource) {
+    return undefined;
+  }
+
+  const audioStreams = asArray(mediaSource?.MediaStreams).filter((stream) => isAudioMediaStream(stream));
+  if (audioStreams.length === 0) {
+    return undefined;
+  }
+
+  const selectedAudioStreamIndex = numberValue(sessionInfo?.PlayState?.AudioStreamIndex)
+    ?? numberValue(mediaSource?.DefaultAudioStreamIndex);
+
+  if (selectedAudioStreamIndex === undefined) {
+    if (audioStreams.length !== 1) {
+      return undefined;
+    }
+
+    const onlyAudioStream = audioStreams[0];
+    return {
+      trackNumber: 1,
+      languageCode: stringValue(onlyAudioStream?.Language),
+      title: jellyfinAudioTrackTitle(onlyAudioStream),
+    };
+  }
+
+  const selectedAudioTrackIndex = audioStreams.findIndex(
+    (stream) => numberValue(stream?.Index) === selectedAudioStreamIndex
+  );
+  if (selectedAudioTrackIndex < 0) {
+    return undefined;
+  }
+
+  const selectedAudioStream = audioStreams[selectedAudioTrackIndex];
+  return {
+    trackNumber: selectedAudioTrackIndex + 1,
+    languageCode: stringValue(selectedAudioStream?.Language),
+    title: jellyfinAudioTrackTitle(selectedAudioStream),
+  };
+}
+
 function buildStaticStreamPath(item: any, mediaSourceId: string | undefined, context: JellyfinSourceContext, playSessionId: string) {
   const itemId = stringValue(item?.Id);
   if (!itemId) {
@@ -971,6 +1042,7 @@ async function normalizeCurrentPlayback(
   const mediaPath = buildStaticStreamPath(enrichedItem, mediaSourceId, context, playSessionId);
   const previewPath = buildPreviewPath(enrichedItem, mediaSourceId, context, playSessionId);
   const imagePath = itemImagePath(enrichedItem);
+  const selectedAudioTrack = deriveSelectedAudioTrack(sessionInfo, enrichedItem, mediaSourceId);
   const playerState = sessionInfo?.PlayState?.IsPaused ? "paused" : "playing";
 
   return {
@@ -993,6 +1065,7 @@ async function normalizeCurrentPlayback(
       thumbUrl: imagePath ? createMediaHandle(session, context, imagePath) : undefined,
       mediaUrl: mediaPath ? createMediaHandle(session, context, mediaPath) : undefined,
       previewUrl: previewPath ? createMediaHandle(session, context, previewPath, { basePath: playlistBasePath(previewPath) }) : undefined,
+      selectedAudioTrack,
       exportMetadata: createExportMetadata(session, context, enrichedItem),
     },
   } satisfies CurrentlyPlayingEntry;

--- a/apps/server/src/providers/plex/provider.ts
+++ b/apps/server/src/providers/plex/provider.ts
@@ -9,6 +9,7 @@ import type {
   ProviderResource,
   MediaExportMetadata,
   MediaHandle,
+  PlaybackAudioSelection,
 } from "../types.js";
 import type { ProviderSessionRecord } from "../../session/store.js";
 
@@ -420,6 +421,10 @@ function partEntries(media: any) {
   return asArray(media?.Part);
 }
 
+function streamEntries(part: any) {
+  return asArray(part?.Stream);
+}
+
 function selectedIndex(entries: any[]) {
   const index = entries.findIndex((entry) => isSelectedEntry(entry));
   return index >= 0 ? index : 0;
@@ -707,6 +712,46 @@ function buildSourceTitle(item: any) {
   return uniqueStrings([showTitle, episodeCode, title]).join(" - ") || title;
 }
 
+function isAudioStream(stream: any) {
+  return numberValue(stream?.streamType) === 2;
+}
+
+function selectedAudioTrackTitle(stream: any) {
+  return stringValue(stream?.title)
+    ?? stringValue(stream?.extendedDisplayTitle)
+    ?? stringValue(stream?.displayTitle);
+}
+
+function deriveSelectedAudioTrack(
+  item: any,
+  selection?: PlexMediaSelection
+): PlaybackAudioSelection | undefined {
+  const part = resolveSelectedPart(item, selection)?.part;
+  if (!part) {
+    return undefined;
+  }
+
+  const audioStreams = streamEntries(part).filter((stream) => isAudioStream(stream));
+  if (audioStreams.length === 0) {
+    return undefined;
+  }
+
+  const selectedAudioIndex = audioStreams.findIndex((stream) => isSelectedEntry(stream));
+  if (selectedAudioIndex < 0 && audioStreams.length > 1) {
+    return undefined;
+  }
+
+  const trackIndex = selectedAudioIndex >= 0 ? selectedAudioIndex : 0;
+  const selectedAudioStream = audioStreams[trackIndex];
+
+  return {
+    trackNumber: trackIndex + 1,
+    languageCode: stringValue(selectedAudioStream?.languageCode)
+      ?? stringValue(selectedAudioStream?.languageTag),
+    title: selectedAudioTrackTitle(selectedAudioStream),
+  };
+}
+
 async function fetchMetadataItem(context: PlexSourceContext, item: any) {
   const path = metadataPath(item);
   if (!path) {
@@ -924,6 +969,7 @@ async function normalizeCurrentPlayback(
     const mediaPath = await resolveMediaPath(context, item, enrichedItem, mediaSelection);
     const previewPath = createPreviewPath(enrichedItem, mediaSelection);
     const thumbPath = metadataImagePath(enrichedItem);
+    const selectedAudioTrack = deriveSelectedAudioTrack(enrichedItem, mediaSelection);
     const sessionId = playbackSessionIdentity(item);
 
     return {
@@ -943,6 +989,7 @@ async function normalizeCurrentPlayback(
         thumbUrl: thumbPath ? createMediaHandle(session, context, thumbPath) : undefined,
         mediaUrl: mediaPath ? createMediaHandle(session, context, mediaPath) : undefined,
         previewUrl: previewPath ? createMediaHandle(session, context, previewPath) : undefined,
+        selectedAudioTrack,
         exportMetadata: createExportMetadata(session, context, enrichedItem),
       },
     };

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -90,6 +90,12 @@ export interface MediaExportMetadata {
   imageUrl?: string;
 }
 
+export interface PlaybackAudioSelection {
+  trackNumber?: number;
+  languageCode?: string;
+  title?: string;
+}
+
 export interface CurrentlyPlayingItem {
   id: string;
   source: PlaybackSource;
@@ -101,6 +107,7 @@ export interface CurrentlyPlayingItem {
   thumbUrl?: string;
   mediaUrl?: string;
   previewUrl?: string;
+  selectedAudioTrack?: PlaybackAudioSelection;
   exportMetadata?: MediaExportMetadata;
 }
 


### PR DESCRIPTION
This pull request adds support for selecting and persisting the currently active audio track during playback and export, ensuring that the user's chosen audio track is used throughout the application. It introduces a new `PlaybackAudioSelection` interface, updates both frontend and backend to track and pass this selection, and implements logic to match the correct audio track in media operations.

**Audio Track Selection and Persistence**

* Added a new `PlaybackAudioSelection` interface to represent the selected audio track, and updated the `CurrentlyPlayingItem` type to include a `selectedAudioTrack` field on both frontend and backend. [[1]](diffhunk://#diff-051e935654e2dbe8e4b8fff83f6e0d91465d847bf32d88778b51ec0d33444d98R69-R74) [[2]](diffhunk://#diff-051e935654e2dbe8e4b8fff83f6e0d91465d847bf32d88778b51ec0d33444d98R100) [[3]](diffhunk://#diff-f57e28ace1c048feb765e53f8f7e4ca3d5224944ea05da876300882462e805f7R93-R98) [[4]](diffhunk://#diff-f57e28ace1c048feb765e53f8f7e4ca3d5224944ea05da876300882462e805f7R110)
* Both Jellyfin and Plex backend providers now derive and return the selected audio track for the current session, using new helper functions to extract the track from session or media metadata. [[1]](diffhunk://#diff-d5e998cbedb2579bbe658660c86f4f65dfbc1fc56f3e449f58efaa3ad84dbb92R686-R755) [[2]](diffhunk://#diff-d5e998cbedb2579bbe658660c86f4f65dfbc1fc56f3e449f58efaa3ad84dbb92R1045) [[3]](diffhunk://#diff-d5e998cbedb2579bbe658660c86f4f65dfbc1fc56f3e449f58efaa3ad84dbb92R1068) [[4]](diffhunk://#diff-4fbe8a190c9c24152dd45662a8c2f8ccd62214b3ce689f6ca991a2cc3549c82dR424-R427) [[5]](diffhunk://#diff-4fbe8a190c9c24152dd45662a8c2f8ccd62214b3ce689f6ca991a2cc3549c82dR715-R754) [[6]](diffhunk://#diff-4fbe8a190c9c24152dd45662a8c2f8ccd62214b3ce689f6ca991a2cc3549c82dR972) [[7]](diffhunk://#diff-4fbe8a190c9c24152dd45662a8c2f8ccd62214b3ce689f6ca991a2cc3549c82dR992)

**Frontend Playback and Export Updates**

* The editor playback and export logic now accepts and uses the `selectedAudioTrack` property, ensuring that playback and exported clips use the correct audio track. [[1]](diffhunk://#diff-1e21b89c79d26c4593a3ff48472f7ee16cf1a6543f80764b614d1c46682a3291R60) [[2]](diffhunk://#diff-1e21b89c79d26c4593a3ff48472f7ee16cf1a6543f80764b614d1c46682a3291R118) [[3]](diffhunk://#diff-53911031da7666a54dba7d9af210074cfc4959f62ae5d706a31b1cbcb12f7206R14) [[4]](diffhunk://#diff-53911031da7666a54dba7d9af210074cfc4959f62ae5d706a31b1cbcb12f7206R31) [[5]](diffhunk://#diff-53911031da7666a54dba7d9af210074cfc4959f62ae5d706a31b1cbcb12f7206L445-R450) [[6]](diffhunk://#diff-53911031da7666a54dba7d9af210074cfc4959f62ae5d706a31b1cbcb12f7206L531-R544) [[7]](diffhunk://#diff-a241fd211d80de801d68054503fef7c10a0c422f62eb4d5d31463fe0f67629c1L13-R21) [[8]](diffhunk://#diff-a241fd211d80de801d68054503fef7c10a0c422f62eb4d5d31463fe0f67629c1R421) [[9]](diffhunk://#diff-a241fd211d80de801d68054503fef7c10a0c422f62eb4d5d31463fe0f67629c1R435)

**Audio Track Matching Logic**

* Added a new utility function `selectPreferredAudioTrack` that matches the selected audio track against available tracks using track number, language code, and title, with a robust fallback mechanism. [[1]](diffhunk://#diff-448daf4fa10da63586a58f8b5955f20c5acf63bb5c2a9ad1636cf2f0e3b265b1R1-R55) [[2]](diffhunk://#diff-a241fd211d80de801d68054503fef7c10a0c422f62eb4d5d31463fe0f67629c1L442-R461)

These changes ensure that the user's audio track preference is respected during both playback and export, improving the user experience for multi-audio media.