### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a bug in Cliparr.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please share the basics below so we can triage the issue quickly.
+  - type: checkboxes
+    id: impacted-media-sources
+    attributes:
+      label: Impacted media sources
+      description: Which media source is affected?
+      options:
+        - label: Plex
+        - label: Jellyfin
+    validations:
+      required: true
+  - type: input
+    id: cliparr-version
+    attributes:
+      label: Cliparr version
+      description: What version of Cliparr are you running?
+      placeholder: ex. 0.2.0 or ghcr.io/techsquidtv/cliparr:latest
+    validations:
+      required: true
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser type and version
+      description: Which browser are you using, and what version is it?
+      placeholder: ex. Chrome 136, Firefox 138, Safari 18.4
+    validations:
+      required: true
+  - type: textarea
+    id: bug-summary
+    attributes:
+      label: What happened?
+      description: Tell us what went wrong.
+      placeholder: ex. The timeline loads, but exporting the clip fails after processing.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Share the shortest set of steps that reproduces the bug.
+      placeholder: |
+        1. Open Cliparr
+        2. Connect your media server
+        3. Load the currently playing item
+        4. Try to create or export a clip
+    validations:
+      required: true
+  - type: textarea
+    id: extra-details
+    attributes:
+      label: Extra details
+      description: Include errors, screenshots, or anything else that may help.
+      placeholder: Optional

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/discuss.yml
+++ b/.github/ISSUE_TEMPLATE/discuss.yml
@@ -1,0 +1,28 @@
+name: Discuss
+description: Share feedback, ask a question, or start a general discussion about Cliparr.
+title: "[Discuss]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for anything that does not fit the bug report or feature request templates.
+  - type: textarea
+    id: general-topic
+    attributes:
+      label: What would you like to share?
+      description: Tell us your question, feedback, note, or discussion topic.
+      placeholder: ex. I want to share feedback, ask a question, or mention something that does not fit the other forms.
+    validations:
+      required: true
+  - type: input
+    id: cliparr-version
+    attributes:
+      label: Cliparr version
+      description: If relevant, what version of Cliparr are you running?
+      placeholder: ex. 0.2.0 or ghcr.io/techsquidtv/cliparr:latest
+  - type: textarea
+    id: extra-details
+    attributes:
+      label: Extra details
+      description: Add any supporting details, screenshots, or links here if they are useful.
+      placeholder: Optional

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an improvement or new capability for Cliparr.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share the feature idea below and a little context about why it would help.
+  - type: textarea
+    id: feature-summary
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or improvement you want.
+      placeholder: ex. Add a quicker way to duplicate the current clip selection.
+    validations:
+      required: true
+  - type: textarea
+    id: problem-or-goal
+    attributes:
+      label: What problem would this solve?
+      description: Tell us what is hard today or what goal this would help you reach.
+      placeholder: ex. I often need to create several clips with similar timing, and repeating the same setup is slow.
+    validations:
+      required: true
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Extra context
+      description: Add mockups, examples, or any other details that may help.
+      placeholder: Optional
+


### PR DESCRIPTION
This pull request introduces standardized GitHub issue templates for the Cliparr project, making it easier for users to report bugs, request features, and start discussions. It also disables blank issues to ensure all submissions use a relevant template.

**New GitHub Issue Templates:**

* Added a bug report template to guide users in providing detailed information for troubleshooting, including media source selection, version details, browser info, and reproduction steps. (.github/ISSUE_TEMPLATE/bug_report.yml)
* Added a feature request template to collect suggestions for improvements or new capabilities, with prompts for feature description, problem statement, and extra context. (.github/ISSUE_TEMPLATE/feature_request.yml)
* Added a discussion template for general feedback, questions, or topics not covered by other templates, including fields for discussion topic and optional version/context details. (.github/ISSUE_TEMPLATE/discuss.yml)

**Repository Configuration:**

* Disabled blank issues to ensure all new issues use one of the provided templates. (.github/ISSUE_TEMPLATE/config.yml)