### PR TITLE
Keep prerelease Docker tags off latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,13 +41,17 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=beta,enable=${{ github.ref_type == 'tag' && contains(github.ref_name, '-beta.') }}
+            type=raw,value=rc,enable=${{ github.ref_type == 'tag' && contains(github.ref_name, '-rc.') }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Resolve app version
         id: version


### PR DESCRIPTION
## Summary
- disable automatic `latest` tagging in the Docker metadata workflow
- add explicit `beta` and `rc` channel tags for prerelease version tags
- only publish `latest` for stable release tags without a prerelease suffix

## Validation
- pnpm install --frozen-lockfile
- pnpm lint