### PR TITLE
[codex] fix hls duration and subtitle export

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -559,7 +559,7 @@ export default function EditorScreen({ session, onBack }: Props) {
         selectedAudioTrack: session.selectedAudioTrack,
         metadata: session.exportMetadata,
         includeBurnedSubtitles: shouldBurnSubtitles,
-        subtitleCues: clippedSubtitleCues,
+        subtitleCues,
         subtitleStyleSettings,
         onProgress: setProgress,
       });
@@ -592,6 +592,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     session.exportMetadata,
     session.selectedAudioTrack,
     startTime,
+    subtitleCues,
     subtitleEnabled,
     subtitleLoading,
     subtitleStyleSettings,

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -168,6 +168,25 @@ function samePlaybackRange(
   );
 }
 
+function finiteNonNegativeDuration(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function resolvePlaybackDuration(
+  playbackSource: PlaybackSourceCandidate,
+  computedDuration: number,
+  initialDuration: number,
+) {
+  const fallbackDuration = finiteNonNegativeDuration(initialDuration);
+  const normalizedComputedDuration = finiteNonNegativeDuration(computedDuration);
+
+  if (playbackSource.label === "hls stream") {
+    return Math.max(fallbackDuration, normalizedComputedDuration);
+  }
+
+  return normalizedComputedDuration || fallbackDuration;
+}
+
 function buildPlaybackLoadError(failures: PlaybackLoadFailure[]) {
   if (failures.length === 0) {
     return "Playback could not be loaded.";
@@ -1563,10 +1582,12 @@ export function useEditorPlayback({
                   isLivePlayback ? { skipLiveWait: true } : undefined
                 )
               : Math.max(initialDuration, 0);
-            const nextDuration = Math.max(
-              0,
-              fromSourceTimelineTime(sourceTimelineEnd, timelineOffsetSeconds)
-            ) || Math.max(initialDuration, 0);
+            const computedDuration = fromSourceTimelineTime(sourceTimelineEnd, timelineOffsetSeconds);
+            const nextDuration = resolvePlaybackDuration(
+              playbackSource,
+              computedDuration,
+              initialDuration,
+            );
             setDuration(nextDuration);
             durationRef.current = nextDuration;
             setCurrentTime(0);


### PR DESCRIPTION
## Summary

- Keep provider item duration as the floor when HLS playlist metadata reports a shorter window.
- Pass original subtitle cues into export so burn-in trimming happens exactly once.

## Root Cause

Plex HLS playlist metadata can describe only the current transcode or buffered window. The editor replaced the full provider duration with that shorter value. Subtitle export also received already-trimmed cues, then exportClip trimmed them a second time, dropping cues for non-zero clip starts.

## Validation

- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/frontend lint:eslint
- pnpm --filter @cliparr/frontend build