### PR TITLE
[codex] Fix release tag version display

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,8 +56,12 @@ jobs:
       - name: Resolve app version
         id: version
         run: |
-          ref_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          version="${ref_name}@${GITHUB_SHA::7}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            ref_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+            version="${ref_name}@${GITHUB_SHA::7}"
+          fi
           echo "value=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- display release tag builds as the tag name only
- keep branch and PR builds on the existing ref@sha format

## Root cause
The Docker workflow always set CLIPARR_VERSION to ref@sha, including release tag builds, so a v0.4.0 image displayed as v0.4.0@9f5d257.

## Validation
- Simulated tag, branch, and PR version resolution locally
- Ran git diff --check