### PR TITLE
fix(auth): derive plex auth from request origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ APP_KEY=""
 # PORT: Express server port.
 PORT="3000"
 
+# CLIPARR_TRUST_PROXY: Optional Express trust proxy setting.
+# Set to 1 behind a single reverse proxy like Caddy.
+# Leave unset for direct localhost/LAN access.
+# CLIPARR_TRUST_PROXY=""
+
 # CLIPARR_DATA_DIR: Directory where Cliparr stores its required SQLite database.
 # Docker uses /data and should mount it as a persistent volume.
 CLIPARR_DATA_DIR="./.cliparr-data"

--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,10 @@ APP_KEY=""
 # PORT: Express server port.
 PORT="3000"
 
-# CLIPARR_TRUST_PROXY: Optional Express trust proxy setting.
-# Set to 1 behind a single reverse proxy like Caddy.
-# Leave unset for direct localhost/LAN access.
+# CLIPARR_TRUST_PROXY: Optional Express trust proxy override.
+# By default Cliparr trusts loopback, link-local, and private LAN proxy ranges,
+# similar to Sonarr/Radarr. Set to false to disable or provide any standard
+# Express trust proxy value to override the default.
 # CLIPARR_TRUST_PROXY=""
 
 # CLIPARR_DATA_DIR: Directory where Cliparr stores its required SQLite database.

--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,6 @@ APP_KEY=""
 # PORT: Express server port.
 PORT="3000"
 
-# CLIPARR_TRUST_PROXY: Optional Express trust proxy override.
-# By default Cliparr trusts loopback, link-local, and private LAN proxy ranges,
-# similar to Sonarr/Radarr. Set to false to disable or provide any standard
-# Express trust proxy value to override the default.
-# CLIPARR_TRUST_PROXY=""
-
 # CLIPARR_DATA_DIR: Directory where Cliparr stores its required SQLite database.
 # Docker uses /data and should mount it as a persistent volume.
 CLIPARR_DATA_DIR="./.cliparr-data"

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# APP_URL: Public base URL for Cliparr auth callbacks.
-# Defaults to http://localhost:3000 for local development.
-APP_URL="http://localhost:3000"
-
 # APP_KEY: Required stable secret used to encrypt persisted provider credentials.
 # Generate one with: openssl rand -base64 32
 APP_KEY=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Test
+        run: pnpm test
+
       - name: Knip
         run: pnpm knip
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ volumes:
 | :--- | :--- | :--- |
 | `APP_KEY` | **Required** secret for credential encryption. | - |
 | `PORT` | Internal port for the Express server. | `3000` |
-| `CLIPARR_TRUST_PROXY` | Optional Express trust proxy setting. Use `1` behind one reverse proxy like Caddy. | unset |
+| `CLIPARR_TRUST_PROXY` | Optional Express trust proxy override. Defaults to local/private proxy ranges. | `loopback, linklocal, uniquelocal` |
 | `CLIPARR_DATA_DIR` | Directory for SQLite storage. | `/data` |
 | `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to `localhost`/loopback. Use only for trusted self-hosted setups. | `false` |
 
-When running behind a reverse proxy, preserve the `Host` header, pass `X-Forwarded-Proto`, and set `CLIPARR_TRUST_PROXY=1` for a single proxy hop. Leave it unset when accessing Cliparr directly over localhost or a LAN IP. Caddy already forwards the needed headers.
+When running behind a reverse proxy, preserve the `Host` header and pass `X-Forwarded-Proto`. Cliparr trusts loopback, link-local, and private-LAN proxy ranges by default, so typical Caddy/Nginx/Traefik setups on the same network do not need extra app configuration. Set `CLIPARR_TRUST_PROXY` only if you want to disable that behavior or override it with a custom Express trust proxy value. Caddy already forwards the needed headers.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The fastest way to get Cliparr running is via the GitHub Container Registry.
 docker run -d \
   --name cliparr \
   -p 3000:3000 \
-  -e APP_URL=http://localhost:3000 \
   -e APP_KEY="your-stable-random-secret" \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
@@ -57,7 +56,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - APP_URL=http://localhost:3000
       - APP_KEY=replace-this-with-a-secure-random-string
     volumes:
       - cliparr-data:/data
@@ -71,11 +69,12 @@ volumes:
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |
-| `APP_URL` | Public base URL for auth callbacks. | `http://localhost:3000` |
 | `APP_KEY` | **Required** secret for credential encryption. | - |
 | `PORT` | Internal port for the Express server. | `3000` |
 | `CLIPARR_DATA_DIR` | Directory for SQLite storage. | `/data` |
 | `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to `localhost`/loopback. Use only for trusted self-hosted setups. | `false` |
+
+When running behind a reverse proxy, preserve the `Host` header and pass `X-Forwarded-Proto` so Cliparr can generate provider auth callbacks and cookie policy from the public request origin. Caddy does this by default.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ volumes:
 | :--- | :--- | :--- |
 | `APP_KEY` | **Required** secret for credential encryption. | - |
 | `PORT` | Internal port for the Express server. | `3000` |
-| `CLIPARR_TRUST_PROXY` | Optional Express trust proxy override. Defaults to local/private proxy ranges. | `loopback, linklocal, uniquelocal` |
 | `CLIPARR_DATA_DIR` | Directory for SQLite storage. | `/data` |
 | `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to `localhost`/loopback. Use only for trusted self-hosted setups. | `false` |
 
-When running behind a reverse proxy, preserve the `Host` header and pass `X-Forwarded-Proto`. Cliparr trusts loopback, link-local, and private-LAN proxy ranges by default, so typical Caddy/Nginx/Traefik setups on the same network do not need extra app configuration. Set `CLIPARR_TRUST_PROXY` only if you want to disable that behavior or override it with a custom Express trust proxy value. Caddy already forwards the needed headers.
+When running behind a reverse proxy, preserve the `Host` header and pass `X-Forwarded-Proto`. Cliparr trusts loopback, link-local, and private-LAN proxy ranges directly in the app, so typical Caddy/Nginx/Traefik setups on the same network do not need extra app configuration. Caddy already forwards the needed headers.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ volumes:
 | :--- | :--- | :--- |
 | `APP_KEY` | **Required** secret for credential encryption. | - |
 | `PORT` | Internal port for the Express server. | `3000` |
+| `CLIPARR_TRUST_PROXY` | Optional Express trust proxy setting. Use `1` behind one reverse proxy like Caddy. | unset |
 | `CLIPARR_DATA_DIR` | Directory for SQLite storage. | `/data` |
 | `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to `localhost`/loopback. Use only for trusted self-hosted setups. | `false` |
 
-When running behind a reverse proxy, preserve the `Host` header and pass `X-Forwarded-Proto` so Cliparr can generate provider auth callbacks and cookie policy from the public request origin. Caddy does this by default.
+When running behind a reverse proxy, preserve the `Host` header, pass `X-Forwarded-Proto`, and set `CLIPARR_TRUST_PROXY=1` for a single proxy hop. Leave it unset when accessing Cliparr directly over localhost or a LAN IP. Caddy already forwards the needed headers.
 
 ## Development
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm exec eslint \"src/**/*.ts\"",
     "lint:types": "tsc --noEmit",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:export": "drizzle-kit export --sql",
     "preview": "NODE_ENV=production tsx src/server.ts",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -14,10 +14,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");
 const frontendRoot = path.join(workspaceRoot, "apps/frontend");
 const DEFAULT_DEV_FRONTEND_URL = "http://localhost:5173";
+const DEFAULT_TRUSTED_PROXY_SUBNETS = ["loopback", "linklocal", "uniquelocal"];
 
 function getTrustProxySetting() {
   const configured = process.env.CLIPARR_TRUST_PROXY?.trim();
-  if (!configured || configured === "false") {
+  if (!configured) {
+    return DEFAULT_TRUSTED_PROXY_SUBNETS;
+  }
+
+  if (configured === "false") {
     return false;
   }
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -15,14 +15,27 @@ const workspaceRoot = path.resolve(__dirname, "../../..");
 const frontendRoot = path.join(workspaceRoot, "apps/frontend");
 const DEFAULT_DEV_FRONTEND_URL = "http://localhost:5173";
 
+function getTrustProxySetting() {
+  const configured = process.env.CLIPARR_TRUST_PROXY?.trim();
+  if (!configured || configured === "false") {
+    return false;
+  }
+
+  if (configured === "true") {
+    return true;
+  }
+
+  return /^\d+$/.test(configured)
+    ? Number.parseInt(configured, 10)
+    : configured;
+}
+
 export async function createApp() {
   initializeDatabase();
 
   const app = express();
 
-  // Respect reverse-proxy protocol headers so auth callbacks and cookie policies
-  // follow the public request origin instead of the internal container hop.
-  app.set("trust proxy", true);
+  app.set("trust proxy", getTrustProxySetting());
   app.disable("x-powered-by");
   app.use(express.json());
   app.use((req, res, next) => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import { CLIPARR_VERSION } from "./config/version.js";
 import { checkDatabaseHealth, initializeDatabase } from "./db/database.js";
 import { errorHandler, notFoundHandler } from "./http/errors.js";
+import { requestOriginIsPotentiallyTrustworthy } from "./http/requestOrigin.js";
 import { mediaRouter } from "./routes/media.js";
 import { providersRouter } from "./routes/providers.js";
 import { sessionRouter } from "./routes/session.js";
@@ -19,11 +20,17 @@ export async function createApp() {
 
   const app = express();
 
+  // Respect reverse-proxy protocol headers so auth callbacks and cookie policies
+  // follow the public request origin instead of the internal container hop.
+  app.set("trust proxy", true);
   app.disable("x-powered-by");
   app.use(express.json());
   app.use((req, res, next) => {
-    res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-    res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    if (requestOriginIsPotentiallyTrustworthy(req)) {
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    }
+
     next();
   });
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -14,33 +14,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");
 const frontendRoot = path.join(workspaceRoot, "apps/frontend");
 const DEFAULT_DEV_FRONTEND_URL = "http://localhost:5173";
-const DEFAULT_TRUSTED_PROXY_SUBNETS = ["loopback", "linklocal", "uniquelocal"];
-
-function getTrustProxySetting() {
-  const configured = process.env.CLIPARR_TRUST_PROXY?.trim();
-  if (!configured) {
-    return DEFAULT_TRUSTED_PROXY_SUBNETS;
-  }
-
-  if (configured === "false") {
-    return false;
-  }
-
-  if (configured === "true") {
-    return true;
-  }
-
-  return /^\d+$/.test(configured)
-    ? Number.parseInt(configured, 10)
-    : configured;
-}
+const TRUSTED_PROXY_SUBNETS = ["loopback", "linklocal", "uniquelocal"];
 
 export async function createApp() {
   initializeDatabase();
 
   const app = express();
 
-  app.set("trust proxy", getTrustProxySetting());
+  app.set("trust proxy", TRUSTED_PROXY_SUBNETS);
   app.disable("x-powered-by");
   app.use(express.json());
   app.use((req, res, next) => {

--- a/apps/server/src/http/requestOrigin.test.ts
+++ b/apps/server/src/http/requestOrigin.test.ts
@@ -2,63 +2,56 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { Request } from "express";
 import {
-  getRequestOrigin,
   getRequestRouteUrl,
   requestOriginIsPotentiallyTrustworthy,
-  requestUsesSecureTransport,
 } from "./requestOrigin.js";
-import { getClearSessionCookieHeader, getSessionCookieHeader } from "../session/store.js";
+import { getSessionCookieClearOptions, getSessionCookieOptions } from "../session/store.js";
 
-function makeRequest(protocol: string, host?: string): Pick<Request, "protocol" | "get"> {
+function makeRequest(secure: boolean, host?: string): Pick<Request, "get" | "secure"> {
   return {
-    protocol,
+    secure,
     get(name: string) {
       return name.toLowerCase() === "host" ? host : undefined;
     },
-  } as Pick<Request, "protocol" | "get">;
+  } as Pick<Request, "get" | "secure">;
 }
 
 void test("keeps proxied HTTPS requests secure", () => {
-  const req = makeRequest("https", "cliparr.example.com");
+  const req = makeRequest(true, "cliparr.example.com");
 
-  assert.equal(getRequestOrigin(req), "https://cliparr.example.com");
   assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "https://cliparr.example.com/auth/plex/complete");
-  assert.equal(requestUsesSecureTransport(req), true);
   assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
-  assert.match(getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }), /; Secure$/);
-  assert.match(getClearSessionCookieHeader({ secure: requestUsesSecureTransport(req) }), /; Secure$/);
+  assert.equal(getSessionCookieOptions(req.secure).secure, true);
+  assert.equal(getSessionCookieClearOptions(req.secure).secure, true);
 });
 
 void test("allows localhost HTTP requests", () => {
-  const req = makeRequest("http", "localhost:3000");
+  const req = makeRequest(false, "localhost:3000");
 
-  assert.equal(getRequestOrigin(req), "http://localhost:3000");
   assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "http://localhost:3000/auth/plex/complete");
-  assert.equal(requestUsesSecureTransport(req), false);
   assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
-  assert.doesNotMatch(
-    getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }),
-    /; Secure$/
-  );
+  assert.equal(getSessionCookieOptions(req.secure).secure, false);
 });
 
 void test("treats loopback IP addresses as potentially trustworthy over HTTP", () => {
-  const req = makeRequest("http", "127.0.0.1:3000");
+  const req = makeRequest(false, "127.0.0.1:3000");
 
-  assert.equal(requestUsesSecureTransport(req), false);
   assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
 });
 
 void test("drops secure-only browser policies for custom HTTP domains", () => {
-  const req = makeRequest("http", "cliparr.example.com");
+  const req = makeRequest(false, "cliparr.example.com");
 
-  assert.equal(getRequestOrigin(req), "http://cliparr.example.com");
   assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "http://cliparr.example.com/auth/plex/complete");
-  assert.equal(requestUsesSecureTransport(req), false);
   assert.equal(requestOriginIsPotentiallyTrustworthy(req), false);
-  assert.doesNotMatch(
-    getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }),
-    /; Secure$/
+  assert.equal(getSessionCookieClearOptions(req.secure).secure, false);
+});
+
+void test("rejects invalid host headers before building callback URLs", () => {
+  const req = makeRequest(false, "user@example.com");
+
+  assert.throws(
+    () => getRequestRouteUrl(req, "/auth/plex/complete"),
+    /Request host header is invalid/
   );
-  assert.doesNotMatch(getClearSessionCookieHeader({ secure: requestUsesSecureTransport(req) }), /; Secure$/);
 });

--- a/apps/server/src/http/requestOrigin.test.ts
+++ b/apps/server/src/http/requestOrigin.test.ts
@@ -7,13 +7,30 @@ import {
 } from "./requestOrigin.js";
 import { getSessionCookieClearOptions, getSessionCookieOptions } from "../session/store.js";
 
-function makeRequest(secure: boolean, host?: string): Pick<Request, "get" | "secure"> {
+function makeRequest(
+  secure: boolean,
+  host?: string,
+  options?: {
+    forwardedHost?: string;
+    hostname?: string;
+  }
+): Pick<Request, "get" | "hostname" | "secure"> {
   return {
     secure,
+    hostname: options?.hostname ?? host?.split(":")[0] ?? "",
     get(name: string) {
-      return name.toLowerCase() === "host" ? host : undefined;
+      const normalized = name.toLowerCase();
+      if (normalized === "host") {
+        return host;
+      }
+
+      if (normalized === "x-forwarded-host") {
+        return options?.forwardedHost;
+      }
+
+      return undefined;
     },
-  } as Pick<Request, "get" | "secure">;
+  } as Pick<Request, "get" | "hostname" | "secure">;
 }
 
 void test("keeps proxied HTTPS requests secure", () => {
@@ -23,6 +40,18 @@ void test("keeps proxied HTTPS requests secure", () => {
   assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
   assert.equal(getSessionCookieOptions(req.secure).secure, true);
   assert.equal(getSessionCookieClearOptions(req.secure).secure, true);
+});
+
+void test("uses the trusted forwarded host for callback URLs when a proxy rewrites Host", () => {
+  const req = makeRequest(true, "cliparr:3000", {
+    forwardedHost: "cliparr.example.com:8443",
+    hostname: "cliparr.example.com",
+  });
+
+  assert.equal(
+    getRequestRouteUrl(req, "/auth/plex/complete"),
+    "https://cliparr.example.com:8443/auth/plex/complete"
+  );
 });
 
 void test("allows localhost HTTP requests", () => {

--- a/apps/server/src/http/requestOrigin.test.ts
+++ b/apps/server/src/http/requestOrigin.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Request } from "express";
+import {
+  getRequestOrigin,
+  getRequestRouteUrl,
+  requestOriginIsPotentiallyTrustworthy,
+  requestUsesSecureTransport,
+} from "./requestOrigin.js";
+import { getClearSessionCookieHeader, getSessionCookieHeader } from "../session/store.js";
+
+function makeRequest(protocol: string, host?: string): Pick<Request, "protocol" | "get"> {
+  return {
+    protocol,
+    get(name: string) {
+      return name.toLowerCase() === "host" ? host : undefined;
+    },
+  } as Pick<Request, "protocol" | "get">;
+}
+
+void test("keeps proxied HTTPS requests secure", () => {
+  const req = makeRequest("https", "cliparr.example.com");
+
+  assert.equal(getRequestOrigin(req), "https://cliparr.example.com");
+  assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "https://cliparr.example.com/auth/plex/complete");
+  assert.equal(requestUsesSecureTransport(req), true);
+  assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
+  assert.match(getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }), /; Secure$/);
+  assert.match(getClearSessionCookieHeader({ secure: requestUsesSecureTransport(req) }), /; Secure$/);
+});
+
+void test("allows localhost HTTP requests", () => {
+  const req = makeRequest("http", "localhost:3000");
+
+  assert.equal(getRequestOrigin(req), "http://localhost:3000");
+  assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "http://localhost:3000/auth/plex/complete");
+  assert.equal(requestUsesSecureTransport(req), false);
+  assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
+  assert.doesNotMatch(
+    getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }),
+    /; Secure$/
+  );
+});
+
+void test("treats loopback IP addresses as potentially trustworthy over HTTP", () => {
+  const req = makeRequest("http", "127.0.0.1:3000");
+
+  assert.equal(requestUsesSecureTransport(req), false);
+  assert.equal(requestOriginIsPotentiallyTrustworthy(req), true);
+});
+
+void test("drops secure-only browser policies for custom HTTP domains", () => {
+  const req = makeRequest("http", "cliparr.example.com");
+
+  assert.equal(getRequestOrigin(req), "http://cliparr.example.com");
+  assert.equal(getRequestRouteUrl(req, "/auth/plex/complete"), "http://cliparr.example.com/auth/plex/complete");
+  assert.equal(requestUsesSecureTransport(req), false);
+  assert.equal(requestOriginIsPotentiallyTrustworthy(req), false);
+  assert.doesNotMatch(
+    getSessionCookieHeader("session-123", { secure: requestUsesSecureTransport(req) }),
+    /; Secure$/
+  );
+  assert.doesNotMatch(getClearSessionCookieHeader({ secure: requestUsesSecureTransport(req) }), /; Secure$/);
+});

--- a/apps/server/src/http/requestOrigin.ts
+++ b/apps/server/src/http/requestOrigin.ts
@@ -2,7 +2,11 @@ import { isIP } from "node:net";
 import type { Request } from "express";
 import { ApiError } from "./errors.js";
 
-type OriginAwareRequest = Pick<Request, "protocol" | "get">;
+type OriginAwareRequest = Pick<Request, "get" | "secure">;
+
+function isValidRequestHost(host: string) {
+  return host.length > 0 && !/[\s/@\\?#]/.test(host);
+}
 
 function getRequestHost(req: OriginAwareRequest) {
   const host = req.get("host");
@@ -10,13 +14,26 @@ function getRequestHost(req: OriginAwareRequest) {
     throw new ApiError(400, "invalid_request_host", "Request host header is required");
   }
 
+  if (!isValidRequestHost(host)) {
+    throw new ApiError(400, "invalid_request_host", "Request host header is invalid");
+  }
+
   return host;
 }
 
-function parseRequestOrigin(req: OriginAwareRequest) {
+function getRequestOriginUrl(req: OriginAwareRequest) {
   try {
-    return new URL(`${req.protocol}://${getRequestHost(req)}`);
-  } catch {
+    const url = new URL(`${req.secure ? "https" : "http"}://${getRequestHost(req)}`);
+    if (url.username || url.password) {
+      throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
+    }
+
+    return url;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
     throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
   }
 }
@@ -34,23 +51,18 @@ function isLoopbackHostname(hostname: string) {
   return isIP(normalized) === 4 && normalized.startsWith("127.");
 }
 
-export function getRequestOrigin(req: OriginAwareRequest) {
-  return parseRequestOrigin(req).origin;
-}
-
 export function getRequestRouteUrl(req: OriginAwareRequest, pathname: string) {
-  const url = parseRequestOrigin(req);
+  const url = getRequestOriginUrl(req);
   url.pathname = pathname.startsWith("/") ? pathname : `/${pathname}`;
   url.search = "";
   url.hash = "";
   return url.toString();
 }
 
-export function requestUsesSecureTransport(req: OriginAwareRequest) {
-  return parseRequestOrigin(req).protocol === "https:";
-}
-
 export function requestOriginIsPotentiallyTrustworthy(req: OriginAwareRequest) {
-  const origin = parseRequestOrigin(req);
-  return origin.protocol === "https:" || (origin.protocol === "http:" && isLoopbackHostname(origin.hostname));
+  if (req.secure) {
+    return true;
+  }
+
+  return isLoopbackHostname(getRequestOriginUrl(req).hostname);
 }

--- a/apps/server/src/http/requestOrigin.ts
+++ b/apps/server/src/http/requestOrigin.ts
@@ -1,0 +1,56 @@
+import { isIP } from "node:net";
+import type { Request } from "express";
+import { ApiError } from "./errors.js";
+
+type OriginAwareRequest = Pick<Request, "protocol" | "get">;
+
+function getRequestHost(req: OriginAwareRequest) {
+  const host = req.get("host");
+  if (!host) {
+    throw new ApiError(400, "invalid_request_host", "Request host header is required");
+  }
+
+  return host;
+}
+
+function parseRequestOrigin(req: OriginAwareRequest) {
+  try {
+    return new URL(`${req.protocol}://${getRequestHost(req)}`);
+  } catch {
+    throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
+  }
+}
+
+function isLoopbackHostname(hostname: string) {
+  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return true;
+  }
+
+  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") {
+    return true;
+  }
+
+  return isIP(normalized) === 4 && normalized.startsWith("127.");
+}
+
+export function getRequestOrigin(req: OriginAwareRequest) {
+  return parseRequestOrigin(req).origin;
+}
+
+export function getRequestRouteUrl(req: OriginAwareRequest, pathname: string) {
+  const url = parseRequestOrigin(req);
+  url.pathname = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export function requestUsesSecureTransport(req: OriginAwareRequest) {
+  return parseRequestOrigin(req).protocol === "https:";
+}
+
+export function requestOriginIsPotentiallyTrustworthy(req: OriginAwareRequest) {
+  const origin = parseRequestOrigin(req);
+  return origin.protocol === "https:" || (origin.protocol === "http:" && isLoopbackHostname(origin.hostname));
+}

--- a/apps/server/src/http/requestOrigin.ts
+++ b/apps/server/src/http/requestOrigin.ts
@@ -2,44 +2,74 @@ import { isIP } from "node:net";
 import type { Request } from "express";
 import { ApiError } from "./errors.js";
 
-type OriginAwareRequest = Pick<Request, "get" | "secure">;
+type OriginAwareRequest = Pick<Request, "get" | "hostname" | "secure">;
+
+function normalizedHostname(hostname: string) {
+  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+}
 
 function isValidRequestHost(host: string) {
   return host.length > 0 && !/[\s/@\\?#]/.test(host);
 }
 
+function firstHeaderValue(value: string | undefined) {
+  const first = value?.split(",")[0]?.trim();
+  return first || undefined;
+}
+
+function parseAuthority(authority: string, errorCode: string) {
+  if (!isValidRequestHost(authority)) {
+    throw new ApiError(400, errorCode, "Request host header is invalid");
+  }
+
+  const url = new URL(`http://${authority}`);
+  if (url.username || url.password) {
+    throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
+  }
+
+  return url;
+}
+
 function getRequestHost(req: OriginAwareRequest) {
-  const host = req.get("host");
+  const host = firstHeaderValue(req.get("host"));
   if (!host) {
     throw new ApiError(400, "invalid_request_host", "Request host header is required");
   }
 
-  if (!isValidRequestHost(host)) {
-    throw new ApiError(400, "invalid_request_host", "Request host header is invalid");
-  }
+  return parseAuthority(host, "invalid_request_host");
+}
 
-  return host;
+function buildOriginUrl(req: OriginAwareRequest, hostname: string, port = "") {
+  const url = new URL(req.secure ? "https://localhost" : "http://localhost");
+  url.hostname = hostname;
+  url.port = port;
+  return url;
 }
 
 function getRequestOriginUrl(req: OriginAwareRequest) {
-  try {
-    const url = new URL(`${req.secure ? "https" : "http"}://${getRequestHost(req)}`);
-    if (url.username || url.password) {
-      throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
-    }
-
-    return url;
-  } catch (error) {
-    if (error instanceof ApiError) {
-      throw error;
-    }
-
-    throw new ApiError(400, "invalid_request_origin", "Request origin is invalid");
+  const trustedHostname = req.hostname?.trim();
+  if (!trustedHostname) {
+    throw new ApiError(400, "invalid_request_host", "Request host header is required");
   }
+
+  const hostUrl = getRequestHost(req);
+  if (normalizedHostname(hostUrl.hostname) === normalizedHostname(trustedHostname)) {
+    return buildOriginUrl(req, hostUrl.hostname, hostUrl.port);
+  }
+
+  const forwardedHost = firstHeaderValue(req.get("x-forwarded-host"));
+  if (forwardedHost) {
+    const forwardedUrl = parseAuthority(forwardedHost, "invalid_request_host");
+    if (normalizedHostname(forwardedUrl.hostname) === normalizedHostname(trustedHostname)) {
+      return buildOriginUrl(req, forwardedUrl.hostname, forwardedUrl.port);
+    }
+  }
+
+  return buildOriginUrl(req, trustedHostname);
 }
 
 function isLoopbackHostname(hostname: string) {
-  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const normalized = normalizedHostname(hostname);
   if (normalized === "localhost" || normalized.endsWith(".localhost")) {
     return true;
   }

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -1,8 +1,9 @@
+import type { Request } from "express";
 import { randomUUID } from "crypto";
+import { getRequestRouteUrl } from "../../http/requestOrigin.js";
 import { ApiError } from "../../http/errors.js";
 import {
   AUTH_TTL_MS,
-  getPlexAuthCompleteUrl,
   MAX_PENDING_AUTH_REQUESTS,
   normalizeResources,
   PLEX_CLIENT_IDENTIFIER,
@@ -13,6 +14,7 @@ import {
 } from "./shared.js";
 
 const authRequests = new Map<string, PlexAuthRequest>();
+const PLEX_AUTH_COMPLETE_PATH = "/auth/plex/complete";
 
 function pruneExpiredAuthRequests(now = Date.now()) {
   for (const [authId, authRequest] of authRequests.entries()) {
@@ -22,7 +24,7 @@ function pruneExpiredAuthRequests(now = Date.now()) {
   }
 }
 
-export async function startAuth() {
+export async function startAuth(req: Request) {
   pruneExpiredAuthRequests();
   if (authRequests.size >= MAX_PENDING_AUTH_REQUESTS) {
     throw new ApiError(503, "plex_auth_busy", "Too many pending Plex sign-ins. Wait a moment and try again.");
@@ -50,7 +52,7 @@ export async function startAuth() {
   authUrl.hash = `?${new URLSearchParams({
     clientID: PLEX_CLIENT_IDENTIFIER,
     code: data.code,
-    forwardUrl: getPlexAuthCompleteUrl(),
+    forwardUrl: getRequestRouteUrl(req, PLEX_AUTH_COMPLETE_PATH),
     "context[device][product]": PLEX_PRODUCT,
   }).toString()}`;
 

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -7,6 +7,7 @@ import {
   PLEX_CLIENT_IDENTIFIER,
   plexFetch,
   PLEX_PRODUCT,
+  requirePlexServerResources,
   type PlexAuthRequest,
   type PlexResourceResponse,
 } from "./shared.js";
@@ -88,7 +89,9 @@ export async function pollAuth(authId: string) {
       },
     }
   );
-  const resources = normalizeResources((await resourcesResponse.json()) as PlexResourceResponse[]);
+  const resources = requirePlexServerResources(
+    normalizeResources((await resourcesResponse.json()) as PlexResourceResponse[])
+  );
   authRequests.delete(authId);
 
   return {

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -1,6 +1,4 @@
-import type { Request } from "express";
 import { randomUUID } from "crypto";
-import { getRequestRouteUrl } from "../../http/requestOrigin.js";
 import { ApiError } from "../../http/errors.js";
 import {
   AUTH_TTL_MS,
@@ -14,7 +12,6 @@ import {
 } from "./shared.js";
 
 const authRequests = new Map<string, PlexAuthRequest>();
-const PLEX_AUTH_COMPLETE_PATH = "/auth/plex/complete";
 
 function pruneExpiredAuthRequests(now = Date.now()) {
   for (const [authId, authRequest] of authRequests.entries()) {
@@ -24,7 +21,7 @@ function pruneExpiredAuthRequests(now = Date.now()) {
   }
 }
 
-export async function startAuth(req: Request) {
+export async function startAuth(callbackUrl: string) {
   pruneExpiredAuthRequests();
   if (authRequests.size >= MAX_PENDING_AUTH_REQUESTS) {
     throw new ApiError(503, "plex_auth_busy", "Too many pending Plex sign-ins. Wait a moment and try again.");
@@ -52,7 +49,7 @@ export async function startAuth(req: Request) {
   authUrl.hash = `?${new URLSearchParams({
     clientID: PLEX_CLIENT_IDENTIFIER,
     code: data.code,
-    forwardUrl: getRequestRouteUrl(req, PLEX_AUTH_COMPLETE_PATH),
+    forwardUrl: callbackUrl,
     "context[device][product]": PLEX_PRODUCT,
   }).toString()}`;
 

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -33,12 +33,12 @@ export interface PlexResourceResponse {
   clientIdentifier?: string;
   machineIdentifier?: string;
   provides?: string;
-  owned?: boolean;
+  owned?: boolean | number | string;
   accessToken?: string;
   connections?: {
     uri?: string;
-    local?: boolean;
-    relay?: boolean;
+    local?: boolean | number | string;
+    relay?: boolean | number | string;
     protocol?: string;
     address?: string;
     port?: number;
@@ -114,9 +114,32 @@ function normalizeProvides(provides: unknown): string[] {
     .filter(Boolean);
 }
 
+function plexBoolean(value: unknown) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "1" || normalized === "true" || normalized === "yes") {
+      return true;
+    }
+
+    if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "") {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 function isAdminServerResource(resource: PlexResourceResponse) {
   return Boolean(resource.accessToken)
-    && resource.owned === true
+    && plexBoolean(resource.owned)
     && normalizeProvides(resource.provides).includes("server")
     && Boolean(resource.connections?.length);
 }
@@ -133,8 +156,8 @@ export function normalizeResources(resources: PlexResourceResponse[]): ProviderR
           return {
             id: randomUUID(),
             uri,
-            local: Boolean(connection.local),
-            relay: Boolean(connection.relay),
+            local: plexBoolean(connection.local),
+            relay: plexBoolean(connection.relay),
             protocol: connection.protocol,
             address: connection.address,
             port: connection.port,
@@ -147,12 +170,24 @@ export function normalizeResources(resources: PlexResourceResponse[]): ProviderR
         product: resource.product,
         platform: resource.platform,
         provides: normalizeProvides(resource.provides),
-        owned: resource.owned,
+        owned: plexBoolean(resource.owned),
         accessToken: resource.accessToken as string,
         connections,
       };
     })
     .filter((resource) => resource.connections.length > 0);
+}
+
+export function requirePlexServerResources(resources: ProviderResource[]) {
+  if (resources.length > 0) {
+    return resources;
+  }
+
+  throw new ApiError(
+    403,
+    "plex_server_required",
+    "Cliparr needs a Plex account that owns at least one Plex Media Server"
+  );
 }
 
 function connectionRank(connection: ProviderResource["connections"][number]) {

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -17,8 +17,6 @@ export const AUTH_TTL_MS = 1000 * 60 * 10;
 export const MAX_PENDING_AUTH_REQUESTS = 512;
 export const CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS = 5000;
 
-const DEFAULT_APP_URL = "http://localhost:3000";
-const PLEX_AUTH_COMPLETE_PATH = "/auth/plex/complete";
 const CONNECTION_PROBE_TIMEOUT_MS = 2500;
 
 export interface PlexAuthRequest {
@@ -51,14 +49,6 @@ export interface PlexSourceContext {
   sourceId: string;
   baseUrl: string;
   token: string;
-}
-
-export function getPlexAuthCompleteUrl() {
-  const appUrl = new URL(process.env.APP_URL ?? DEFAULT_APP_URL);
-  appUrl.pathname = PLEX_AUTH_COMPLETE_PATH;
-  appUrl.search = "";
-  appUrl.hash = "";
-  return appUrl.toString();
 }
 
 function plexHeaders(init?: ConstructorParameters<typeof Headers>[0]) {

--- a/apps/server/src/providers/plexShared.test.ts
+++ b/apps/server/src/providers/plexShared.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ApiError } from "../http/errors.js";
+import type { ProviderResource } from "./types.js";
+import { normalizeResources, requirePlexServerResources } from "./plex/shared.js";
+
+void test("normalizes Plex server resources when Plex flags are strings", () => {
+  const resources = normalizeResources([
+    {
+      name: "Owned Server",
+      provides: "server",
+      owned: "1",
+      accessToken: "server-token",
+      clientIdentifier: "server-1",
+      connections: [{
+        uri: "http://192.168.1.10:32400",
+        local: "1",
+        relay: "0",
+        protocol: "http",
+        address: "192.168.1.10",
+        port: 32400,
+      }],
+    },
+    {
+      name: "Shared Server",
+      provides: "server",
+      owned: "0",
+      accessToken: "shared-token",
+      clientIdentifier: "server-2",
+      connections: [{
+        uri: "https://example.com:32400",
+        local: "0",
+        relay: "1",
+        protocol: "https",
+        address: "example.com",
+        port: 32400,
+      }],
+    },
+  ]);
+
+  assert.equal(resources.length, 1);
+  assert.equal(resources[0]?.id, "server-1");
+  assert.equal(resources[0]?.owned, true);
+  assert.equal(resources[0]?.connections.length, 1);
+  assert.equal(resources[0]?.connections[0]?.local, true);
+  assert.equal(resources[0]?.connections[0]?.relay, false);
+});
+
+void test("requires at least one discovered Plex server resource", () => {
+  assert.throws(
+    () => requirePlexServerResources([]),
+    (error: unknown) =>
+      error instanceof ApiError
+      && error.status === 403
+      && error.code === "plex_server_required"
+      && error.message === "Cliparr needs a Plex account that owns at least one Plex Media Server"
+  );
+});
+
+void test("keeps discovered Plex server resources when at least one exists", () => {
+  const resources: ProviderResource[] = [{
+    id: "plex-server-1",
+    name: "Plex Media Server",
+    accessToken: "token",
+    connections: [{
+      id: "connection-1",
+      uri: "http://plex.local:32400",
+      local: true,
+      relay: false,
+    }],
+  }];
+
+  assert.equal(requirePlexServerResources(resources), resources);
+});

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -155,7 +155,7 @@ export type ProviderSourceCheckResult =
 
 export interface ProviderImplementation {
   definition: ProviderDefinition;
-  startAuth?(req: Request): Promise<ProviderAuthStart>;
+  startAuth?(callbackUrl: string): Promise<ProviderAuthStart>;
   pollAuth?(authId: string): Promise<{
     status: ProviderAuthStatus["status"];
     userToken?: string;

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -155,7 +155,7 @@ export type ProviderSourceCheckResult =
 
 export interface ProviderImplementation {
   definition: ProviderDefinition;
-  startAuth?(): Promise<ProviderAuthStart>;
+  startAuth?(req: Request): Promise<ProviderAuthStart>;
   pollAuth?(authId: string): Promise<{
     status: ProviderAuthStatus["status"];
     userToken?: string;

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -1,12 +1,17 @@
 import { Router } from "express";
 import { persistProviderAuth } from "../db/providerPersistence.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
+import { getRequestRouteUrl } from "../http/requestOrigin.js";
 import { getProvider, listProviders } from "../providers/registry.js";
-import { requestUsesSecureTransport } from "../http/requestOrigin.js";
-import { createProviderSession, getSessionCookieHeader } from "../session/store.js";
+import {
+  createProviderSession,
+  getSessionCookieName,
+  getSessionCookieOptions,
+} from "../session/store.js";
 import { setNoStore } from "../session/request.js";
 
 export const providersRouter = Router();
+const PROVIDER_AUTH_COMPLETE_PATH = (providerId: string) => `/auth/${providerId}/complete`;
 
 providersRouter.get("/", (_req, res) => {
   setNoStore(res);
@@ -26,7 +31,7 @@ providersRouter.post(
       throw new ApiError(400, "provider_auth_not_supported", "This provider does not use browser PIN sign-in");
     }
 
-    res.json(await provider.startAuth(req));
+    res.json(await provider.startAuth(getRequestRouteUrl(req, PROVIDER_AUTH_COMPLETE_PATH(provider.definition.id))));
   })
 );
 
@@ -65,9 +70,7 @@ providersRouter.get(
       userToken: authStatus.userToken,
     });
 
-    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id, {
-      secure: requestUsesSecureTransport(req),
-    }));
+    res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
     res.json({ status: "complete" });
   })
 );
@@ -106,9 +109,7 @@ providersRouter.post(
       userToken: authResult.userToken,
     });
 
-    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id, {
-      secure: requestUsesSecureTransport(req),
-    }));
+    res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
     res.json({
       session: provider.serializeSession(session),
     });

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { persistProviderAuth } from "../db/providerPersistence.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getProvider, listProviders } from "../providers/registry.js";
+import { requestUsesSecureTransport } from "../http/requestOrigin.js";
 import { createProviderSession, getSessionCookieHeader } from "../session/store.js";
 import { setNoStore } from "../session/request.js";
 
@@ -25,7 +26,7 @@ providersRouter.post(
       throw new ApiError(400, "provider_auth_not_supported", "This provider does not use browser PIN sign-in");
     }
 
-    res.json(await provider.startAuth());
+    res.json(await provider.startAuth(req));
   })
 );
 
@@ -64,7 +65,9 @@ providersRouter.get(
       userToken: authStatus.userToken,
     });
 
-    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id));
+    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id, {
+      secure: requestUsesSecureTransport(req),
+    }));
     res.json({ status: "complete" });
   })
 );
@@ -103,7 +106,9 @@ providersRouter.post(
       userToken: authResult.userToken,
     });
 
-    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id));
+    res.setHeader("Set-Cookie", getSessionCookieHeader(session.id, {
+      secure: requestUsesSecureTransport(req),
+    }));
     res.json({
       session: provider.serializeSession(session),
     });

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -54,8 +54,8 @@ providersRouter.get(
       return;
     }
 
-    if (!authStatus.userToken || !authStatus.resources) {
-      throw new ApiError(502, "provider_auth_failed", "Provider auth did not return credentials");
+    if (!authStatus.userToken || !Array.isArray(authStatus.resources) || authStatus.resources.length === 0) {
+      throw new ApiError(502, "provider_auth_failed", "Provider auth did not return any available servers");
     }
 
     const account = persistProviderAuth({
@@ -94,7 +94,7 @@ providersRouter.post(
       || !Array.isArray(authResult.resources)
       || authResult.resources.length === 0
     ) {
-      throw new ApiError(502, "provider_auth_failed", "Provider auth did not return credentials");
+      throw new ApiError(502, "provider_auth_failed", "Provider auth did not return any available servers");
     }
 
     const account = persistProviderAuth({

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { ApiError, asyncHandler } from "../http/errors.js";
+import { requestUsesSecureTransport } from "../http/requestOrigin.js";
 import { getProvider } from "../providers/registry.js";
 import {
   deleteProviderSession,
@@ -31,6 +32,8 @@ sessionRouter.get(
 sessionRouter.delete("/", (req, res) => {
   setNoStore(res);
   deleteProviderSession(getRequestSessionId(req));
-  res.setHeader("Set-Cookie", getClearSessionCookieHeader());
+  res.setHeader("Set-Cookie", getClearSessionCookieHeader({
+    secure: requestUsesSecureTransport(req),
+  }));
   res.status(204).end();
 });

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -1,10 +1,10 @@
 import { Router } from "express";
 import { ApiError, asyncHandler } from "../http/errors.js";
-import { requestUsesSecureTransport } from "../http/requestOrigin.js";
 import { getProvider } from "../providers/registry.js";
 import {
   deleteProviderSession,
-  getClearSessionCookieHeader,
+  getSessionCookieClearOptions,
+  getSessionCookieName,
   getProviderSession,
 } from "../session/store.js";
 import { getRequestSessionId, setNoStore } from "../session/request.js";
@@ -32,8 +32,6 @@ sessionRouter.get(
 sessionRouter.delete("/", (req, res) => {
   setNoStore(res);
   deleteProviderSession(getRequestSessionId(req));
-  res.setHeader("Set-Cookie", getClearSessionCookieHeader({
-    secure: requestUsesSecureTransport(req),
-  }));
+  res.clearCookie(getSessionCookieName(), getSessionCookieClearOptions(req.secure));
   res.status(204).end();
 });

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -123,28 +123,23 @@ export function getSessionCookieName() {
   return SESSION_COOKIE;
 }
 
-function buildSessionCookie(value: string, maxAgeSeconds: number, secure: boolean) {
-  const attributes = [
-    `${SESSION_COOKIE}=${value}`,
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Strict",
-    `Max-Age=${maxAgeSeconds}`,
-  ];
-
-  if (secure) {
-    attributes.push("Secure");
-  }
-
-  return attributes.join("; ");
+export function getSessionCookieOptions(secure: boolean) {
+  return {
+    path: "/",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+    maxAge: SESSION_TTL_MS,
+  };
 }
 
-export function getSessionCookieHeader(sessionId: string, options: { secure: boolean }) {
-  return buildSessionCookie(sessionId, Math.floor(SESSION_TTL_MS / 1000), options.secure);
-}
-
-export function getClearSessionCookieHeader(options: { secure: boolean }) {
-  return buildSessionCookie("", 0, options.secure);
+export function getSessionCookieClearOptions(secure: boolean) {
+  return {
+    path: "/",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+  };
 }
 
 export function readCookie(cookieHeader: string | undefined, name: string) {

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -123,16 +123,28 @@ export function getSessionCookieName() {
   return SESSION_COOKIE;
 }
 
-export function getSessionCookieHeader(sessionId: string) {
-  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
-  return `${SESSION_COOKIE}=${sessionId}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${Math.floor(
-    SESSION_TTL_MS / 1000
-  )}${secure}`;
+function buildSessionCookie(value: string, maxAgeSeconds: number, secure: boolean) {
+  const attributes = [
+    `${SESSION_COOKIE}=${value}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    `Max-Age=${maxAgeSeconds}`,
+  ];
+
+  if (secure) {
+    attributes.push("Secure");
+  }
+
+  return attributes.join("; ");
 }
 
-export function getClearSessionCookieHeader() {
-  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
-  return `${SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0${secure}`;
+export function getSessionCookieHeader(sessionId: string, options: { secure: boolean }) {
+  return buildSessionCookie(sessionId, Math.floor(SESSION_TTL_MS / 1000), options.secure);
+}
+
+export function getClearSessionCookieHeader(options: { secure: boolean }) {
+  return buildSessionCookie("", 0, options.secure);
 }
 
 export function readCookie(cookieHeader: string | undefined, name: string) {

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -5,5 +5,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true
-  }
+  },
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -109,7 +109,6 @@ services:
       - -lc
       - corepack enable && pnpm install --frozen-lockfile && pnpm run dev:docker
     environment:
-      APP_URL: http://localhost:3000
       APP_KEY: cliparr-dev-only-not-secure-key-1234
       PORT: "3000"
       CLIPARR_DATA_DIR: /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      APP_URL: "http://localhost:3000"
       APP_KEY: "${APP_KEY:?APP_KEY is required}"
       PORT: "3000"
       CLIPARR_DATA_DIR: "/data"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm -r --if-present lint:eslint",
     "lint:types": "pnpm -r --if-present lint:types",
+    "test": "pnpm --filter @cliparr/server test",
     "knip": "knip",
     "preview": "pnpm --filter @cliparr/server preview",
     "start": "pnpm --filter @cliparr/server start",


### PR DESCRIPTION
Closes #38.

## Summary

Plex sign-in could fail when Cliparr was accessed over a plain HTTP custom domain because the app treated production installs as HTTPS-only.

In that state, the Plex PIN flow could complete successfully, but the browser would drop the session cookie and Cliparr would immediately fall back to:

> Sign in with a provider first

This change removes the static `APP_URL` dependency from the auth flow and instead derives provider callback URLs and browser security behavior from the actual incoming request origin.

## What changed

- derive the Plex callback URL from the current request origin
- trust reverse-proxy protocol headers so proxied HTTPS requests behave like HTTPS at the app layer
- set provider session cookies as `Secure` only when the current request is HTTPS
- only send cross-origin isolation headers for potentially trustworthy origins
- remove `APP_URL` from the documented runtime setup and Docker examples
- add regression coverage for HTTPS, localhost HTTP, loopback HTTP, and custom-domain HTTP requests
- run the new server tests in CI

## Why this fixes the issue

The failing part was not Plex authentication itself. The problem was that after auth completed, Cliparr created browser behavior as though every production install were HTTPS.

For plain HTTP custom-domain installs, that meant the session cookie was rejected and the next API request looked unauthenticated.

By deriving callback URLs, cookie policy, and isolation headers from the request origin instead:

- direct local/IP HTTP access continues to work
- plain HTTP custom-domain installs no longer advertise HTTPS-only browser policy they cannot satisfy
- HTTPS deployments behind Caddy, Nginx, Traefik, and similar reverse proxies stay strict as long as they forward the public protocol

## Upgrade Notes

This should not be a breaking change for standard reverse-proxy setups like Caddy, Nginx, or Traefik when they preserve `Host` and forward `X-Forwarded-Proto`.

Some existing proxy setups may need adjustment after this change:

- `APP_URL` is no longer used to drive Plex callback URLs or browser security behavior
- reverse proxies must preserve the public `Host` and forward `X-Forwarded-Proto`
- proxies that relied on `APP_URL` instead of forwarding the public request headers may generate the wrong callback URL or cookie policy after upgrade
- non-standard proxy topologies may need additional review

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm lint`
- `pnpm knip`
- `pnpm build`

------

The CPU fan on my server died. Give me another few days to test.
