### PR TITLE
[codex] Add timeline zoom buttons

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -169,6 +169,10 @@ export default function EditorScreen({ session, onBack }: Props) {
     timelineViewportWidth,
     handleTimelineScroll,
     handleTimelineWheel,
+    handleTimelineZoomIn,
+    handleTimelineZoomOut,
+    canZoomIn,
+    canZoomOut,
     handleTimelineChange,
     handleTimelineActionMoveEnd,
     handleTimelineActionResizeEnd,
@@ -433,6 +437,10 @@ export default function EditorScreen({ session, onBack }: Props) {
                     handleTimelineActionMoveEnd={handleTimelineActionMoveEnd}
                     handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
                     handleTimelineWheel={handleTimelineWheel}
+                    handleTimelineZoomIn={handleTimelineZoomIn}
+                    handleTimelineZoomOut={handleTimelineZoomOut}
+                    canZoomIn={canZoomIn}
+                    canZoomOut={canZoomOut}
                     isValidTimelineRange={isValidTimelineRange}
                     seekToTime={seekToTime}
                     onCursorDragStart={() => {

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { RefObject, WheelEvent as ReactWheelEvent } from "react";
-import { Scissors } from "lucide-react";
+import { Scissors, ZoomIn, ZoomOut } from "lucide-react";
 import type { PlaybackReadyRange } from "./useEditorPlayback";
 import { 
   formatTime,
@@ -31,6 +31,10 @@ interface EditorTimelineProps {
   handleTimelineActionMoveEnd: (params: { action: { id: string }; start: number; end: number }) => void;
   handleTimelineActionResizeEnd: (params: { action: { id: string }; start: number; end: number }) => void;
   handleTimelineWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
+  handleTimelineZoomIn: () => void;
+  handleTimelineZoomOut: () => void;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
   isValidTimelineRange: (start: number, end: number) => boolean;
   seekToTime: (time: number) => Promise<void> | void;
   onCursorDragStart: () => void;
@@ -54,6 +58,10 @@ export function EditorTimeline({
   handleTimelineActionMoveEnd,
   handleTimelineActionResizeEnd,
   handleTimelineWheel,
+  handleTimelineZoomIn,
+  handleTimelineZoomOut,
+  canZoomIn,
+  canZoomOut,
   isValidTimelineRange,
   seekToTime,
   onCursorDragStart,
@@ -123,6 +131,28 @@ export function EditorTimeline({
       className="cliparr-timeline"
       onWheelCapture={handleTimelineWheel}
     >
+      <div className="cliparr-timeline-zoom-controls" aria-label="Timeline zoom controls">
+        <button
+          type="button"
+          onClick={handleTimelineZoomOut}
+          disabled={!canZoomOut}
+          className="cliparr-timeline-zoom-button"
+          aria-label="Zoom timeline out"
+          title="Zoom timeline out"
+        >
+          <ZoomOut className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={handleTimelineZoomIn}
+          disabled={!canZoomIn}
+          className="cliparr-timeline-zoom-button"
+          aria-label="Zoom timeline in"
+          title="Zoom timeline in"
+        >
+          <ZoomIn className="h-3.5 w-3.5" />
+        </button>
+      </div>
       <Timeline
         ref={timelineRef}
         editorData={timelineData}

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -203,6 +203,84 @@ export function useEditorTimeline({
     setTimelineScrollLeft(scrollLeft);
   }, []);
 
+  const updateTimelineZoom = useCallback((zoomDelta: number, anchorClientX?: number) => {
+    if (!hasDuration || availableTimelineZoomLevels.length < 2 || zoomDelta === 0) {
+      return;
+    }
+
+    const timelineWheelRegion = timelineWheelRegionRef.current;
+    if (!timelineWheelRegion) return;
+
+    const currentZoomIndex = timelineZoomIndexRef.current;
+    const currentTimelineScale = getTimelineZoomLevel(
+      availableTimelineZoomLevels,
+      currentZoomIndex,
+      activeTimelineScale,
+    );
+    const currentScrollLeft = pendingTimelineScrollLeftRef.current ?? timelineScrollLeftRef.current;
+    const nextZoomIndex = Math.min(
+      availableTimelineZoomLevels.length - 1,
+      Math.max(0, currentZoomIndex + Math.sign(zoomDelta)),
+    );
+    if (nextZoomIndex === currentZoomIndex) {
+      timelineWheelDeltaRef.current = 0;
+      return;
+    }
+
+    const nextTimelineScale = getTimelineZoomLevel(
+      availableTimelineZoomLevels,
+      nextZoomIndex,
+      currentTimelineScale,
+    );
+    const regionRect = timelineWheelRegion.getBoundingClientRect();
+    const pointerX = typeof anchorClientX === "number"
+      ? Math.min(Math.max(anchorClientX - regionRect.left, 0), regionRect.width)
+      : regionRect.width / 2;
+    const anchorPixel = Math.max(TIMELINE_START_LEFT, currentScrollLeft + pointerX);
+    const anchorTime = Math.min(
+      duration,
+      Math.max(
+        0,
+        timelinePixelToTime(
+          anchorPixel,
+          currentTimelineScale.scale,
+          currentTimelineScale.scaleWidth,
+          TIMELINE_START_LEFT,
+        ),
+      ),
+    );
+    const nextAnchorPixel = timelineTimeToPixel(
+      anchorTime,
+      nextTimelineScale.scale,
+      nextTimelineScale.scaleWidth,
+      TIMELINE_START_LEFT,
+    );
+    const nextMaxScrollLeft = getTimelineMaxScrollLeft(
+      duration,
+      nextTimelineScale.scale,
+      nextTimelineScale.scaleWidth,
+      regionRect.width,
+    );
+    const nextScrollLeft = Math.min(nextMaxScrollLeft, Math.max(0, nextAnchorPixel - pointerX));
+    pendingTimelineScrollLeftRef.current = nextScrollLeft;
+    timelineScrollLeftRef.current = nextScrollLeft;
+    setTimelineScrollLeft(nextScrollLeft);
+    timelineZoomIndexRef.current = nextZoomIndex;
+    hasUserAdjustedTimelineZoomRef.current = true;
+
+    startTransition(() => {
+      setTimelineZoomIndex(nextZoomIndex);
+    });
+  }, [activeTimelineScale, availableTimelineZoomLevels, duration, hasDuration]);
+
+  const handleTimelineZoomIn = useCallback(() => {
+    updateTimelineZoom(-1);
+  }, [updateTimelineZoom]);
+
+  const handleTimelineZoomOut = useCallback(() => {
+    updateTimelineZoom(1);
+  }, [updateTimelineZoom]);
+
   const handleTimelineWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
     if (!hasDuration) return;
 
@@ -255,67 +333,10 @@ export function useEditorTimeline({
     const accumulatedZoomDelta = Math.trunc(timelineWheelDeltaRef.current / TIMELINE_ZOOM_WHEEL_STEP);
     if (accumulatedZoomDelta === 0) return;
 
-    const currentZoomIndex = timelineZoomIndexRef.current;
-    const currentTimelineScale = getTimelineZoomLevel(
-      availableTimelineZoomLevels,
-      currentZoomIndex,
-      activeTimelineScale,
-    );
-    const currentScrollLeft = pendingTimelineScrollLeftRef.current ?? timelineScrollLeftRef.current;
     const zoomDelta = Math.sign(accumulatedZoomDelta);
     timelineWheelDeltaRef.current = 0;
-    const nextZoomIndex = Math.min(
-      availableTimelineZoomLevels.length - 1,
-      Math.max(0, currentZoomIndex + zoomDelta),
-    );
-    if (nextZoomIndex === currentZoomIndex) {
-      timelineWheelDeltaRef.current = 0;
-      return;
-    }
-
-    const nextTimelineScale = getTimelineZoomLevel(
-      availableTimelineZoomLevels,
-      nextZoomIndex,
-      currentTimelineScale,
-    );
-    const regionRect = timelineWheelRegion.getBoundingClientRect();
-    const pointerX = Math.min(Math.max(event.clientX - regionRect.left, 0), regionRect.width);
-    const anchorPixel = Math.max(TIMELINE_START_LEFT, currentScrollLeft + pointerX);
-    const anchorTime = Math.min(
-      duration,
-      Math.max(
-        0,
-        timelinePixelToTime(
-          anchorPixel,
-          currentTimelineScale.scale,
-          currentTimelineScale.scaleWidth,
-          TIMELINE_START_LEFT,
-        ),
-      ),
-    );
-    const nextAnchorPixel = timelineTimeToPixel(
-      anchorTime,
-      nextTimelineScale.scale,
-      nextTimelineScale.scaleWidth,
-      TIMELINE_START_LEFT,
-    );
-    const nextMaxScrollLeft = getTimelineMaxScrollLeft(
-      duration,
-      nextTimelineScale.scale,
-      nextTimelineScale.scaleWidth,
-      regionRect.width,
-    );
-    const nextScrollLeft = Math.min(nextMaxScrollLeft, Math.max(0, nextAnchorPixel - pointerX));
-    pendingTimelineScrollLeftRef.current = nextScrollLeft;
-    timelineScrollLeftRef.current = nextScrollLeft;
-    setTimelineScrollLeft(nextScrollLeft);
-    timelineZoomIndexRef.current = nextZoomIndex;
-    hasUserAdjustedTimelineZoomRef.current = true;
-
-    startTransition(() => {
-      setTimelineZoomIndex(nextZoomIndex);
-    });
-  }, [hasDuration, duration, activeTimelineScale, availableTimelineZoomLevels]);
+    updateTimelineZoom(zoomDelta, event.clientX);
+  }, [hasDuration, duration, activeTimelineScale, availableTimelineZoomLevels, updateTimelineZoom]);
 
   const handleTimelineChange = useCallback((nextData: ClipTimelineData) => {
     const nextAction = nextData
@@ -373,6 +394,10 @@ export function useEditorTimeline({
     timelineViewportWidth,
     handleTimelineScroll,
     handleTimelineWheel,
+    handleTimelineZoomIn,
+    handleTimelineZoomOut,
+    canZoomIn: hasDuration && timelineZoomIndex > 0,
+    canZoomOut: hasDuration && timelineZoomIndex < availableTimelineZoomLevels.length - 1,
     handleTimelineChange,
     handleTimelineActionMoveEnd,
     handleTimelineActionResizeEnd,

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -198,6 +198,45 @@
     width: 100%;
   }
 
+  .cliparr-timeline-zoom-controls {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: color-mix(in oklch, var(--background) 92%, transparent);
+  }
+
+  .cliparr-timeline-zoom-button {
+    display: flex;
+    width: 26px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted-foreground);
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      opacity 150ms ease;
+  }
+
+  .cliparr-timeline-zoom-button + .cliparr-timeline-zoom-button {
+    border-left: 1px solid var(--border);
+  }
+
+  .cliparr-timeline-zoom-button:hover:not(:disabled) {
+    background: var(--accent);
+    color: var(--foreground);
+  }
+
+  .cliparr-timeline-zoom-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
   .cliparr-timeline .timeline-editor {
     width: 100%;
     height: 154px;


### PR DESCRIPTION
## Summary
- add timeline zoom in and zoom out icon buttons using Lucide icons
- reuse the existing timeline zoom behavior for wheel and button controls
- add disabled button states at minimum and maximum zoom

## Validation
- pnpm --filter @cliparr/frontend lint
- Started the frontend and confirmed it loads, but local editor verification was blocked because the API server was not running