### PR TITLE
[codex] Restore provider sessions from saved auth

### DIFF
--- a/apps/server/drizzle/20260524172137_remembered_provider_sessions/migration.sql
+++ b/apps/server/drizzle/20260524172137_remembered_provider_sessions/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `remembered_provider_sessions` (
+	`id` text PRIMARY KEY,
+	`provider_account_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`expires_at` integer NOT NULL,
+	`revoked_at` integer,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	CONSTRAINT `fk_remembered_provider_sessions_provider_account_id_provider_accounts_id_fk` FOREIGN KEY (`provider_account_id`) REFERENCES `provider_accounts`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remembered_provider_sessions_token_hash_idx` ON `remembered_provider_sessions` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `remembered_provider_sessions_provider_account_id_idx` ON `remembered_provider_sessions` (`provider_account_id`);--> statement-breakpoint
+CREATE INDEX `remembered_provider_sessions_expires_at_idx` ON `remembered_provider_sessions` (`expires_at`);

--- a/apps/server/drizzle/20260524172137_remembered_provider_sessions/snapshot.json
+++ b/apps/server/drizzle/20260524172137_remembered_provider_sessions/snapshot.json
@@ -1,0 +1,648 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "72cf1bff-c329-43f8-9122-c57650329b74",
+  "prevIds": [
+    "5cb53d7c-208f-412f-8544-99f25f221859"
+  ],
+  "ddl": [
+    {
+      "name": "media_sources",
+      "entityType": "tables"
+    },
+    {
+      "name": "provider_accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "provider_sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "remembered_provider_sessions",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_account_id",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "base_url",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "connection_json",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "credentials_json",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata_json",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_checked_at",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_error",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "media_sources"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "label",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_hash",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata_json",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "provider_accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_account_id",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_token",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_account_id",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "columns": [
+        "provider_account_id"
+      ],
+      "tableTo": "provider_accounts",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_media_sources_provider_account_id_provider_accounts_id_fk",
+      "entityType": "fks",
+      "table": "media_sources"
+    },
+    {
+      "columns": [
+        "provider_account_id"
+      ],
+      "tableTo": "provider_accounts",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_provider_sessions_provider_account_id_provider_accounts_id_fk",
+      "entityType": "fks",
+      "table": "provider_sessions"
+    },
+    {
+      "columns": [
+        "provider_account_id"
+      ],
+      "tableTo": "provider_accounts",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_remembered_provider_sessions_provider_account_id_provider_accounts_id_fk",
+      "entityType": "fks",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "media_sources_pk",
+      "table": "media_sources",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "provider_accounts_pk",
+      "table": "provider_accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "provider_sessions_pk",
+      "table": "provider_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "remembered_provider_sessions_pk",
+      "table": "remembered_provider_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "enabled",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "media_sources_enabled_idx",
+      "entityType": "indexes",
+      "table": "media_sources"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "media_sources_provider_id_idx",
+      "entityType": "indexes",
+      "table": "media_sources"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_account_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "media_sources_provider_account_id_idx",
+      "entityType": "indexes",
+      "table": "media_sources"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider_account_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "media_sources_provider_external_id_idx",
+      "entityType": "indexes",
+      "table": "media_sources"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "provider_accounts_provider_id_idx",
+      "entityType": "indexes",
+      "table": "provider_accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false
+        },
+        {
+          "value": "access_token_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"provider_accounts\".\"access_token_hash\" IS NOT NULL",
+      "origin": "manual",
+      "name": "provider_accounts_provider_access_token_hash_idx",
+      "entityType": "indexes",
+      "table": "provider_accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "provider_sessions_provider_id_idx",
+      "entityType": "indexes",
+      "table": "provider_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_account_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "provider_sessions_provider_account_id_idx",
+      "entityType": "indexes",
+      "table": "provider_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "provider_sessions_expires_at_idx",
+      "entityType": "indexes",
+      "table": "provider_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "remembered_provider_sessions_token_hash_idx",
+      "entityType": "indexes",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "provider_account_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "remembered_provider_sessions_provider_account_id_idx",
+      "entityType": "indexes",
+      "table": "remembered_provider_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "remembered_provider_sessions_expires_at_idx",
+      "entityType": "indexes",
+      "table": "remembered_provider_sessions"
+    }
+  ],
+  "renames": []
+}

--- a/apps/server/src/db/migrationState.ts
+++ b/apps/server/src/db/migrationState.ts
@@ -4,6 +4,7 @@ const APP_TABLE_NAMES = [
   "provider_accounts",
   "media_sources",
   "provider_sessions",
+  "remembered_provider_sessions",
 ] as const;
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 const LEGACY_MIGRATIONS_TABLE = "schema_migrations";

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -4,7 +4,7 @@ import { getDatabase } from "./database.js";
 import { providerAccounts, type ProviderAccountRow } from "./schema.js";
 import { decryptSecret, encryptSecret, hashSecret } from "../security/secrets.js";
 
-interface ProviderAccount {
+export interface ProviderAccount {
   id: string;
   providerId: string;
   label: string;
@@ -82,7 +82,7 @@ function updateProviderAccount(id: string, input: UpdateProviderAccountInput) {
   return getProviderAccount(id);
 }
 
-function getProviderAccount(id: string) {
+export function getProviderAccount(id: string) {
   const row = getDatabase()
     .select()
     .from(providerAccounts)

--- a/apps/server/src/db/rememberedProviderSessionsRepository.ts
+++ b/apps/server/src/db/rememberedProviderSessionsRepository.ts
@@ -1,0 +1,96 @@
+import { randomBytes, randomUUID } from "crypto";
+import { eq, sql } from "drizzle-orm";
+import { getDatabase } from "./database.js";
+import { rememberedProviderSessions, type RememberedProviderSessionRow } from "./schema.js";
+import { hashSecret } from "../security/secrets.js";
+
+export const REMEMBERED_PROVIDER_SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 365;
+
+export interface RememberedProviderSession {
+  id: string;
+  providerAccountId: string;
+  createdAt: number;
+  expiresAt: number;
+  revokedAt?: number;
+}
+
+export interface CreatedRememberedProviderSession extends RememberedProviderSession {
+  token: string;
+}
+
+function createRememberToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+function mapRememberedProviderSession(row: RememberedProviderSessionRow): RememberedProviderSession {
+  return {
+    id: row.id,
+    providerAccountId: row.providerAccountId,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    revokedAt: row.revokedAt ?? undefined,
+  };
+}
+
+export function createRememberedProviderSession(providerAccountId: string): CreatedRememberedProviderSession {
+  const now = Date.now();
+  const id = randomUUID();
+  const token = createRememberToken();
+  const expiresAt = now + REMEMBERED_PROVIDER_SESSION_TTL_MS;
+
+  getDatabase()
+    .insert(rememberedProviderSessions)
+    .values({
+      id,
+      providerAccountId,
+      tokenHash: hashSecret(token),
+      createdAt: now,
+      expiresAt,
+      revokedAt: null,
+    })
+    .run();
+
+  return {
+    id,
+    providerAccountId,
+    token,
+    createdAt: now,
+    expiresAt,
+  };
+}
+
+export function getRememberedProviderSession(token?: string) {
+  if (!token) {
+    return undefined;
+  }
+
+  const row = getDatabase()
+    .select()
+    .from(rememberedProviderSessions)
+    .where(eq(rememberedProviderSessions.tokenHash, hashSecret(token)))
+    .get();
+
+  if (!row || row.revokedAt != null || row.expiresAt <= Date.now()) {
+    return undefined;
+  }
+
+  return mapRememberedProviderSession(row);
+}
+
+export function revokeRememberedProviderSession(token?: string) {
+  if (!token) {
+    return false;
+  }
+
+  const now = Date.now();
+  const result = getDatabase()
+    .update(rememberedProviderSessions)
+    .set({
+      revokedAt: now,
+      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+    })
+    .where(eq(rememberedProviderSessions.tokenHash, hashSecret(token)))
+    .run();
+
+  return result.changes > 0;
+}

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -68,6 +68,25 @@ export const providerSessions = sqliteTable(
   ]
 );
 
+export const rememberedProviderSessions = sqliteTable(
+  "remembered_provider_sessions",
+  {
+    id: text("id").primaryKey(),
+    providerAccountId: text("provider_account_id").notNull().references(() => providerAccounts.id, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    createdAt: integer("created_at").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+    revokedAt: integer("revoked_at"),
+    updatedAt: text("updated_at").notNull().default(nowIso),
+  },
+  (table) => [
+    uniqueIndex("remembered_provider_sessions_token_hash_idx").on(table.tokenHash),
+    index("remembered_provider_sessions_provider_account_id_idx").on(table.providerAccountId),
+    index("remembered_provider_sessions_expires_at_idx").on(table.expiresAt),
+  ]
+);
+
 export type ProviderAccountRow = typeof providerAccounts.$inferSelect;
 export type MediaSourceRow = typeof mediaSources.$inferSelect;
 export type ProviderSessionRow = typeof providerSessions.$inferSelect;
+export type RememberedProviderSessionRow = typeof rememberedProviderSessions.$inferSelect;

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -1,10 +1,13 @@
 import { Router } from "express";
 import { persistProviderAuth } from "../db/providerPersistence.js";
+import { createRememberedProviderSession } from "../db/rememberedProviderSessionsRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getRequestRouteUrl } from "../http/requestOrigin.js";
 import { getProvider, listProviders } from "../providers/registry.js";
 import {
   createProviderSession,
+  getRememberedProviderSessionCookieName,
+  getRememberedProviderSessionCookieOptions,
   getSessionCookieName,
   getSessionCookieOptions,
 } from "../session/store.js";
@@ -70,7 +73,14 @@ providersRouter.get(
       userToken: authStatus.userToken,
     });
 
+    const rememberedSession = createRememberedProviderSession(session.providerAccountId);
+
     res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
+    res.cookie(
+      getRememberedProviderSessionCookieName(),
+      rememberedSession.token,
+      getRememberedProviderSessionCookieOptions(req.secure)
+    );
     res.json({ status: "complete" });
   })
 );
@@ -109,7 +119,14 @@ providersRouter.post(
       userToken: authResult.userToken,
     });
 
+    const rememberedSession = createRememberedProviderSession(session.providerAccountId);
+
     res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
+    res.cookie(
+      getRememberedProviderSessionCookieName(),
+      rememberedSession.token,
+      getRememberedProviderSessionCookieOptions(req.secure)
+    );
     res.json({
       session: provider.serializeSession(session),
     });

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -1,11 +1,22 @@
 import { Router } from "express";
+import {
+  createRememberedProviderSession,
+  getRememberedProviderSession,
+  revokeRememberedProviderSession,
+} from "../db/rememberedProviderSessionsRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getProvider } from "../providers/registry.js";
 import {
   deleteProviderSession,
+  getRememberedProviderSessionCookieClearOptions,
+  getRememberedProviderSessionCookieName,
+  getRememberedProviderSessionCookieOptions,
   getSessionCookieClearOptions,
   getSessionCookieName,
+  getSessionCookieOptions,
   getProviderSession,
+  readCookie,
+  restoreProviderSessionFromProviderAccount,
 } from "../session/store.js";
 import { getRequestSessionId, setNoStore } from "../session/request.js";
 
@@ -15,8 +26,21 @@ sessionRouter.get(
   "/",
   asyncHandler(async (req, res) => {
     setNoStore(res);
-    const session = getProviderSession(getRequestSessionId(req));
+    const rememberedToken = readCookie(
+      req.header("cookie"),
+      getRememberedProviderSessionCookieName()
+    );
+    const rememberedSession = getRememberedProviderSession(rememberedToken);
+    const session = getProviderSession(getRequestSessionId(req))
+      ?? restoreProviderSessionFromProviderAccount(rememberedSession?.providerAccountId);
     if (!session) {
+      if (rememberedToken) {
+        revokeRememberedProviderSession(rememberedToken);
+        res.clearCookie(
+          getRememberedProviderSessionCookieName(),
+          getRememberedProviderSessionCookieClearOptions(req.secure)
+        );
+      }
       throw new ApiError(401, "not_authenticated", "Sign in with a provider first");
     }
 
@@ -25,13 +49,37 @@ sessionRouter.get(
       throw new ApiError(500, "provider_not_registered", "Session provider is not registered");
     }
 
+    const rememberedSessionMatches = rememberedSession?.providerAccountId === session.providerAccountId;
+    const nextRememberedSession = rememberedSessionMatches
+      ? undefined
+      : createRememberedProviderSession(session.providerAccountId);
+    if (rememberedToken && rememberedSession && !rememberedSessionMatches) {
+      revokeRememberedProviderSession(rememberedToken);
+    }
+
+    res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
+    if (nextRememberedSession) {
+      res.cookie(
+        getRememberedProviderSessionCookieName(),
+        nextRememberedSession.token,
+        getRememberedProviderSessionCookieOptions(req.secure)
+      );
+    }
     res.json({ session: provider.serializeSession(session) });
   })
 );
 
 sessionRouter.delete("/", (req, res) => {
   setNoStore(res);
+  revokeRememberedProviderSession(readCookie(
+    req.header("cookie"),
+    getRememberedProviderSessionCookieName()
+  ));
   deleteProviderSession(getRequestSessionId(req));
   res.clearCookie(getSessionCookieName(), getSessionCookieClearOptions(req.secure));
+  res.clearCookie(
+    getRememberedProviderSessionCookieName(),
+    getRememberedProviderSessionCookieClearOptions(req.secure)
+  );
   res.status(204).end();
 });

--- a/apps/server/src/session/store.test.ts
+++ b/apps/server/src/session/store.test.ts
@@ -1,0 +1,322 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const TEST_APP_KEY = "session-store-test-key-with-at-least-32-characters";
+const MISMATCHED_APP_KEY = "session-store-test-key-with-a-different-32-char-secret";
+
+const appModuleUrl = new URL("../app.js", import.meta.url).href;
+const databaseModuleUrl = new URL("../db/database.js", import.meta.url).href;
+const providerAccountsRepositoryModuleUrl = new URL("../db/providerAccountsRepository.js", import.meta.url).href;
+const rememberedProviderSessionsRepositoryModuleUrl = new URL(
+  "../db/rememberedProviderSessionsRepository.js",
+  import.meta.url
+).href;
+const storeModuleUrl = new URL("./store.js", import.meta.url).href;
+
+function runStoreScript(script: string, options: {
+  dataDir: string;
+  appKey?: string;
+}) {
+  const child = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        APP_KEY: options.appKey ?? TEST_APP_KEY,
+        CLIPARR_DATA_DIR: options.dataDir,
+      },
+      encoding: "utf8",
+    }
+  );
+
+  assert.equal(
+    child.status,
+    0,
+    `child process failed with status ${child.status}\nstdout:\n${child.stdout}\nstderr:\n${child.stderr}`
+  );
+  assert.equal(child.signal, null);
+
+  return child.stdout.trim();
+}
+
+void test("restores a provider session from an opaque remembered provider session token", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-session-store-"));
+
+  try {
+    runStoreScript(`
+      import assert from "node:assert/strict";
+
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const {
+        createRememberedProviderSession,
+        getRememberedProviderSession,
+        revokeRememberedProviderSession,
+      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      const { restoreProviderSessionFromProviderAccount } = await import(${JSON.stringify(storeModuleUrl)});
+
+      try {
+        initializeDatabase();
+
+        const account = upsertProviderAccountByAccessToken({
+          providerId: "plex",
+          label: "Plex Account",
+          accessToken: "persisted-user-token",
+        });
+
+        assert(account);
+
+        const rememberedSession = createRememberedProviderSession(account.id);
+        assert.notEqual(rememberedSession.token, account.id);
+        assert.equal(rememberedSession.providerAccountId, account.id);
+
+        const matchedRememberedSession = getRememberedProviderSession(rememberedSession.token);
+        assert(matchedRememberedSession);
+        assert.equal(matchedRememberedSession.providerAccountId, account.id);
+
+        const restoredSession = restoreProviderSessionFromProviderAccount(
+          matchedRememberedSession.providerAccountId
+        );
+
+        assert(restoredSession);
+        assert.equal(restoredSession.providerId, "plex");
+        assert.equal(restoredSession.providerAccountId, account.id);
+        assert.equal(restoredSession.userToken, "persisted-user-token");
+
+        assert.equal(revokeRememberedProviderSession(rememberedSession.token), true);
+        assert.equal(getRememberedProviderSession(rememberedSession.token), undefined);
+      } finally {
+        closeDatabase();
+      }
+    `, { dataDir });
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+void test("remembered provider session tokens are not reusable after APP_KEY changes", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-session-store-"));
+
+  try {
+    const token = runStoreScript(`
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+
+      try {
+        initializeDatabase();
+
+        const account = upsertProviderAccountByAccessToken({
+          providerId: "plex",
+          label: "Plex Account",
+          accessToken: "persisted-user-token",
+        });
+
+        const rememberedSession = createRememberedProviderSession(account.id);
+        console.log(rememberedSession.token);
+      } finally {
+        closeDatabase();
+      }
+    `, { dataDir });
+
+    runStoreScript(`
+      import assert from "node:assert/strict";
+
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { getRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+
+      try {
+        initializeDatabase();
+        assert.equal(getRememberedProviderSession(${JSON.stringify(token)}), undefined);
+      } finally {
+        closeDatabase();
+      }
+    `, {
+      dataDir,
+      appKey: MISMATCHED_APP_KEY,
+    });
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+void test("restores /api/session from a remembered provider session cookie", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-session-route-"));
+
+  try {
+    runStoreScript(`
+      import assert from "node:assert/strict";
+
+      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      const { getRememberedProviderSessionCookieName, getSessionCookieName } = await import(${JSON.stringify(storeModuleUrl)});
+
+      const { app } = await createApp();
+      const server = app.listen(0, "127.0.0.1");
+
+      try {
+        await new Promise((resolve) => server.once("listening", resolve));
+        const address = server.address();
+        assert(address && typeof address === "object");
+
+        const account = upsertProviderAccountByAccessToken({
+          providerId: "plex",
+          label: "Plex Account",
+          accessToken: "persisted-user-token",
+        });
+        assert(account);
+
+        const rememberedSession = createRememberedProviderSession(account.id);
+        const response = await fetch(
+          \`http://127.0.0.1:\${address.port}/api/session\`,
+          {
+            headers: {
+              cookie: \`\${getRememberedProviderSessionCookieName()}=\${rememberedSession.token}\`,
+            },
+          }
+        );
+
+        assert.equal(response.status, 200);
+        const body = await response.json();
+        assert.equal(body.session.providerId, "plex");
+
+        const setCookies = response.headers.getSetCookie();
+        assert(setCookies.some((cookie) => cookie.startsWith(\`\${getSessionCookieName()}=\`)));
+        assert(!setCookies.some((cookie) => cookie.startsWith(\`\${getRememberedProviderSessionCookieName()}=\`)));
+      } finally {
+        await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve(undefined)));
+        closeDatabase();
+      }
+    `, { dataDir });
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+void test("clears invalid remembered provider session cookies from /api/session", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-session-route-"));
+
+  try {
+    runStoreScript(`
+      import assert from "node:assert/strict";
+
+      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { getRememberedProviderSessionCookieName } = await import(${JSON.stringify(storeModuleUrl)});
+
+      const { app } = await createApp();
+      const server = app.listen(0, "127.0.0.1");
+
+      try {
+        await new Promise((resolve) => server.once("listening", resolve));
+        const address = server.address();
+        assert(address && typeof address === "object");
+
+        const response = await fetch(
+          \`http://127.0.0.1:\${address.port}/api/session\`,
+          {
+            headers: {
+              cookie: \`\${getRememberedProviderSessionCookieName()}=invalid-token\`,
+            },
+          }
+        );
+
+        assert.equal(response.status, 401);
+        const setCookies = response.headers.getSetCookie();
+        assert(setCookies.some((cookie) =>
+          cookie.startsWith(\`\${getRememberedProviderSessionCookieName()}=\`)
+          && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+        ));
+      } finally {
+        await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve(undefined)));
+        closeDatabase();
+      }
+    `, { dataDir });
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+void test("logout revokes the remembered provider session token", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-session-route-"));
+
+  try {
+    runStoreScript(`
+      import assert from "node:assert/strict";
+
+      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const {
+        createRememberedProviderSession,
+        getRememberedProviderSession,
+      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      const {
+        createProviderSession,
+        getRememberedProviderSessionCookieName,
+        getSessionCookieName,
+      } = await import(${JSON.stringify(storeModuleUrl)});
+
+      const { app } = await createApp();
+      const server = app.listen(0, "127.0.0.1");
+
+      try {
+        await new Promise((resolve) => server.once("listening", resolve));
+        const address = server.address();
+        assert(address && typeof address === "object");
+
+        const account = upsertProviderAccountByAccessToken({
+          providerId: "plex",
+          label: "Plex Account",
+          accessToken: "persisted-user-token",
+        });
+        assert(account);
+
+        const session = createProviderSession({
+          providerId: "plex",
+          providerAccountId: account.id,
+          userToken: "persisted-user-token",
+        });
+        const rememberedSession = createRememberedProviderSession(account.id);
+        const response = await fetch(
+          \`http://127.0.0.1:\${address.port}/api/session\`,
+          {
+            method: "DELETE",
+            headers: {
+              cookie: [
+                \`\${getSessionCookieName()}=\${session.id}\`,
+                \`\${getRememberedProviderSessionCookieName()}=\${rememberedSession.token}\`,
+              ].join("; "),
+            },
+          }
+        );
+
+        assert.equal(response.status, 204);
+        assert.equal(getRememberedProviderSession(rememberedSession.token), undefined);
+
+        const setCookies = response.headers.getSetCookie();
+        assert(setCookies.some((cookie) =>
+          cookie.startsWith(\`\${getSessionCookieName()}=\`)
+          && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+        ));
+        assert(setCookies.some((cookie) =>
+          cookie.startsWith(\`\${getRememberedProviderSessionCookieName()}=\`)
+          && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+        ));
+      } finally {
+        await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve(undefined)));
+        closeDatabase();
+      }
+    `, { dataDir });
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,12 +1,15 @@
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
 import { getDatabase } from "../db/database.js";
+import { getProviderAccount } from "../db/providerAccountsRepository.js";
+import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "../db/rememberedProviderSessionsRepository.js";
 import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
-import { getServerLogger } from "../logging.js";
+import { getServerLogger, serializeError } from "../logging.js";
 import type { MediaHandle } from "../providers/types.js";
 import { decryptSecret, encryptSecret } from "../security/secrets.js";
 
 const SESSION_COOKIE = "cliparr_session";
+const REMEMBERED_PROVIDER_SESSION_COOKIE = "cliparr_remember";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 12;
 const MEDIA_HANDLE_IDLE_TTL_MS = 1000 * 60 * 15;
 const logger = getServerLogger(["session", "store"]);
@@ -99,6 +102,30 @@ export function getProviderSession(sessionId?: string) {
   return mapProviderSession(row);
 }
 
+export function restoreProviderSessionFromProviderAccount(providerAccountId?: string) {
+  if (!providerAccountId) {
+    return undefined;
+  }
+
+  try {
+    const account = getProviderAccount(providerAccountId);
+    if (!account?.accessToken) {
+      return undefined;
+    }
+
+    return createProviderSession({
+      providerId: account.providerId,
+      providerAccountId: account.id,
+      userToken: account.accessToken,
+    });
+  } catch (err) {
+    logger.warn("Failed to restore provider session from remembered provider account.", {
+      ...serializeError(err),
+    });
+    return undefined;
+  }
+}
+
 export function pruneSessionMediaHandles(session: ProviderSessionRecord, maxIdleMs = MEDIA_HANDLE_IDLE_TTL_MS) {
   const cutoff = Date.now() - maxIdleMs;
   let prunedCount = 0;
@@ -141,6 +168,10 @@ export function getSessionCookieName() {
   return SESSION_COOKIE;
 }
 
+export function getRememberedProviderSessionCookieName() {
+  return REMEMBERED_PROVIDER_SESSION_COOKIE;
+}
+
 export function getSessionCookieOptions(secure: boolean) {
   return {
     path: "/",
@@ -151,7 +182,26 @@ export function getSessionCookieOptions(secure: boolean) {
   };
 }
 
+export function getRememberedProviderSessionCookieOptions(secure: boolean) {
+  return {
+    path: "/",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+    maxAge: REMEMBERED_PROVIDER_SESSION_TTL_MS,
+  };
+}
+
 export function getSessionCookieClearOptions(secure: boolean) {
+  return {
+    path: "/",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+  };
+}
+
+export function getRememberedProviderSessionCookieClearOptions(secure: boolean) {
   return {
     path: "/",
     httpOnly: true,


### PR DESCRIPTION
## Summary
- add a `remembered_provider_sessions` table for long-lived remember tokens
- store only hashed opaque remember tokens server-side and keep the raw token in an HTTP-only cookie
- restore a fresh app session from persisted provider auth when the short session cookie is missing or expired
- revoke remembered tokens on logout and clear invalid remember cookies
- add server tests for token restore, APP_KEY invalidation, route restore, invalid-cookie clearing, and logout revocation

## Root Cause
Cliparr persisted Plex/Jellyfin credentials, but `/api/session` only trusted the short-lived `cliparr_session` row and cookie. Once that 12-hour app session expired, the frontend received `not_authenticated` and sent users back through provider auth even though saved provider credentials were still available.

## Impact
Returning users can reload Cliparr without re-authorizing Plex or Jellyfin. Existing valid sessions will receive an opaque remember token on their next `/api/session` request; users whose old session already expired may need one final reconnect.

## Validation
- `pnpm --filter @cliparr/server test`
- `pnpm lint`
