### PR TITLE
[codex] Set app build version from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Resolve app version
+        run: |
+          ref_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          echo "CLIPARR_VERSION=${ref_name}@${GITHUB_SHA::7}" >> "${GITHUB_ENV}"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,10 +56,8 @@ jobs:
       - name: Resolve app version
         id: version
         run: |
-          version="0.0.0"
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          fi
+          ref_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          version="${ref_name}@${GITHUB_SHA::7}"
           echo "value=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push Docker image

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -151,7 +151,7 @@ export default function DashboardScreen({ onSelectSession, onOpenSources, onLogo
   const emptyMessage = sourceErrors.length > 0
     ? "No active playback was found on the sources that responded."
     : "No one is currently watching anything.";
-  const versionLabel = appVersion ? `v${appVersion}` : "";
+  const versionLabel = appVersion;
 
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">

--- a/apps/server/src/config/version.test.ts
+++ b/apps/server/src/config/version.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveCliparrVersion } from "./version.js";
+
+void test("uses CI build identity exactly as provided", () => {
+  assert.equal(
+    resolveCliparrVersion({
+      CLIPARR_VERSION: "main@abc1234",
+    }),
+    "main@abc1234"
+  );
+});
+
+void test("preserves release tags as display-ready values", () => {
+  assert.equal(
+    resolveCliparrVersion({
+      CLIPARR_VERSION: "v0.4.0",
+    }),
+    "v0.4.0"
+  );
+});
+
+void test("falls back to the package version when environment values are empty", () => {
+  assert.equal(
+    resolveCliparrVersion({
+      CLIPARR_VERSION: " ",
+      npm_package_version: "",
+    }),
+    "0.4.0"
+  );
+});

--- a/apps/server/src/config/version.ts
+++ b/apps/server/src/config/version.ts
@@ -11,9 +11,7 @@ function normalizeVersion(value: string | undefined) {
     return undefined;
   }
 
-  return normalized.startsWith("v") && /^\d/.test(normalized.slice(1))
-    ? normalized.slice(1)
-    : normalized;
+  return normalized;
 }
 
 function readPackageVersion() {
@@ -28,8 +26,13 @@ function readPackageVersion() {
   }
 }
 
-export const CLIPARR_VERSION =
-  normalizeVersion(process.env.CLIPARR_VERSION) ??
-  normalizeVersion(process.env.npm_package_version) ??
-  readPackageVersion() ??
-  "0.0.0";
+export function resolveCliparrVersion(env: NodeJS.ProcessEnv = process.env) {
+  return (
+    normalizeVersion(env.CLIPARR_VERSION) ??
+    normalizeVersion(env.npm_package_version) ??
+    readPackageVersion() ??
+    "0.0.0"
+  );
+}
+
+export const CLIPARR_VERSION = resolveCliparrVersion();


### PR DESCRIPTION
## Summary
- set CI and Docker app-visible versions from the current ref and short SHA
- preserve CLIPARR_VERSION as a display-ready value from /api/health
- show the server-provided dashboard version label directly
- add server tests for CI build labels, release tags, and package fallback

## Validation
- pnpm lint
- pnpm test
- pnpm build
- git diff --check