### PR TITLE
Implement session-scoped media source access and deduplicate Plex playback metadata

### DIFF
--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -126,7 +126,7 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
   return getMediaSource(id);
 }
 
-export function getMediaSource(id: string) {
+function getMediaSource(id: string) {
   return getMediaSourceWhere(eq(mediaSources.id, id));
 }
 

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -130,7 +130,7 @@ export function getMediaSource(id: string) {
   return getMediaSourceWhere(eq(mediaSources.id, id));
 }
 
-function getMediaSourceForAccount(id: string, providerAccountId: string) {
+export function getMediaSourceForAccount(id: string, providerAccountId: string) {
   const where = and(
     eq(mediaSources.id, id),
     eq(mediaSources.providerAccountId, providerAccountId)

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -259,6 +259,53 @@ async function fetchCurrentlyPlayingData(source: MediaSource) {
   );
 }
 
+function playbackFallbackIdentity(item: any) {
+  const userId = idValue(item?.User?.id);
+  const playerId = stringValue(item?.Player?.machineIdentifier) ?? stringValue(item?.Player?.title);
+  const itemId = idValue(item?.ratingKey) ?? stringValue(item?.key) ?? metadataPath(item);
+  const parts = [userId, playerId, itemId].filter((value): value is string => Boolean(value));
+
+  return parts.length > 0 ? parts.join(":") : undefined;
+}
+
+function playbackDeduplicationKey(item: any) {
+  const sessionKey = idValue(item?.sessionKey);
+  if (sessionKey) {
+    return `session:${sessionKey}`;
+  }
+
+  const sessionId = idValue(item?.Session?.id);
+  if (sessionId) {
+    return `session-id:${sessionId}`;
+  }
+
+  const fallbackIdentity = playbackFallbackIdentity(item);
+  if (fallbackIdentity) {
+    return `fallback:${fallbackIdentity}`;
+  }
+
+  return undefined;
+}
+
+function dedupeCurrentlyPlayingMetadata(metadata: any[]) {
+  // Plex can emit duplicate rows for one live session, especially from web clients.
+  const seen = new Set<string>();
+
+  return metadata.filter((item) => {
+    const dedupeKey = playbackDeduplicationKey(item);
+    if (!dedupeKey) {
+      return true;
+    }
+
+    if (seen.has(dedupeKey)) {
+      return false;
+    }
+
+    seen.add(dedupeKey);
+    return true;
+  });
+}
+
 function tagValues(value: unknown) {
   return uniqueStrings(
     asArray(value as any).map((entry: any) => {
@@ -451,10 +498,9 @@ async function resolveMediaPath(
 
 function playbackSessionIdentity(item: any) {
   return String(
-    item?.Session?.id
-    ?? item?.ratingKey
-    ?? item?.key
-    ?? item?.Player?.machineIdentifier
+    item?.sessionKey
+    ?? item?.Session?.id
+    ?? playbackFallbackIdentity(item)
     ?? randomUUID()
   );
 }
@@ -481,7 +527,9 @@ async function normalizeCurrentPlayback(
     return [];
   }
 
-  return Promise.all(metadata.map(async (item: any) => {
+  const uniqueMetadata = dedupeCurrentlyPlayingMetadata(metadata);
+
+  return Promise.all(uniqueMetadata.map(async (item: any) => {
     const mediaSelection = deriveMediaSelection(item);
     const enrichedItem = await enrichMetadataItem(context, item);
     const mediaPath = await resolveMediaPath(context, item, enrichedItem, mediaSelection);

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -61,6 +61,7 @@ mediaRouter.get(
     const sourceErrors: SourcePlaybackError[] = [];
     const sources = listMediaSources({
       enabledOnly: true,
+      providerAccountId: session.providerAccountId,
     })
       .flatMap((source) => {
         const provider = getProvider(source.providerId);

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -147,9 +147,7 @@ sourcesRouter.delete(
   asyncHandler(async (req, res) => {
     const session = requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(req.params.id as string, session.providerAccountId);
-
-    const deleted = deleteMediaSourceForAccount(source.id, session.providerAccountId);
+    const deleted = deleteMediaSourceForAccount(req.params.id as string, session.providerAccountId);
     if (!deleted) {
       throw new ApiError(404, "source_not_found", "Source was not found");
     }

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
 import {
   listMediaSources,
-  getMediaSource,
   deleteMediaSourceForAccount,
-  updateMediaSourceForAccount,
+  getMediaSourceForAccount,
   updateMediaSourceHealthForAccount,
   type MediaSource,
   type UpdateMediaSourceInput,
+  updateMediaSourceForAccount,
 } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getProvider } from "../providers/registry.js";
@@ -29,8 +29,8 @@ function serializeSource(source: MediaSource) {
   };
 }
 
-function requireMediaSource(sourceId: string) {
-  const source = getMediaSource(sourceId);
+function requireMediaSource(sourceId: string, providerAccountId: string) {
+  const source = getMediaSourceForAccount(sourceId, providerAccountId);
   if (!source) {
     throw new ApiError(404, "source_not_found", "Source was not found");
   }
@@ -104,10 +104,12 @@ function parseSourceUpdate(body: unknown): UpdateMediaSourceInput {
 sourcesRouter.get(
   "/",
   asyncHandler(async (req, res) => {
-    requireAccountSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
     res.json({
-      sources: listMediaSources().map(serializeSource),
+      sources: listMediaSources({
+        providerAccountId: session.providerAccountId,
+      }).map(serializeSource),
     });
   })
 );
@@ -115,9 +117,9 @@ sourcesRouter.get(
 sourcesRouter.get(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireAccountSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(req.params.id as string, session.providerAccountId);
     res.json({ source: serializeSource(source) });
   })
 );
@@ -125,12 +127,12 @@ sourcesRouter.get(
 sourcesRouter.patch(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireAccountSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    const existingSource = requireMediaSource(req.params.id as string);
+    requireMediaSource(req.params.id as string, session.providerAccountId);
     const source = updateMediaSourceForAccount(
       req.params.id as string,
-      existingSource.providerAccountId,
+      session.providerAccountId,
       parseSourceUpdate(req.body)
     );
     if (!source) {
@@ -143,11 +145,11 @@ sourcesRouter.patch(
 sourcesRouter.delete(
   "/:id",
   asyncHandler(async (req, res) => {
-    requireAccountSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(req.params.id as string, session.providerAccountId);
 
-    const deleted = deleteMediaSourceForAccount(source.id, source.providerAccountId);
+    const deleted = deleteMediaSourceForAccount(source.id, session.providerAccountId);
     if (!deleted) {
       throw new ApiError(404, "source_not_found", "Source was not found");
     }
@@ -159,10 +161,10 @@ sourcesRouter.delete(
 sourcesRouter.post(
   "/:id/check",
   asyncHandler(async (req, res) => {
-    requireAccountSession(req);
+    const session = requireAccountSession(req);
     setNoStore(res);
 
-    const source = requireMediaSource(req.params.id as string);
+    const source = requireMediaSource(req.params.id as string, session.providerAccountId);
     const provider = getProvider(source.providerId);
     if (!provider) {
       throw new ApiError(500, "provider_not_registered", "Source provider is not registered");
@@ -172,7 +174,7 @@ sourcesRouter.post(
     const result = await provider.checkSource(source);
 
     if (!result.ok) {
-      const updatedSource = updateMediaSourceHealthForAccount(source.id, source.providerAccountId, {
+      const updatedSource = updateMediaSourceHealthForAccount(source.id, session.providerAccountId, {
         lastCheckedAt: checkedAt,
         lastError: result.message,
       });
@@ -191,7 +193,7 @@ sourcesRouter.post(
       return;
     }
 
-    const updatedSource = updateMediaSourceForAccount(source.id, source.providerAccountId, {
+    const updatedSource = updateMediaSourceForAccount(source.id, session.providerAccountId, {
       ...(result.name !== undefined ? { name: result.name } : {}),
       ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
       ...(result.connection !== undefined ? { connection: result.connection } : {}),


### PR DESCRIPTION
This pull request introduces several improvements to how media sources are managed and how currently playing Plex sessions are deduplicated and identified. The main changes are focused on ensuring that media source operations are account-scoped for better security and correctness, and on improving the reliability of playback session tracking by deduplicating Plex session data.

**Account-scoped media source operations:**

* All routes and repository functions that interact with media sources now require a `providerAccountId`, ensuring that only sources belonging to the current account can be accessed or modified. This includes updates to the `requireMediaSource` function, all route handlers in `sources.ts`, and the media sources listing in both `media.ts` and `sources.ts`. [[1]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L4-R9) [[2]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L32-R33) [[3]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L107-R135) [[4]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L146-R152) [[5]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L162-R167) [[6]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L175-R177) [[7]](diffhunk://#diff-243428cee4b9c969d844bd38faeb5269f6bd3eef249866037cdd8efc422edd20L194-R196) [[8]](diffhunk://#diff-6f05490c0d78c47efb7bba7bf8fe2a474a35676f8d47358f31b717a2749eef76L133-R133) [[9]](diffhunk://#diff-e7cc234a8333c632fb06f6d852622f7fd00bf495722f66f7f4378e5299d6f8d3R64)

**Plex playback session deduplication and identification:**

* New utility functions (`playbackFallbackIdentity`, `playbackDeduplicationKey`, `dedupeCurrentlyPlayingMetadata`) are added to deduplicate currently playing Plex session metadata, addressing issues with duplicate session rows from certain clients. The normalization of current playback now uses deduplicated metadata. [[1]](diffhunk://#diff-ceccaaec851bc67f2d0ba01cff6a379dcb88ea017c51980794a87cb49822bc57R262-R308) [[2]](diffhunk://#diff-ceccaaec851bc67f2d0ba01cff6a379dcb88ea017c51980794a87cb49822bc57L484-R532)
* The logic for generating a unique playback session identity is improved to prioritize `sessionKey`, then `Session.id`, then a fallback identity, ensuring more robust and consistent session tracking.

These changes improve both the security of media source management and the accuracy of Plex playback session handling.