### PR TITLE
fix(plex): preserve manual source url overrides

### DIFF
--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -151,7 +151,7 @@ export function deleteMediaSourceForAccount(id: string, providerAccountId: strin
   return result.changes > 0;
 }
 
-function getMediaSourceByProviderExternalId(
+export function getMediaSourceByProviderExternalId(
   providerId: string,
   providerAccountId: string,
   externalId: string

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -1,7 +1,18 @@
 import { ApiError } from "../http/errors.js";
 import type { ProviderConnection, ProviderDefinition, ProviderResource } from "../providers/types.js";
-import { listMediaSources, updateMediaSource, upsertMediaSource } from "./mediaSourcesRepository.js";
+import {
+  getMediaSourceByProviderExternalId,
+  listMediaSources,
+  updateMediaSource,
+  upsertMediaSource,
+} from "./mediaSourcesRepository.js";
 import { upsertProviderAccountByAccessToken } from "./providerAccountsRepository.js";
+import {
+  plexBaseUrlMode,
+  PLEX_BASE_URL_MODE_AUTO,
+  PLEX_BASE_URL_MODE_MANUAL,
+  withPlexBaseUrlMode,
+} from "../providers/plex/connectionState.js";
 
 function connectionRank(connection: ProviderConnection) {
   if (connection.local && !connection.relay) {
@@ -71,10 +82,31 @@ function persistProviderResource(input: {
   resource: ProviderResource;
   selectedConnection?: ProviderConnection;
 }) {
+  const existingSource = getMediaSourceByProviderExternalId(
+    input.providerId,
+    input.providerAccountId,
+    input.resource.id
+  );
   const connection = preferredConnection(input.resource, input.selectedConnection);
   if (!connection) {
     return undefined;
   }
+
+  const baseUrlMode = input.providerId === "plex" && existingSource
+    ? plexBaseUrlMode(existingSource.connection)
+    : PLEX_BASE_URL_MODE_AUTO;
+  const nextBaseUrl = input.providerId === "plex" && baseUrlMode === PLEX_BASE_URL_MODE_MANUAL && existingSource
+    ? existingSource.baseUrl
+    : connection.uri;
+  const nextConnection = input.providerId === "plex"
+    ? withPlexBaseUrlMode({
+      connections: input.resource.connections,
+      selectedConnectionId: connection.id,
+    }, baseUrlMode)
+    : {
+      connections: input.resource.connections,
+      selectedConnectionId: connection.id,
+    };
 
   return upsertMediaSource({
     providerId: input.providerId,
@@ -82,11 +114,8 @@ function persistProviderResource(input: {
     externalId: input.resource.id,
     name: input.resource.name,
     enabled: true,
-    baseUrl: connection.uri,
-    connection: {
-      connections: input.resource.connections,
-      selectedConnectionId: connection.id,
-    },
+    baseUrl: nextBaseUrl,
+    connection: nextConnection,
     credentials: {
       ...(input.resource.credentials ?? {}),
       accessToken: input.resource.accessToken,

--- a/apps/server/src/providers/plex/connectionState.ts
+++ b/apps/server/src/providers/plex/connectionState.ts
@@ -1,0 +1,21 @@
+import { stringValue } from "../shared/utils.js";
+
+export const PLEX_BASE_URL_MODE_AUTO = "auto";
+export const PLEX_BASE_URL_MODE_MANUAL = "manual";
+
+export type PlexBaseUrlMode =
+  | typeof PLEX_BASE_URL_MODE_AUTO
+  | typeof PLEX_BASE_URL_MODE_MANUAL;
+
+export function plexBaseUrlMode(connection: Record<string, unknown>): PlexBaseUrlMode {
+  return stringValue((connection as any)?.baseUrlMode) === PLEX_BASE_URL_MODE_MANUAL
+    ? PLEX_BASE_URL_MODE_MANUAL
+    : PLEX_BASE_URL_MODE_AUTO;
+}
+
+export function withPlexBaseUrlMode(connection: Record<string, unknown>, mode: PlexBaseUrlMode) {
+  return {
+    ...connection,
+    baseUrlMode: mode,
+  };
+}

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -24,13 +24,20 @@ import {
 } from "../shared/utils.js";
 import {
   buildSourceContext,
+  candidateConnections,
   CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS,
   fetchPmsJson,
-  orderedConnections,
   plexMediaHeaders,
   sourceResource,
+  unreachableConnectionMessage,
   type PlexSourceContext,
 } from "./shared.js";
+import {
+  PLEX_BASE_URL_MODE_AUTO,
+  PLEX_BASE_URL_MODE_MANUAL,
+  type PlexBaseUrlMode,
+  withPlexBaseUrlMode,
+} from "./connectionState.js";
 
 function createMediaHandle(
   session: ProviderSessionRecord,
@@ -210,9 +217,29 @@ function isRetryableConnectionError(err: unknown) {
 
 function persistWorkingSourceConnection(
   source: MediaSource,
-  resource: ProviderResource,
-  connection: ProviderConnection
+  connections: ProviderResource["connections"],
+  connection: ProviderConnection,
+  options: { baseUrlMode: PlexBaseUrlMode; manualConnectionId?: string }
 ) {
+  if (options.baseUrlMode === PLEX_BASE_URL_MODE_MANUAL) {
+    if (connection.id === options.manualConnectionId) {
+      return;
+    }
+
+    if (stringValue(source.connection.selectedConnectionId) === connection.id) {
+      return;
+    }
+
+    updateMediaSource(source.id, {
+      connection: {
+        ...withPlexBaseUrlMode(source.connection, PLEX_BASE_URL_MODE_MANUAL),
+        connections,
+        selectedConnectionId: connection.id,
+      },
+    });
+    return;
+  }
+
   if (
     source.baseUrl === connection.uri
     && stringValue(source.connection.selectedConnectionId) === connection.id
@@ -223,25 +250,34 @@ function persistWorkingSourceConnection(
   updateMediaSource(source.id, {
     baseUrl: connection.uri,
     connection: {
-      ...source.connection,
-      connections: resource.connections,
+      ...withPlexBaseUrlMode(source.connection, PLEX_BASE_URL_MODE_AUTO),
+      connections,
       selectedConnectionId: connection.id,
     },
   });
 }
 
 async function fetchCurrentlyPlayingData(source: MediaSource) {
-  const { resource, preferredConnectionId } = sourceResource(source);
+  const {
+    baseUrlMode,
+    manualConnectionId,
+    persistedConnections,
+    preferredConnectionId,
+    resource,
+  } = sourceResource(source);
   const failures: string[] = [];
 
-  for (const connection of orderedConnections(resource, preferredConnectionId)) {
+  for (const connection of candidateConnections(resource, preferredConnectionId, baseUrlMode)) {
     const context = buildSourceContext(source.id, resource.accessToken, connection);
 
     try {
       const data = await fetchPmsJson(context, "/status/sessions", {
         timeoutMs: CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS,
       });
-      persistWorkingSourceConnection(source, resource, connection);
+      persistWorkingSourceConnection(source, persistedConnections, connection, {
+        baseUrlMode,
+        manualConnectionId,
+      });
       return { context, data };
     } catch (err) {
       if (!isRetryableConnectionError(err)) {
@@ -255,7 +291,7 @@ async function fetchCurrentlyPlayingData(source: MediaSource) {
   throw new ApiError(
     502,
     "plex_unreachable",
-    `Cliparr could not reach any discovered connection for ${resource.name}. Tried: ${failures.join("; ")}`
+    unreachableConnectionMessage(resource, failures, baseUrlMode)
   );
 }
 

--- a/apps/server/src/providers/plex/provider.ts
+++ b/apps/server/src/providers/plex/provider.ts
@@ -1,21 +1,38 @@
 import { ApiError } from "../../http/errors.js";
 import type { ProviderImplementation } from "../types.js";
 import { pollAuth, startAuth } from "./auth.js";
+import {
+  PLEX_BASE_URL_MODE_AUTO,
+  withPlexBaseUrlMode,
+} from "./connectionState.js";
 import { listCurrentlyPlaying, proxyMedia } from "./playback.js";
 import { selectReachableConnection, sourceResource, sourceSupportsCurrentlyPlaying } from "./shared.js";
 
 async function checkSource(source: Parameters<ProviderImplementation["checkSource"]>[0]) {
-  const { resource, preferredConnectionId } = sourceResource(source);
+  const {
+    baseUrlMode,
+    manualConnectionId,
+    persistedConnections,
+    preferredConnectionId,
+    resource,
+  } = sourceResource(source);
   try {
-    const selectedConnection = await selectReachableConnection(resource, preferredConnectionId);
+    const selectedConnection = await selectReachableConnection(resource, preferredConnectionId, {
+      baseUrlMode,
+    });
 
     return {
       ok: true as const,
-      baseUrl: selectedConnection.uri,
+      ...(baseUrlMode === PLEX_BASE_URL_MODE_AUTO ? { baseUrl: selectedConnection.uri } : {}),
       connection: {
-        ...source.connection,
-        connections: resource.connections,
-        selectedConnectionId: selectedConnection.id,
+        ...withPlexBaseUrlMode(
+          source.connection,
+          baseUrlMode
+        ),
+        connections: persistedConnections,
+        selectedConnectionId: selectedConnection.id === manualConnectionId
+          ? source.connection.selectedConnectionId
+          : selectedConnection.id,
       },
     };
   } catch (err) {

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -4,6 +4,12 @@ import { ApiError } from "../../http/errors.js";
 import { normalizeMediaPath } from "../shared/mediaProxy.js";
 import { errorMessage, numberValue, stringValue } from "../shared/utils.js";
 import type { ProviderResource } from "../types.js";
+import {
+  plexBaseUrlMode,
+  PLEX_BASE_URL_MODE_AUTO,
+  PLEX_BASE_URL_MODE_MANUAL,
+  type PlexBaseUrlMode,
+} from "./connectionState.js";
 
 export const PLEX_PRODUCT = "Cliparr";
 export const PLEX_CLIENT_IDENTIFIER = process.env.PLEX_CLIENT_IDENTIFIER ?? `cliparr-${randomUUID()}`;
@@ -169,7 +175,7 @@ function connectionRank(connection: ProviderResource["connections"][number]) {
   return 2;
 }
 
-export function orderedConnections(resource: ProviderResource, preferredConnectionId: string) {
+function orderedConnections(resource: ProviderResource, preferredConnectionId: string) {
   return [...resource.connections].sort((left, right) => {
     if (left.id === preferredConnectionId) {
       return -1;
@@ -179,6 +185,25 @@ export function orderedConnections(resource: ProviderResource, preferredConnecti
     }
     return connectionRank(left) - connectionRank(right);
   });
+}
+
+export function candidateConnections(
+  resource: ProviderResource,
+  preferredConnectionId: string,
+  baseUrlMode: PlexBaseUrlMode
+) {
+  const ordered = orderedConnections(resource, preferredConnectionId);
+  return baseUrlMode === PLEX_BASE_URL_MODE_MANUAL ? ordered.slice(0, 1) : ordered;
+}
+
+export function unreachableConnectionMessage(
+  resource: ProviderResource,
+  failures: string[],
+  baseUrlMode: PlexBaseUrlMode
+) {
+  return baseUrlMode === PLEX_BASE_URL_MODE_MANUAL
+    ? `Cliparr could not reach the configured server URL for ${resource.name}. Tried: ${failures.join("; ")}`
+    : `Cliparr could not reach any discovered connection for ${resource.name}. Tried: ${failures.join("; ")}`;
 }
 
 function sourceConnections(source: MediaSource) {
@@ -207,6 +232,31 @@ function sourceConnections(source: MediaSource) {
   });
 }
 
+function manualConnectionId(sourceId: string) {
+  return `manual-base-url:${sourceId}`;
+}
+
+function manualConnection(source: MediaSource) {
+  if (plexBaseUrlMode(source.connection) !== PLEX_BASE_URL_MODE_MANUAL) {
+    return undefined;
+  }
+
+  const parsed = assertHttpUrl(source.baseUrl);
+  return {
+    id: manualConnectionId(source.id),
+    uri: source.baseUrl,
+    local: false,
+    relay: false,
+    protocol: parsed.protocol.replace(/:$/, ""),
+    address: parsed.hostname,
+    port: parsed.port
+      ? Number(parsed.port)
+      : parsed.protocol === "https:"
+        ? 443
+        : 80,
+  };
+}
+
 export function sourceResource(source: MediaSource) {
   const accessToken = stringValue(source.credentials.accessToken);
   if (!accessToken) {
@@ -222,8 +272,9 @@ export function sourceResource(source: MediaSource) {
     );
   }
 
+  const manual = manualConnection(source);
   const connections = sourceConnections(source);
-  if (connections.length === 0) {
+  if (connections.length === 0 && !manual) {
     throw new ApiError(500, "source_connections_missing", "Stored Plex source is missing connection details");
   }
 
@@ -232,13 +283,20 @@ export function sourceResource(source: MediaSource) {
     ? connections.find((candidate) => candidate.id === selectedConnectionId)
     : undefined;
   const matchingBaseUrl = connections.find((candidate) => candidate.uri === source.baseUrl);
-  const preferredConnectionId = matchingSelectedConnection?.id ?? matchingBaseUrl?.id ?? connections[0]?.id;
+  const resourceConnections = manual && !matchingBaseUrl ? [manual, ...connections] : connections;
+  const baseUrlMode: PlexBaseUrlMode = manual ? PLEX_BASE_URL_MODE_MANUAL : PLEX_BASE_URL_MODE_AUTO;
+  const preferredConnectionId = manual
+    ? matchingBaseUrl?.id ?? manual.id
+    : matchingSelectedConnection?.id ?? matchingBaseUrl?.id ?? connections[0]?.id;
 
   if (!preferredConnectionId) {
     throw new ApiError(500, "source_connections_missing", "Stored Plex source is missing connection details");
   }
 
   return {
+    baseUrlMode,
+    manualConnectionId: manual?.id,
+    persistedConnections: connections,
     preferredConnectionId,
     resource: {
       id: source.externalId ?? source.id,
@@ -248,7 +306,7 @@ export function sourceResource(source: MediaSource) {
       provides,
       owned: Boolean(source.metadata.owned),
       accessToken,
-      connections,
+      connections: resourceConnections,
     } satisfies ProviderResource,
   };
 }
@@ -288,10 +346,19 @@ async function probeConnection(resource: ProviderResource, connection: ProviderR
   }
 }
 
-export async function selectReachableConnection(resource: ProviderResource, preferredConnectionId: string) {
+export async function selectReachableConnection(
+  resource: ProviderResource,
+  preferredConnectionId: string,
+  options: { baseUrlMode?: PlexBaseUrlMode } = {}
+) {
   const failures: string[] = [];
+  const baseUrlMode = options.baseUrlMode ?? PLEX_BASE_URL_MODE_AUTO;
 
-  for (const connection of orderedConnections(resource, preferredConnectionId)) {
+  for (const connection of candidateConnections(
+    resource,
+    preferredConnectionId,
+    baseUrlMode
+  )) {
     const result = await probeConnection(resource, connection);
     if (result.ok) {
       return connection;
@@ -303,7 +370,7 @@ export async function selectReachableConnection(resource: ProviderResource, pref
   throw new ApiError(
     502,
     "plex_unreachable",
-    `Cliparr could not reach any discovered connection for ${resource.name}. Tried: ${failures.join("; ")}`
+    unreachableConnectionMessage(resource, failures, baseUrlMode)
   );
 }
 

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -9,6 +9,10 @@ import {
   updateMediaSourceForAccount,
 } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
+import {
+  PLEX_BASE_URL_MODE_MANUAL,
+  withPlexBaseUrlMode,
+} from "../providers/plex/connectionState.js";
 import { getProvider } from "../providers/registry.js";
 import { requireAccountSession, setNoStore } from "../session/request.js";
 
@@ -129,11 +133,18 @@ sourcesRouter.patch(
   asyncHandler(async (req, res) => {
     const session = requireAccountSession(req);
     setNoStore(res);
-    requireMediaSource(req.params.id as string, session.providerAccountId);
+    const existingSource = requireMediaSource(req.params.id as string, session.providerAccountId);
+    const input = parseSourceUpdate(req.body);
+    const nextInput = existingSource.providerId === "plex" && input.baseUrl !== undefined
+      ? {
+        ...input,
+        connection: withPlexBaseUrlMode(existingSource.connection, PLEX_BASE_URL_MODE_MANUAL),
+      }
+      : input;
     const source = updateMediaSourceForAccount(
       req.params.id as string,
       session.providerAccountId,
-      parseSourceUpdate(req.body)
+      nextInput
     );
     if (!source) {
       throw new ApiError(404, "source_not_found", "Source was not found");


### PR DESCRIPTION
## Summary
- add an explicit Plex `baseUrlMode` in source connection state so Cliparr can distinguish auto-discovered URLs from user-pinned ones
- mark Plex source URL edits as manual overrides and preserve only those overrides across re-auth
- disable Plex connection fallback when a source is pinned so the configured URL is used as the single source of truth

## Testing
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/server lint:eslint

Closes #37