### PR TITLE
chore: add Docker Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- add a weekly Docker Dependabot ecosystem entry for root Docker files
- keep npm and GitHub Actions Dependabot schedules unchanged

## Validation
- docker compose -f docker-compose.yml config
- docker compose -f docker-compose.dev.yml config