### PR TITLE
[codex] Refactor frontend editor workflows

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -3,7 +3,38 @@
 This file captures the current HLS playback, preview-ready warmup, export, and
 proxy decision trees. It reflects the stable branch behavior after the fallback,
 timeline normalization, alternate track selection, playlist rewrite, proxy
-auth/cache handling, and export memory fixes.
+auth/cache handling, export memory fixes, and the frontend refactor that split
+large editor workflows into focused hooks/helpers.
+
+## Frontend Responsibility Map
+
+```mermaid
+flowchart TD
+    A["EditorScreen"] --> B["useEditorPlayback"]
+    A --> C["useEditorExport"]
+    A --> D["useEditorTimeline"]
+    A --> E["useEditorKeyboardShortcuts"]
+
+    B --> B1["editorPlaybackSources"]
+    B --> B2["useEditorPlaybackRenderLoop"]
+    B --> B3["editorPlaybackAudio"]
+    B --> B4["editorPlaybackSinks"]
+    B --> B5["useEditorPlaybackWarmup"]
+    B5 --> B6["useEditorPlaybackSelectionWarmup"]
+
+    C --> C1["exportClip"]
+    C --> C2["exportFileName"]
+    C1 --> C3["exportMetadata"]
+    C1 --> C4["subtitle burn-in processor"]
+
+    D --> D1["timelineZoom helpers"]
+
+    F["SourcesModal"] --> F1["useSourcesModalState"]
+    F --> F2["SourcesModalSections"]
+
+    G["ProviderConnectFlow"] --> G1["useProviderConnectFlow"]
+    G --> G2["ProviderConnectFlowSections"]
+```
 
 ## Playback Candidate Tree
 
@@ -98,10 +129,10 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["Active preview source is HLS stream"] --> B["Set playbackReadyRange for selection"]
+    A["Active preview source is HLS stream"] --> B["useEditorPlaybackSelectionWarmup sets playbackReadyRange"]
     B --> C["Paused auto-warmup starts from selection start"]
-    C --> D["Warm exact playback/selection start first"]
-    D --> E["Warm an initial front window"]
+    C --> D["useEditorPlaybackWarmup warms exact playback/selection start first"]
+    D --> E["Selection warmup warms an initial front window"]
     E --> F["Publish readyUntilTime = min(videoReadyUntil, audioReadyUntil)"]
     F --> G{"Still paused and selection not complete?"}
     G -- "Yes" --> H["Schedule extension warmup toward selection end"]
@@ -204,15 +235,17 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["User clicks Export"] --> B["Build fresh Mediabunny input from export source URL"]
-    B --> C["Create Output(BufferTarget)"]
-    C --> D["Conversion.init validates selected tracks and audio plan"]
-    D --> E{"Conversion valid?"}
-    E -- "No" --> F["Surface conversion/discard error"]
-    E -- "Yes" --> G["Execute conversion"]
-    G --> H["Patch MP4 metadata boxes when needed"]
-    H --> I["Return Blob from target buffer"]
-    I --> J["Do not reopen the finished Blob just to recheck audio"]
+    A["User clicks Export"] --> B["useEditorExport resolves source/options and lazy-loads exportClip"]
+    B --> C["exportClip builds fresh Mediabunny input from export source URL"]
+    C --> D["exportMetadata builds tags and artwork when metadata exists"]
+    D --> E["Create Output(BufferTarget)"]
+    E --> F["Conversion.init validates selected tracks and audio plan"]
+    F --> G{"Conversion valid?"}
+    G -- "No" --> H["Surface conversion/discard error"]
+    G -- "Yes" --> I["Execute conversion"]
+    I --> J["Patch MP4 metadata boxes when needed"]
+    J --> K["Return Blob from target buffer"]
+    K --> L["Do not reopen the finished Blob just to recheck audio"]
 ```
 
 ## End-To-End Summary
@@ -230,10 +263,11 @@ flowchart LR
     D --> K["Preview tracks for browser playback"]
     D --> L["Optional playbackReadyRange for HLS preview only"]
     L --> M["EditorTimeline Preview Ready overlay and note"]
-    B --> G["EditorScreen export source selection"]
+    B --> G["useEditorExport source selection"]
     C --> G
     F --> G
     G --> H["exportClip input URL"]
     H --> N["exportClip builds a fresh input"]
     I --> N
+    N --> O["exportMetadata applies tags/artwork/MP4 metadata patching"]
 ```

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm exec eslint \"src/**/*.{ts,tsx}\" vite.config.js",
     "lint:types": "tsc --noEmit",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },
@@ -36,6 +37,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "tailwindcss": "^4.3.0",
+    "tsx": "^4.22.3",
     "typescript": "~6.0.3",
     "vite": "^8.0.14"
   }

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -11,6 +11,7 @@ import { EditorSidebar } from "./editor/EditorSidebar";
 import { EditorPlaybackSourcePanel } from "./editor/EditorPlaybackSourcePanel";
 import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
+import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
 import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../providers/types";
 import type { ExportFormat, ExportResolution } from "../lib/exportClip";
 import {
@@ -68,16 +69,6 @@ function isInteractiveKeyboardTarget(target: EventTarget | null) {
   );
 }
 
-function subtitleTrackDisplayName(track: PlaybackSubtitleTrack | null) {
-  if (!track) {
-    return "No subtitle track selected";
-  }
-
-  return track.title?.trim()
-    || track.languageCode?.trim()?.toUpperCase()
-    || "Selected subtitle track";
-}
-
 export default function EditorScreen({ session, onBack }: Props) {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(() => Math.min(10, Math.max(session.duration, 0)));
@@ -123,71 +114,22 @@ export default function EditorScreen({ session, onBack }: Props) {
     () => subtitleEnabled ? trimSubtitleCues(subtitleCues, startTime, endTime) : [],
     [endTime, startTime, subtitleCues, subtitleEnabled]
   );
-  const subtitleExportSummary = useMemo(() => {
-    if (!selectedSubtitleTrack || !subtitleEnabled) {
-      return {
-        label: "Not included",
-        detail: subtitleTracks.length > 0
-          ? "Subtitle burn-in is currently turned off for this export."
-          : "No supported text subtitle tracks are available for this session.",
-        tone: "muted" as const,
-        disabledReason: null as string | null,
-      };
-    }
-
-    const trackName = subtitleTrackDisplayName(selectedSubtitleTrack);
-
-    if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
-      return {
-        label: "Unsupported track",
-        detail: subtitleTrackUnavailableMessage(selectedSubtitleTrack, session.source.providerId)
-          ?? `${trackName} cannot be burned in yet because it is not an exposed text subtitle stream.`,
-        tone: "warning" as const,
-        disabledReason: "Choose a supported text subtitle track or turn subtitle burn-in off.",
-      };
-    }
-
-    if (subtitleLoading) {
-      return {
-        label: "Loading cues",
-        detail: `${trackName} is still being prepared for burn-in.`,
-        tone: "warning" as const,
-        disabledReason: "Subtitles are still loading. Please wait for the cue list to finish loading.",
-      };
-    }
-
-    if (subtitleError) {
-      return {
-        label: "Subtitle issue",
-        detail: subtitleError,
-        tone: "warning" as const,
-        disabledReason: subtitleError,
-      };
-    }
-
-    if (clippedSubtitleCues.length === 0) {
-      return {
-        label: "No cues found",
-        detail: `${trackName} has no subtitle cues inside the selected clip range.`,
-        tone: "muted" as const,
-        disabledReason: null as string | null,
-      };
-    }
-
-    return {
-      label: "Burned in",
-      detail: `${trackName} will be rendered into the exported video frames.`,
-      tone: "ready" as const,
-      disabledReason: null as string | null,
-    };
-  }, [
+  const subtitleExportSummary = useMemo(() => buildSubtitleExportSummary({
     selectedSubtitleTrack,
-    session.source.providerId,
-    clippedSubtitleCues.length,
     subtitleEnabled,
-    subtitleError,
+    subtitleTrackCount: subtitleTracks.length,
+    clippedSubtitleCueCount: clippedSubtitleCues.length,
     subtitleLoading,
+    subtitleError,
+    providerId: session.source.providerId,
+  }), [
+    selectedSubtitleTrack,
+    subtitleEnabled,
     subtitleTracks.length,
+    clippedSubtitleCues.length,
+    subtitleLoading,
+    subtitleError,
+    session.source.providerId,
   ]);
 
   const {

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -3,6 +3,7 @@ import { Eye } from "lucide-react";
 import { MIN_CLIP_SECONDS, roundTimelineTime } from "./editor/EditorUtils";
 import { useEditorPlayback, type PlaybackFallbackInfo } from "./editor/useEditorPlayback";
 import { useEditorExport } from "./editor/useEditorExport";
+import { useEditorKeyboardShortcuts } from "./editor/useEditorKeyboardShortcuts";
 import { useEditorTimeline } from "./editor/useEditorTimeline";
 import { EditorHeader } from "./editor/EditorHeader";
 import { EditorExportDialog } from "./editor/EditorExportDialog";
@@ -29,20 +30,6 @@ import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
 interface Props {
   session: CurrentlyPlayingItem;
   onBack: () => void;
-}
-
-function isInteractiveKeyboardTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  if (target.isContentEditable) {
-    return true;
-  }
-
-  return Boolean(
-    target.closest("input, textarea, select, button, [contenteditable=\"true\"], [role=\"slider\"]"),
-  );
 }
 
 export default function EditorScreen({ session, onBack }: Props) {
@@ -280,30 +267,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     setSubtitleEnabled(Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)));
   }, [clearSubtitleError, resetSubtitleCues, subtitleTracks]);
 
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.code !== "Space") {
-        return;
-      }
-
-      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-
-      if (isInteractiveKeyboardTarget(event.target)) {
-        return;
-      }
-
-      event.preventDefault();
-      togglePlay();
-    }
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [togglePlay]);
+  useEditorKeyboardShortcuts({ togglePlay });
 
   if (!exportSource.url) {
     return (

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -12,6 +12,7 @@ import { EditorPlaybackSourcePanel } from "./editor/EditorPlaybackSourcePanel";
 import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
 import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
+import { useSubtitleCues } from "./editor/useSubtitleCues";
 import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../providers/types";
 import type { ExportFormat, ExportResolution } from "../lib/exportClip";
 import {
@@ -26,15 +27,12 @@ import {
   selectPreferredSubtitleTrack,
   subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
-  subtitleTrackUnavailableMessage,
 } from "../lib/selectPreferredSubtitleTrack";
 import {
   loadSubtitleStyleSettings,
   saveSubtitleStyleSettings,
 } from "../lib/subtitles/settings";
-import { parseSubtitleText } from "../lib/subtitles/parseSubtitleText";
 import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
-import type { SubtitleCue } from "../lib/subtitles/types";
 
 interface Props {
   session: CurrentlyPlayingItem;
@@ -52,8 +50,6 @@ interface ResolvedExportSource {
   url: string;
   kind: ResolvedExportSourceKind;
 }
-
-const SUBTITLE_REQUEST_TIMEOUT_MS = 15_000;
 
 function isInteractiveKeyboardTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) {
@@ -86,9 +82,6 @@ export default function EditorScreen({ session, onBack }: Props) {
   const [exportError, setExportError] = useState<string | null>(null);
   const [subtitleEnabled, setSubtitleEnabled] = useState(false);
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState("none");
-  const [subtitleCues, setSubtitleCues] = useState<SubtitleCue[]>([]);
-  const [subtitleLoading, setSubtitleLoading] = useState(false);
-  const [subtitleError, setSubtitleError] = useState<string | null>(null);
   const effectiveExportSourcePreference =
     exportSourcePreference === "direct" && !session.mediaUrl
       ? "auto"
@@ -107,6 +100,17 @@ export default function EditorScreen({ session, onBack }: Props) {
 
     return subtitleTracks.find((track) => subtitleTrackKey(track) === selectedSubtitleTrackKey) ?? null;
   }, [selectedSubtitleTrackKey, subtitleTracks]);
+  const {
+    subtitleCues,
+    subtitleLoading,
+    subtitleError,
+    resetSubtitleCues,
+    clearSubtitleError,
+  } = useSubtitleCues({
+    selectedSubtitleTrack,
+    subtitleEnabled,
+    providerId: session.source.providerId,
+  });
   const subtitlePreviewEnabled = subtitleEnabled
     && subtitleTrackSupportsBurnIn(selectedSubtitleTrack)
     && subtitleCues.length > 0;
@@ -288,128 +292,27 @@ export default function EditorScreen({ session, onBack }: Props) {
 
     setSelectedSubtitleTrackKey(preferredSubtitleTrack ? subtitleTrackKey(preferredSubtitleTrack) : "none");
     setSubtitleEnabled(Boolean(preferredSubtitleTrack && subtitleTrackSupportsBurnIn(preferredSubtitleTrack)));
-    setSubtitleCues([]);
-    setSubtitleLoading(false);
-    setSubtitleError(null);
+    resetSubtitleCues();
   }, [
     session.id,
     session.selectedSubtitleTrack,
     subtitleTracks,
+    resetSubtitleCues,
   ]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const abortController = new AbortController();
-    const timeout = window.setTimeout(() => {
-      abortController.abort();
-    }, SUBTITLE_REQUEST_TIMEOUT_MS);
-
-    async function loadSubtitleCues() {
-      if (!subtitleEnabled || !selectedSubtitleTrack) {
-        setSubtitleLoading(false);
-        setSubtitleCues([]);
-        setSubtitleError(null);
-        return;
-      }
-
-      if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack) || !selectedSubtitleTrack.contentUrl) {
-        setSubtitleLoading(false);
-        setSubtitleCues([]);
-        setSubtitleError(
-          subtitleTrackUnavailableMessage(selectedSubtitleTrack, session.source.providerId)
-            ?? "This subtitle track is not yet supported for styled burn-in."
-        );
-        return;
-      }
-
-      setSubtitleCues([]);
-      setSubtitleLoading(true);
-      setSubtitleError(null);
-
-      try {
-        const response = await fetch(selectedSubtitleTrack.contentUrl, {
-          signal: abortController.signal,
-        });
-        if (!response.ok) {
-          let detail = "";
-
-          try {
-            const contentType = response.headers.get("content-type") ?? "";
-            if (contentType.toLowerCase().includes("application/json")) {
-              const payload = await response.json() as {
-                error?: {
-                  message?: string;
-                };
-              };
-              detail = payload.error?.message?.trim() ?? "";
-            } else {
-              detail = (await response.text()).replace(/\s+/g, " ").trim();
-            }
-          } catch {
-            detail = "";
-          }
-
-          throw new Error(
-            detail
-              ? `Subtitle download failed (${response.status}): ${detail}`
-              : `Subtitle download failed (${response.status})`
-          );
-        }
-
-        const subtitleText = await response.text();
-        const parsedSubtitleCues = parseSubtitleText(
-          subtitleText,
-          selectedSubtitleTrack.contentFormat
-        );
-
-        if (cancelled) {
-          return;
-        }
-
-        setSubtitleCues(parsedSubtitleCues);
-        setSubtitleError(parsedSubtitleCues.length === 0 ? "No subtitle cues were found in this track." : null);
-      } catch (err) {
-        if (cancelled || abortController.signal.aborted) {
-          if (!cancelled) {
-            setSubtitleCues([]);
-            setSubtitleError("Subtitle request timed out. Please try again.");
-            setSubtitleLoading(false);
-          }
-          return;
-        }
-
-        console.error("Could not load subtitle cues", err);
-        setSubtitleCues([]);
-        setSubtitleError(err instanceof Error ? err.message : "Could not load subtitle cues.");
-      } finally {
-        if (!cancelled) {
-          setSubtitleLoading(false);
-        }
-      }
-    }
-
-    void loadSubtitleCues();
-
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timeout);
-      abortController.abort();
-    };
-  }, [selectedSubtitleTrack, session.source.providerId, subtitleEnabled]);
 
   const handleSelectedSubtitleTrackChange = useCallback((value: string) => {
     setSelectedSubtitleTrackKey(value);
-    setSubtitleError(null);
+    clearSubtitleError();
 
     if (value === "none") {
       setSubtitleEnabled(false);
-      setSubtitleCues([]);
+      resetSubtitleCues();
       return;
     }
 
     const nextTrack = subtitleTracks.find((track) => subtitleTrackKey(track) === value) ?? null;
     setSubtitleEnabled(Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)));
-  }, [subtitleTracks]);
+  }, [clearSubtitleError, resetSubtitleCues, subtitleTracks]);
 
   const handleOpenExportDialog = useCallback(() => {
     setExportError(null);

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -2,9 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Eye } from "lucide-react";
 import { MIN_CLIP_SECONDS, roundTimelineTime } from "./editor/EditorUtils";
 import { useEditorPlayback, type PlaybackFallbackInfo } from "./editor/useEditorPlayback";
+import { useEditorExport } from "./editor/useEditorExport";
 import { useEditorTimeline } from "./editor/useEditorTimeline";
 import { EditorHeader } from "./editor/EditorHeader";
-import { EditorExportDialog, type ExportSourcePreference } from "./editor/EditorExportDialog";
+import { EditorExportDialog } from "./editor/EditorExportDialog";
 import { EditorPreview } from "./editor/EditorPreview";
 import { EditorControls } from "./editor/EditorControls";
 import { EditorSidebar } from "./editor/EditorSidebar";
@@ -14,15 +15,6 @@ import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
 import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
 import { useSubtitleCues } from "./editor/useSubtitleCues";
 import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../providers/types";
-import type { ExportFormat, ExportResolution } from "../lib/exportClip";
-import {
-  buildExportFileName,
-  defaultExportFileNameTemplates,
-  loadExportFileNameTemplates,
-  saveExportFileNameTemplates,
-  type ExportFileNameTemplateKind,
-  type ExportFileNameTemplateSettings,
-} from "../lib/exportFileName";
 import {
   selectPreferredSubtitleTrack,
   subtitleTrackKey,
@@ -37,18 +29,6 @@ import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
 interface Props {
   session: CurrentlyPlayingItem;
   onBack: () => void;
-}
-
-interface VideoDimensions {
-  width: number;
-  height: number;
-}
-
-type ResolvedExportSourceKind = "hls" | "direct" | "none";
-
-interface ResolvedExportSource {
-  url: string;
-  kind: ResolvedExportSourceKind;
 }
 
 function isInteractiveKeyboardTarget(target: EventTarget | null) {
@@ -68,26 +48,10 @@ function isInteractiveKeyboardTarget(target: EventTarget | null) {
 export default function EditorScreen({ session, onBack }: Props) {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(() => Math.min(10, Math.max(session.duration, 0)));
-  const [resolution, setResolution] = useState<ExportResolution>("original");
-  const [exportFormat, setExportFormat] = useState<ExportFormat>("mp4");
-  const [exportSourcePreference, setExportSourcePreference] = useState<ExportSourcePreference>("auto");
-  const [includeAudio, setIncludeAudio] = useState(true);
-  const [fileNameTemplates, setFileNameTemplates] = useState<ExportFileNameTemplateSettings>(() => loadExportFileNameTemplates());
   const [subtitleStyleSettings, setSubtitleStyleSettings] = useState(() => loadSubtitleStyleSettings());
-  const [templateEditorKind, setTemplateEditorKind] = useState<ExportFileNameTemplateKind>("movie");
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
-  const [exportDialogOpen, setExportDialogOpen] = useState(false);
-  const [exporting, setExporting] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [exportError, setExportError] = useState<string | null>(null);
   const [subtitleEnabled, setSubtitleEnabled] = useState(false);
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState("none");
-  const effectiveExportSourcePreference =
-    exportSourcePreference === "direct" && !session.mediaUrl
-      ? "auto"
-      : exportSourcePreference === "hls" && !session.hlsUrl
-        ? "auto"
-        : exportSourcePreference;
 
   const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
     () => (session.subtitleTracks ?? []).filter((track) => subtitleTrackSupportsBurnIn(track)),
@@ -171,28 +135,46 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitlesEnabled: subtitlePreviewEnabled,
     subtitleStyleSettings,
   });
-  const exportSource = resolveExportSource({
-    preference: effectiveExportSourcePreference,
-    hlsUrl: session.hlsUrl,
-    mediaUrl: session.mediaUrl,
+  const {
+    resolution,
+    exportFormat,
+    effectiveExportSourcePreference,
+    includeAudio,
+    fileNameTemplates,
+    templateEditorKind,
+    setTemplateEditorKind,
+    exportDialogOpen,
+    exporting,
+    progress,
+    exportError,
+    fileName,
+    outputDimensions,
+    exportSource,
+    exportSourceMessage,
+    exportSourceSummaryMessage,
+    exportSourceLabel,
+    handleOpenExportDialog,
+    handleCloseExportDialog,
+    handleFormatChange,
+    handleResolutionChange,
+    handleExportSourceChange,
+    handleAudioChange,
+    handleFileNameTemplateChange,
+    handleResetFileNameTemplate,
+    handleExport,
+  } = useEditorExport({
+    session,
+    startTime,
+    endTime,
+    sourceVideoDimensions,
     exportFallbackSourceUrl,
-  });
-  const exportSourceMessage = buildExportSourceMessage({
-    preference: effectiveExportSourcePreference,
-    resolvedSourceKind: exportSource.kind,
-    hlsUrl: session.hlsUrl,
-    mediaUrl: session.mediaUrl,
     hlsFallbackInfo,
-  });
-  const exportSourceSummaryMessage = buildExportSourceSummaryMessage({
-    preference: effectiveExportSourcePreference,
-    resolvedSourceKind: exportSource.kind,
-    hlsUrl: session.hlsUrl,
-  });
-  const exportSourceLabel = buildExportSourceLabel({
-    preference: effectiveExportSourcePreference,
-    resolvedSourceKind: exportSource.kind,
-    exportFallbackSourceUrl,
+    subtitleEnabled,
+    selectedSubtitleTrack,
+    clippedSubtitleCues,
+    subtitleLoading,
+    subtitleCues,
+    subtitleStyleSettings,
   });
   const playbackFallbackReason = buildPlaybackFallbackReason({
     activeSourceLabel,
@@ -255,22 +237,6 @@ export default function EditorScreen({ session, onBack }: Props) {
     },
   });
 
-  const fileName = buildExportFileName({
-    title: session.title,
-    sessionType: session.type,
-    metadata: session.exportMetadata,
-    startTime,
-    endTime,
-    format: exportFormat,
-    templates: fileNameTemplates,
-  });
-
-  const outputDimensions = getOutputDimensions(sourceVideoDimensions, resolution);
-
-  useEffect(() => {
-    saveExportFileNameTemplates(fileNameTemplates);
-  }, [fileNameTemplates]);
-
   useEffect(() => {
     if (!duration || duration <= 0) {
       return;
@@ -313,136 +279,6 @@ export default function EditorScreen({ session, onBack }: Props) {
     const nextTrack = subtitleTracks.find((track) => subtitleTrackKey(track) === value) ?? null;
     setSubtitleEnabled(Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)));
   }, [clearSubtitleError, resetSubtitleCues, subtitleTracks]);
-
-  const handleOpenExportDialog = useCallback(() => {
-    setExportError(null);
-    setTemplateEditorKind(fileName.templateKind);
-    setExportDialogOpen(true);
-  }, [fileName.templateKind]);
-
-  const handleCloseExportDialog = useCallback(() => {
-    if (exporting) {
-      return;
-    }
-
-    setExportDialogOpen(false);
-  }, [exporting]);
-
-  const handleFormatChange = useCallback((nextFormat: ExportFormat) => {
-    setExportFormat(nextFormat);
-    setExportError(null);
-  }, []);
-
-  const handleResolutionChange = useCallback((nextResolution: ExportResolution) => {
-    setResolution(nextResolution);
-    setExportError(null);
-  }, []);
-
-  const handleExportSourceChange = useCallback((nextSourcePreference: ExportSourcePreference) => {
-    setExportSourcePreference(nextSourcePreference);
-    setExportError(null);
-  }, []);
-
-  const handleAudioChange = useCallback((nextIncludeAudio: boolean) => {
-    setIncludeAudio(nextIncludeAudio);
-    setExportError(null);
-  }, []);
-
-  const handleFileNameTemplateChange = useCallback((
-    kind: ExportFileNameTemplateKind,
-    nextTemplate: string
-  ) => {
-    setFileNameTemplates((current) => ({
-      ...current,
-      [kind]: nextTemplate,
-    }));
-    setExportError(null);
-  }, []);
-
-  const handleResetFileNameTemplate = useCallback((kind: ExportFileNameTemplateKind) => {
-    const defaults = defaultExportFileNameTemplates();
-
-    setFileNameTemplates((current) => ({
-      ...current,
-      [kind]: defaults[kind],
-    }));
-    setExportError(null);
-  }, []);
-
-  const handleExport = useCallback(async () => {
-    if (!exportSource.url) return;
-    if (exporting) return;
-
-    const shouldBurnSubtitles = subtitleEnabled
-      && selectedSubtitleTrack !== null
-      && clippedSubtitleCues.length > 0;
-
-    if (shouldBurnSubtitles && subtitleLoading) {
-      setExportError("Subtitles are still loading. Please wait a moment and try again.");
-      return;
-    }
-
-    if (shouldBurnSubtitles && !subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
-      setExportError("This subtitle track cannot be burned in yet.");
-      return;
-    }
-
-    setExportError(null);
-    setExporting(true);
-    setProgress(0);
-
-    try {
-      const { exportClip } = await import("../lib/exportClip");
-      const blob = await exportClip({
-        mediaUrl: exportSource.url,
-        hls: exportSource.kind === "hls",
-        startTime,
-        endTime,
-        format: exportFormat,
-        resolution,
-        includeAudio,
-        selectedAudioTrack: session.selectedAudioTrack,
-        metadata: session.exportMetadata,
-        includeBurnedSubtitles: shouldBurnSubtitles,
-        subtitleCues,
-        subtitleStyleSettings,
-        onProgress: setProgress,
-      });
-      const url = URL.createObjectURL(blob);
-
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = fileName.fullName;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.setTimeout(() => URL.revokeObjectURL(url), 0);
-      setExportDialogOpen(false);
-    } catch (err) {
-      console.error(err);
-      setExportError(err instanceof Error ? err.message : "Export failed");
-    } finally {
-      setExporting(false);
-    }
-  }, [
-    endTime,
-    exportFormat,
-    fileName.fullName,
-    exporting,
-    exportSource.kind,
-    exportSource.url,
-    includeAudio,
-    resolution,
-    clippedSubtitleCues,
-    session.exportMetadata,
-    session.selectedAudioTrack,
-    startTime,
-    subtitleCues,
-    subtitleEnabled,
-    subtitleLoading,
-    subtitleStyleSettings,
-    selectedSubtitleTrack,
-  ]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -677,90 +513,6 @@ export default function EditorScreen({ session, onBack }: Props) {
   );
 }
 
-function getOutputDimensions(
-  sourceVideoDimensions: VideoDimensions | null,
-  resolution: ExportResolution
-) {
-  if (!sourceVideoDimensions || sourceVideoDimensions.width <= 0 || sourceVideoDimensions.height <= 0) {
-    return null;
-  }
-
-  if (resolution === "original") {
-    return sourceVideoDimensions;
-  }
-
-  const height = parseInt(resolution, 10);
-  if (!Number.isFinite(height) || height <= 0) {
-    return sourceVideoDimensions;
-  }
-
-  const width = Math.max(1, Math.round((sourceVideoDimensions.width / sourceVideoDimensions.height) * height));
-
-  return { width, height };
-}
-
-function resolveExportSource({
-  preference,
-  hlsUrl,
-  mediaUrl,
-  exportFallbackSourceUrl,
-}: {
-  preference: ExportSourcePreference;
-  hlsUrl?: string;
-  mediaUrl?: string;
-  exportFallbackSourceUrl?: string;
-}): ResolvedExportSource {
-  if (preference === "direct") {
-    return mediaUrl
-      ? { url: mediaUrl, kind: "direct" }
-      : { url: "", kind: "none" };
-  }
-
-  if (preference === "hls") {
-    return hlsUrl
-      ? { url: hlsUrl, kind: "hls" }
-      : { url: "", kind: "none" };
-  }
-
-  if (exportFallbackSourceUrl) {
-    return { url: exportFallbackSourceUrl, kind: "direct" };
-  }
-
-  if (hlsUrl) {
-    return { url: hlsUrl, kind: "hls" };
-  }
-
-  if (mediaUrl) {
-    return { url: mediaUrl, kind: "direct" };
-  }
-
-  return { url: "", kind: "none" };
-}
-
-function buildExportSourceLabel({
-  preference,
-  resolvedSourceKind,
-  exportFallbackSourceUrl,
-}: {
-  preference: ExportSourcePreference;
-  resolvedSourceKind: ResolvedExportSourceKind;
-  exportFallbackSourceUrl?: string;
-}) {
-  if (resolvedSourceKind === "hls") {
-    return preference === "auto" ? "Auto: HLS playback" : "HLS playback";
-  }
-
-  if (resolvedSourceKind === "direct") {
-    if (preference === "auto" && exportFallbackSourceUrl) {
-      return "Auto: direct fallback";
-    }
-
-    return preference === "auto" ? "Auto: direct/original" : "Direct/original";
-  }
-
-  return "Unavailable";
-}
-
 function buildPlaybackFallbackReason({
   activeSourceLabel,
   hlsUrl,
@@ -781,69 +533,4 @@ function buildPlaybackFallbackReason({
   } as const)[hlsFallbackInfo.category];
 
   return `${prefix}: ${hlsFallbackInfo.message}`;
-}
-
-function buildExportSourceMessage({
-  preference,
-  resolvedSourceKind,
-  hlsUrl,
-  mediaUrl,
-  hlsFallbackInfo,
-}: {
-  preference: ExportSourcePreference;
-  resolvedSourceKind: ResolvedExportSourceKind;
-  hlsUrl?: string;
-  mediaUrl?: string;
-  hlsFallbackInfo: PlaybackFallbackInfo | null;
-}) {
-  if (resolvedSourceKind === "none") {
-    return null;
-  }
-
-  if (preference === "hls" && resolvedSourceKind === "hls" && !hlsFallbackInfo) {
-    return "Export will use the HLS playback stream. This follows the media server playback path and can include server-side transcoding.";
-  }
-
-  if (resolvedSourceKind === "direct" && !hlsUrl && mediaUrl) {
-    return "This session only exposed a direct/original media path, so export will use that source.";
-  }
-
-  if (resolvedSourceKind === "direct" && preference !== "auto") {
-    return null;
-  }
-
-  if (!hlsFallbackInfo) {
-    return null;
-  }
-
-  const exportUsesDirectSource = resolvedSourceKind === "direct";
-  const prefix = exportUsesDirectSource
-    ? ({
-        "open-or-read": "Export is using the direct media source because Cliparr could not open or read the HLS stream",
-        "preview-only": "Export is using the direct media source because Cliparr could not use the HLS stream for this export path",
-        "shared-export-blocking": "Export is using the direct media source because Cliparr cannot currently use this HLS stream for export",
-      } as const)[hlsFallbackInfo.category]
-    : ({
-        "open-or-read": "Export will still try the HLS stream even though preview fell back while opening or reading it",
-        "preview-only": "Export will still try the HLS stream because this limitation only affects preview in the current browser",
-        "shared-export-blocking": "Export cannot currently use this HLS stream",
-      } as const)[hlsFallbackInfo.category];
-
-  return `${prefix}: ${hlsFallbackInfo.message}`;
-}
-
-function buildExportSourceSummaryMessage({
-  preference,
-  resolvedSourceKind,
-  hlsUrl,
-}: {
-  preference: ExportSourcePreference;
-  resolvedSourceKind: ResolvedExportSourceKind;
-  hlsUrl?: string;
-}) {
-  if (preference === "direct" && resolvedSourceKind === "direct" && hlsUrl) {
-    return "Export will use the direct/original media path. Cliparr still uses playback metadata for track and timing hints when it is available.";
-  }
-
-  return null;
 }

--- a/apps/frontend/src/components/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlow.tsx
@@ -1,9 +1,16 @@
 import { AnimatePresence, motion } from "motion/react";
 import { ArrowRight, Check, ExternalLink, Server } from "lucide-react";
 import { cn } from "../lib/utils";
+import {
+  ProviderBadge,
+  ProviderConnectError,
+  ProviderOption,
+  ProviderStatusMessage,
+  providerPresentation,
+} from "./ProviderConnectFlowSections";
 import { ProviderGlyph } from "./ProviderGlyph";
 import { useProviderConnectFlow } from "./useProviderConnectFlow";
-import type { ProviderDefinition, ProviderSession } from "../providers/types";
+import type { ProviderSession } from "../providers/types";
 
 interface Props {
   onConnected: (session: ProviderSession) => Promise<void> | void;
@@ -15,64 +22,8 @@ const devJellyfinUrl = typeof import.meta.env.VITE_CLIPARR_DEV_JELLYFIN_URL === 
   ? import.meta.env.VITE_CLIPARR_DEV_JELLYFIN_URL.trim()
   : "";
 
-function providerPresentation(
-  provider: ProviderDefinition,
-  variant: "panel" | "screen"
-) {
-  switch (provider.id) {
-    case "plex":
-      return {
-        eyebrow: "Browser Sign-In",
-        summary: variant === "panel"
-          ? "Authenticate with Plex in a separate tab, then Cliparr will discover and keep those servers available here."
-          : "Authenticate with Plex in a separate tab, then Cliparr will discover the Plex servers tied to that account.",
-        action: "Continue with Plex",
-      };
-    case "jellyfin":
-      return {
-        eyebrow: "Direct Server Login",
-        summary: "Connect directly to a Jellyfin server with its base URL and an administrator account.",
-        action: "Connect Jellyfin",
-      };
-    default:
-      return {
-        eyebrow: "Provider Setup",
-        summary: `Connect ${provider.name} to start pulling active sessions into Cliparr.`,
-        action: `Continue with ${provider.name}`,
-      };
-  }
-}
-
 function isLoopbackUrl(value: string) {
   return /^https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[::1\]|::1)(?:[:/]|$)/i.test(value.trim());
-}
-
-function ProviderBadge({
-  providerId,
-  name,
-  selected,
-  large = false,
-}: {
-  providerId: string;
-  name: string;
-  selected: boolean;
-  large?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "rounded-2xl p-3 transition-colors",
-        selected ? "bg-primary/15" : "bg-card"
-      )}
-    >
-      <ProviderGlyph
-        providerId={providerId}
-        providerName={name}
-        className={large ? "h-6 w-6" : "h-5 w-5"}
-        fallbackClassName={selected ? "text-primary" : "text-muted-foreground"}
-      />
-    </div>
-  );
 }
 
 export default function ProviderConnectFlow({
@@ -113,127 +64,6 @@ export default function ProviderConnectFlow({
   const isUsingDevJellyfinUrl = selectedProvider?.id === "jellyfin"
     && Boolean(devJellyfinUrl)
     && serverUrl.trim() === devJellyfinUrl;
-
-  function renderError() {
-    if (!error) {
-      return null;
-    }
-
-    if (!isScreen) {
-      return (
-        <div className="rounded-2xl border border-destructive/20 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
-        </div>
-      );
-    }
-
-    return (
-      <div className="mb-5 min-h-19">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={error}
-            initial={{ opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-            className="rounded-2xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive"
-          >
-            {error}
-          </motion.div>
-        </AnimatePresence>
-      </div>
-    );
-  }
-
-  function renderProviderOption(provider: ProviderDefinition) {
-    const details = providerPresentation(provider, variant);
-    const isSelected = provider.id === selectedProvider?.id;
-    const isBusy = authenticating && providerId === provider.id;
-    const commonProps = {
-      type: "button" as const,
-      onClick: () => {
-        setSelectedProviderId(provider.id);
-        setError("");
-      },
-      disabled: authenticating && !isBusy,
-      className: cn(
-        "w-full rounded-2xl border px-4 py-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-        isSelected
-          ? isScreen
-            ? "border-primary/40 bg-primary/10 shadow-lg"
-            : "border-primary/30 bg-primary/10"
-          : "border-border bg-background hover:bg-accent/60"
-      ),
-    };
-
-    const content = (
-      <div className="flex items-start gap-4">
-        <ProviderBadge
-          providerId={provider.id}
-          name={provider.name}
-          selected={isSelected}
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
-                {details.eyebrow}
-              </p>
-              <h2 className="mt-1 text-lg font-semibold text-foreground">
-                {provider.name}
-              </h2>
-            </div>
-            {isSelected && (
-              isScreen ? (
-                <motion.span
-                  layout
-                  initial={{ opacity: 0, scale: 0.92 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.92 }}
-                  className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[var(--tracking-caps-lg)] text-primary"
-                >
-                  Selected
-                </motion.span>
-              ) : (
-                <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[var(--tracking-caps-lg)] text-primary">
-                  Selected
-                </span>
-              )
-            )}
-          </div>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            {details.summary}
-          </p>
-          {isBusy && (
-            <p className="mt-3 text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-primary">
-              In progress
-            </p>
-          )}
-        </div>
-      </div>
-    );
-
-    if (!isScreen) {
-      return (
-        <button key={provider.id} {...commonProps}>
-          {content}
-        </button>
-      );
-    }
-
-    return (
-      <motion.button
-        key={provider.id}
-        layout
-        whileHover={authenticating && !isBusy ? undefined : { y: -2 }}
-        whileTap={authenticating && !isBusy ? undefined : { scale: 0.995 }}
-        transition={{ duration: 0.16, ease: "easeOut" }}
-        {...commonProps}
-      >
-        {content}
-      </motion.button>
-    );
-  }
 
   function renderPinContent() {
     if (!selectedProvider) {
@@ -583,40 +413,25 @@ export default function ProviderConnectFlow({
   function renderContent() {
     if (loading) {
       return (
-        <div className={cn(
-          "text-center text-sm text-muted-foreground",
-          isScreen
-            ? "py-12"
-            : "rounded-3xl border border-border bg-background/60 px-6 py-10"
-        )}>
+        <ProviderStatusMessage isScreen={isScreen}>
           Loading providers...
-        </div>
+        </ProviderStatusMessage>
       );
     }
 
     if (!error && providers.length === 0) {
       return (
-        <div className={cn(
-          "text-center text-sm text-muted-foreground",
-          isScreen
-            ? "py-12"
-            : "rounded-3xl border border-border bg-background/60 px-6 py-10"
-        )}>
+        <ProviderStatusMessage isScreen={isScreen}>
           No providers are currently available.
-        </div>
+        </ProviderStatusMessage>
       );
     }
 
     if (providers.length === 0) {
       return (
-        <div className={cn(
-          "text-center text-sm text-muted-foreground",
-          isScreen
-            ? "py-12"
-            : "rounded-3xl border border-border bg-background/60 px-6 py-10"
-        )}>
+        <ProviderStatusMessage isScreen={isScreen}>
           We could not load providers yet.
-        </div>
+        </ProviderStatusMessage>
       );
     }
 
@@ -626,7 +441,20 @@ export default function ProviderConnectFlow({
           Choose A Provider
         </p>
 
-        {providers.map((provider) => renderProviderOption(provider))}
+        {providers.map((provider) => (
+          <ProviderOption
+            key={provider.id}
+            provider={provider}
+            selectedProvider={selectedProvider}
+            authenticating={authenticating}
+            authenticatingProviderId={providerId}
+            variant={variant}
+            onSelect={(nextProviderId) => {
+              setSelectedProviderId(nextProviderId);
+              setError("");
+            }}
+          />
+        ))}
       </>
     );
 
@@ -660,7 +488,7 @@ export default function ProviderConnectFlow({
   if (!isScreen) {
     return (
       <div className="space-y-5">
-        {renderError()}
+        <ProviderConnectError error={error} isScreen={isScreen} />
         {renderContent()}
       </div>
     );
@@ -668,7 +496,11 @@ export default function ProviderConnectFlow({
 
   return (
     <>
-      {renderError() ?? <div className="mb-5 min-h-19" />}
+      {error ? (
+        <ProviderConnectError error={error} isScreen={isScreen} />
+      ) : (
+        <div className="mb-5 min-h-19" />
+      )}
       {renderContent()}
     </>
   );

--- a/apps/frontend/src/components/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlow.tsx
@@ -153,7 +153,7 @@ export default function ProviderConnectFlow({
       return;
     }
 
-    const intervalId = window.setInterval(async () => {
+    const pollAuthStatus = async () => {
       try {
         const status = await cliparrClient.pollAuth(providerId, authId);
         if (status.status === "complete") {
@@ -174,6 +174,9 @@ export default function ProviderConnectFlow({
         resetProviderState();
         setError(errorMessage(err, `Failed to finish ${providerLabel(providerId)} sign-in`));
       }
+    };
+    const intervalId = window.setInterval(() => {
+      void pollAuthStatus();
     }, 1500);
 
     return () => {

--- a/apps/frontend/src/components/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlow.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { ArrowRight, Check, ExternalLink, Server } from "lucide-react";
-import { cliparrClient } from "../api/cliparrClient";
 import { cn } from "../lib/utils";
 import { ProviderGlyph } from "./ProviderGlyph";
+import { useProviderConnectFlow } from "./useProviderConnectFlow";
 import type { ProviderDefinition, ProviderSession } from "../providers/types";
 
 interface Props {
@@ -48,10 +47,6 @@ function isLoopbackUrl(value: string) {
   return /^https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[::1\]|::1)(?:[:/]|$)/i.test(value.trim());
 }
 
-function errorMessage(err: unknown, fallback: string) {
-  return err instanceof Error && err.message ? err.message : fallback;
-}
-
 function ProviderBadge({
   providerId,
   name,
@@ -86,141 +81,31 @@ export default function ProviderConnectFlow({
   variant = "panel",
 }: Props) {
   const isScreen = variant === "screen";
-  const [providers, setProviders] = useState<ProviderDefinition[]>([]);
-  const [selectedProviderId, setSelectedProviderId] = useState("");
-  const [authId, setAuthId] = useState("");
-  const [providerId, setProviderId] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [authenticating, setAuthenticating] = useState(false);
-  const [error, setError] = useState("");
-  const [serverUrl, setServerUrl] = useState("");
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadProviders() {
-      try {
-        const data = await cliparrClient.listProviders();
-        if (!cancelled) {
-          setProviders(data);
-        }
-      } catch (err: unknown) {
-        if (!cancelled) {
-          setError(errorMessage(err, "Failed to load providers"));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-
-    void loadProviders();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!selectedProviderId && providers[0]) {
-      setSelectedProviderId(providers[0].id);
-    }
-  }, [providers, selectedProviderId]);
-
-  const selectedProvider = useMemo(
-    () => providers.find((provider) => provider.id === selectedProviderId) ?? providers[0],
-    [providers, selectedProviderId]
-  );
+  const {
+    providers,
+    selectedProvider,
+    authId,
+    providerId,
+    loading,
+    authenticating,
+    error,
+    setError,
+    serverUrl,
+    setServerUrl,
+    username,
+    setUsername,
+    password,
+    setPassword,
+    providerLabel,
+    startAuth,
+    loginWithCredentials,
+    setSelectedProviderId,
+  } = useProviderConnectFlow({
+    onConnected,
+  });
   const selectedProviderDetails = selectedProvider
     ? providerPresentation(selectedProvider, variant)
     : undefined;
-
-  const providerLabel = useCallback((id: string) => {
-    return providers.find((provider) => provider.id === id)?.name ?? "provider";
-  }, [providers]);
-
-  const resetProviderState = useCallback(() => {
-    setAuthenticating(false);
-    setAuthId("");
-    setProviderId("");
-    setPassword("");
-  }, []);
-
-  useEffect(() => {
-    if (!authId || !providerId) {
-      return;
-    }
-
-    const pollAuthStatus = async () => {
-      try {
-        const status = await cliparrClient.pollAuth(providerId, authId);
-        if (status.status === "complete") {
-          window.clearInterval(intervalId);
-          const session = await cliparrClient.getSession();
-          await onConnected(session);
-          resetProviderState();
-          return;
-        }
-
-        if (status.status === "expired") {
-          window.clearInterval(intervalId);
-          resetProviderState();
-          setError(`That ${providerLabel(providerId)} sign-in expired. Start again when you're ready.`);
-        }
-      } catch (err: unknown) {
-        window.clearInterval(intervalId);
-        resetProviderState();
-        setError(errorMessage(err, `Failed to finish ${providerLabel(providerId)} sign-in`));
-      }
-    };
-    const intervalId = window.setInterval(() => {
-      void pollAuthStatus();
-    }, 1500);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [authId, onConnected, providerId, providerLabel, resetProviderState]);
-
-  const startAuth = useCallback(async (provider: ProviderDefinition) => {
-    setError("");
-    setAuthId("");
-    setProviderId(provider.id);
-    setAuthenticating(true);
-
-    try {
-      const auth = await cliparrClient.startAuth(provider.id);
-      setAuthId(auth.authId);
-      window.open(auth.authUrl, "_blank", "noopener,noreferrer");
-    } catch (err: unknown) {
-      resetProviderState();
-      setError(errorMessage(err, `Failed to start ${provider.name} sign-in`));
-    }
-  }, [resetProviderState]);
-
-  const loginWithCredentials = useCallback(async (provider: ProviderDefinition) => {
-    setError("");
-    setAuthId("");
-    setProviderId(provider.id);
-    setAuthenticating(true);
-
-    try {
-      const session = await cliparrClient.loginWithCredentials(provider.id, {
-        serverUrl,
-        username,
-        password,
-      });
-      await onConnected(session);
-      resetProviderState();
-      setServerUrl("");
-      setUsername("");
-    } catch (err: unknown) {
-      resetProviderState();
-      setError(errorMessage(err, `Failed to connect ${provider.name}`));
-    }
-  }, [onConnected, password, resetProviderState, serverUrl, username]);
 
   const jellyfinLoopbackWarning = selectedProvider?.id === "jellyfin"
     && Boolean(devJellyfinUrl)

--- a/apps/frontend/src/components/ProviderConnectFlowSections.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlowSections.tsx
@@ -1,0 +1,217 @@
+import { AnimatePresence, motion } from "motion/react";
+import { cn } from "../lib/utils";
+import type { ProviderDefinition } from "../providers/types";
+import { ProviderGlyph } from "./ProviderGlyph";
+
+export function providerPresentation(
+  provider: ProviderDefinition,
+  variant: "panel" | "screen"
+) {
+  switch (provider.id) {
+    case "plex":
+      return {
+        eyebrow: "Browser Sign-In",
+        summary: variant === "panel"
+          ? "Authenticate with Plex in a separate tab, then Cliparr will discover and keep those servers available here."
+          : "Authenticate with Plex in a separate tab, then Cliparr will discover the Plex servers tied to that account.",
+        action: "Continue with Plex",
+      };
+    case "jellyfin":
+      return {
+        eyebrow: "Direct Server Login",
+        summary: "Connect directly to a Jellyfin server with its base URL and an administrator account.",
+        action: "Connect Jellyfin",
+      };
+    default:
+      return {
+        eyebrow: "Provider Setup",
+        summary: `Connect ${provider.name} to start pulling active sessions into Cliparr.`,
+        action: `Continue with ${provider.name}`,
+      };
+  }
+}
+
+export function ProviderBadge({
+  providerId,
+  name,
+  selected,
+  large = false,
+}: {
+  providerId: string;
+  name: string;
+  selected: boolean;
+  large?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl p-3 transition-colors",
+        selected ? "bg-primary/15" : "bg-card"
+      )}
+    >
+      <ProviderGlyph
+        providerId={providerId}
+        providerName={name}
+        className={large ? "h-6 w-6" : "h-5 w-5"}
+        fallbackClassName={selected ? "text-primary" : "text-muted-foreground"}
+      />
+    </div>
+  );
+}
+
+export function ProviderConnectError({
+  error,
+  isScreen,
+}: {
+  error: string;
+  isScreen: boolean;
+}) {
+  if (!error) {
+    return null;
+  }
+
+  if (!isScreen) {
+    return (
+      <div className="rounded-2xl border border-destructive/20 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-5 min-h-19">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={error}
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          className="rounded-2xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          {error}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function ProviderStatusMessage({
+  children,
+  isScreen,
+}: {
+  children: string;
+  isScreen: boolean;
+}) {
+  return (
+    <div className={cn(
+      "text-center text-sm text-muted-foreground",
+      isScreen
+        ? "py-12"
+        : "rounded-3xl border border-border bg-background/60 px-6 py-10"
+    )}>
+      {children}
+    </div>
+  );
+}
+
+export function ProviderOption({
+  provider,
+  selectedProvider,
+  authenticating,
+  authenticatingProviderId,
+  variant,
+  onSelect,
+}: {
+  provider: ProviderDefinition;
+  selectedProvider?: ProviderDefinition;
+  authenticating: boolean;
+  authenticatingProviderId: string;
+  variant: "panel" | "screen";
+  onSelect: (providerId: string) => void;
+}) {
+  const isScreen = variant === "screen";
+  const details = providerPresentation(provider, variant);
+  const isSelected = provider.id === selectedProvider?.id;
+  const isBusy = authenticating && authenticatingProviderId === provider.id;
+  const commonProps = {
+    type: "button" as const,
+    onClick: () => onSelect(provider.id),
+    disabled: authenticating && !isBusy,
+    className: cn(
+      "w-full rounded-2xl border px-4 py-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+      isSelected
+        ? isScreen
+          ? "border-primary/40 bg-primary/10 shadow-lg"
+          : "border-primary/30 bg-primary/10"
+        : "border-border bg-background hover:bg-accent/60"
+    ),
+  };
+
+  const content = (
+    <div className="flex items-start gap-4">
+      <ProviderBadge
+        providerId={provider.id}
+        name={provider.name}
+        selected={isSelected}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
+              {details.eyebrow}
+            </p>
+            <h2 className="mt-1 text-lg font-semibold text-foreground">
+              {provider.name}
+            </h2>
+          </div>
+          {isSelected && (
+            isScreen ? (
+              <motion.span
+                layout
+                initial={{ opacity: 0, scale: 0.92 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.92 }}
+                className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[var(--tracking-caps-lg)] text-primary"
+              >
+                Selected
+              </motion.span>
+            ) : (
+              <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[var(--tracking-caps-lg)] text-primary">
+                Selected
+              </span>
+            )
+          )}
+        </div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {details.summary}
+        </p>
+        {isBusy && (
+          <p className="mt-3 text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-primary">
+            In progress
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
+  if (!isScreen) {
+    return (
+      <button {...commonProps}>
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <motion.button
+      layout
+      whileHover={authenticating && !isBusy ? undefined : { y: -2 }}
+      whileTap={authenticating && !isBusy ? undefined : { scale: 0.995 }}
+      transition={{ duration: 0.16, ease: "easeOut" }}
+      {...commonProps}
+    >
+      {content}
+    </motion.button>
+  );
+}

--- a/apps/frontend/src/components/SourcesModal.tsx
+++ b/apps/frontend/src/components/SourcesModal.tsx
@@ -14,6 +14,7 @@ import {
   SourcesModalHeader,
   stringValue,
 } from "./SourcesModalSections";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 
 interface Props {
   isOpen: boolean;
@@ -38,7 +39,6 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
   const [showAddSource, setShowAddSource] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const latestLoadRequestIdRef = useRef(0);
   const isOpenRef = useRef(isOpen);
 
@@ -351,71 +351,12 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
     }
   }, [isOpen, loading, sources.length]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-    const frameId = window.requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-    });
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-        return;
-      }
-
-      if (event.key !== "Tab") {
-        return;
-      }
-
-      const dialog = dialogRef.current;
-      if (!dialog) {
-        return;
-      }
-
-      const focusable = [...dialog.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )].filter((element) => element.getAttribute("aria-hidden") !== "true");
-
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialog.focus();
-        return;
-      }
-
-      const firstFocusable = focusable[0];
-      const lastFocusable = focusable[focusable.length - 1];
-      const activeElement = document.activeElement;
-
-      if (event.shiftKey) {
-        if (activeElement === firstFocusable || !dialog.contains(activeElement)) {
-          event.preventDefault();
-          lastFocusable?.focus();
-        }
-        return;
-      }
-
-      if (activeElement === lastFocusable) {
-        event.preventDefault();
-        firstFocusable?.focus();
-      }
-    }
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.cancelAnimationFrame(frameId);
-      window.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = previousOverflow;
-      lastFocusedElementRef.current?.focus();
-    };
-  }, [isOpen, onClose]);
+  useModalFocusTrap({
+    isOpen,
+    dialogRef,
+    initialFocusRef: searchInputRef,
+    onEscape: onClose,
+  });
 
   const providerOptions = useMemo(() => {
     const providers = [...new Set(sources.map((source) => source.providerId))];

--- a/apps/frontend/src/components/SourcesModal.tsx
+++ b/apps/frontend/src/components/SourcesModal.tsx
@@ -1,20 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { cliparrClient } from "../api/cliparrClient";
-import { useAuth } from "../auth";
-import type { MediaSource, ProviderSession } from "../providers/types";
-import type { Feedback, SourceFilter } from "./SourcesModalSections";
+import { useRef } from "react";
 import {
-  compareStrings,
-  sortSources,
   SourceCard,
   SourcesConnectSection,
   SourcesEmptyState,
   SourcesModalAlerts,
   SourcesModalFilters,
   SourcesModalHeader,
-  stringValue,
 } from "./SourcesModalSections";
 import { useModalFocusTrap } from "./useModalFocusTrap";
+import { useSourcesModalState } from "./useSourcesModalState";
 
 interface Props {
   isOpen: boolean;
@@ -22,355 +16,45 @@ interface Props {
   onSourcesChanged?: () => Promise<void> | void;
 }
 
-interface SourceActionResult {
-  feedback: Feedback;
-  source?: MediaSource;
-  removeSourceId?: string;
-}
-
-function draftBaseUrlsFor(sources: readonly MediaSource[]) {
-  return Object.fromEntries(sources.map((source) => [source.id, source.baseUrl]));
-}
-
-function draftNamesFor(sources: readonly MediaSource[]) {
-  return Object.fromEntries(sources.map((source) => [source.id, source.name]));
-}
-
 export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Props) {
-  const auth = useAuth();
-  const [sources, setSources] = useState<MediaSource[]>([]);
-  const [draftBaseUrls, setDraftBaseUrls] = useState<Record<string, string>>({});
-  const [draftNames, setDraftNames] = useState<Record<string, string>>({});
-  const [query, setQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<SourceFilter>("all");
-  const [providerFilter, setProviderFilter] = useState("all");
-  const [loading, setLoading] = useState(false);
-  const [reloading, setReloading] = useState(false);
-  const [refreshingAll, setRefreshingAll] = useState(false);
-  const [busyActions, setBusyActions] = useState<Record<string, string>>({});
-  const [error, setError] = useState("");
-  const [feedback, setFeedback] = useState<Feedback | null>(null);
-  const [showAddSource, setShowAddSource] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const latestLoadRequestIdRef = useRef(0);
-  const isOpenRef = useRef(isOpen);
-
-  const replaceSources = useCallback((nextSources: MediaSource[]) => {
-    setSources(nextSources);
-    setDraftBaseUrls(draftBaseUrlsFor(nextSources));
-    setDraftNames(draftNamesFor(nextSources));
-  }, []);
-
-  const applyLoadedSources = useCallback(async (requestId: number) => {
-    const nextSources = sortSources(await cliparrClient.listSources());
-    if (requestId !== latestLoadRequestIdRef.current || !isOpenRef.current) {
-      return false;
-    }
-
-    replaceSources(nextSources);
-    return true;
-  }, [replaceSources]);
-
-  const loadSources = useCallback(async (mode: "initial" | "reload" = "initial") => {
-    const requestId = latestLoadRequestIdRef.current + 1;
-    latestLoadRequestIdRef.current = requestId;
-    const isCurrentRequest = () => requestId === latestLoadRequestIdRef.current && isOpenRef.current;
-
-    if (mode === "initial") {
-      setLoading(true);
-    } else {
-      setReloading(true);
-    }
-
-    setError("");
-
-    try {
-      await applyLoadedSources(requestId);
-    } catch (err) {
-      if (!isCurrentRequest()) {
-        return;
-      }
-
-      const message = err instanceof Error ? err.message : "Failed to load sources";
-      setSources([]);
-      setDraftBaseUrls({});
-      setDraftNames({});
-      setError(message);
-    } finally {
-      if (isCurrentRequest()) {
-        if (mode === "initial") {
-          setLoading(false);
-        } else {
-          setReloading(false);
-        }
-      }
-    }
-  }, [applyLoadedSources]);
-
-  function updateBusyAction(sourceId: string, action?: string) {
-    setBusyActions((current) => {
-      const next = { ...current };
-      if (action) {
-        next[sourceId] = action;
-      } else {
-        delete next[sourceId];
-      }
-      return next;
-    });
-  }
-
-  function upsertSource(source: MediaSource) {
-    setSources((current) => {
-      const exists = current.some((item) => item.id === source.id);
-      return sortSources(exists ? current.map((item) => (item.id === source.id ? source : item)) : [...current, source]);
-    });
-    setDraftBaseUrls((current) => ({
-      ...current,
-      [source.id]: source.baseUrl,
-    }));
-    setDraftNames((current) => ({
-      ...current,
-      [source.id]: source.name,
-    }));
-  }
-
-  function removeSource(sourceId: string) {
-    setSources((current) => current.filter((source) => source.id !== sourceId));
-    setDraftBaseUrls((current) => {
-      const next = { ...current };
-      delete next[sourceId];
-      return next;
-    });
-    setDraftNames((current) => {
-      const next = { ...current };
-      delete next[sourceId];
-      return next;
-    });
-  }
-
-  async function refreshPlaybackView() {
-    await onSourcesChanged?.();
-  }
-
-  async function runSourceAction(
-    source: MediaSource,
-    busyAction: string,
-    fallbackError: string,
-    action: () => Promise<SourceActionResult>
-  ) {
-    setFeedback(null);
-    setError("");
-    updateBusyAction(source.id, busyAction);
-
-    try {
-      const result = await action();
-      if (result.source) {
-        upsertSource(result.source);
-      }
-      if (result.removeSourceId) {
-        removeSource(result.removeSourceId);
-      }
-      setFeedback(result.feedback);
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : fallbackError;
-      setError(message);
-    } finally {
-      updateBusyAction(source.id);
-    }
-  }
-
-  async function handleSourceConnected(session: ProviderSession) {
-    auth.setProviderSession(session);
-    setFeedback({
-      tone: "success",
-      message: "Source connected. Refreshing your library list now.",
-    });
-    setShowAddSource(false);
-    await loadSources("reload");
-    await refreshPlaybackView();
-  }
-
-  async function saveSourceEdits(source: MediaSource) {
-    const nextName = (draftNames[source.id] ?? source.name).trim();
-    const nextBaseUrl = (draftBaseUrls[source.id] ?? source.baseUrl).trim();
-    const hasNameChange = Boolean(nextName) && nextName !== source.name;
-    const hasBaseUrlChange = Boolean(nextBaseUrl) && nextBaseUrl !== source.baseUrl;
-
-    if (!hasNameChange && !hasBaseUrlChange) {
-      return;
-    }
-
-    await runSourceAction(source, "Saving...", "Failed to update source", async () => {
-      const updatedSource = await cliparrClient.updateSource(source.id, {
-        ...(hasNameChange ? { name: nextName } : {}),
-        ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
-      });
-
-      return {
-        source: updatedSource,
-        feedback: {
-          tone: "success",
-          message: `Updated ${updatedSource.name}.`,
-        },
-      };
-    });
-  }
-
-  async function toggleSourceEnabled(source: MediaSource) {
-    await runSourceAction(
-      source,
-      source.enabled ? "Disabling..." : "Enabling...",
-      "Failed to update source",
-      async () => {
-        const updatedSource = await cliparrClient.updateSource(source.id, { enabled: !source.enabled });
-
-        return {
-          source: updatedSource,
-          feedback: {
-            tone: "success",
-            message: `${updatedSource.name} is now ${updatedSource.enabled ? "enabled" : "disabled"}.`,
-          },
-        };
-      },
-    );
-  }
-
-  async function checkSource(source: MediaSource) {
-    await runSourceAction(source, "Refreshing...", "Failed to refresh source", async () => {
-      const result = await cliparrClient.checkSource(source.id);
-
-      return {
-        source: result.source,
-        feedback: {
-          tone: result.ok ? "success" : "warning",
-          message: result.ok
-            ? `${result.source.name} passed its health check.`
-            : `${result.source.name} still needs attention.`,
-        },
-      };
-    });
-  }
-
-  async function deleteSource(source: MediaSource) {
-    const confirmed = window.confirm(
-      `Remove ${source.name}? Cliparr will stop querying it until it is reconnected.`
-    );
-    if (!confirmed) {
-      return;
-    }
-
-    await runSourceAction(source, "Removing...", "Failed to remove source", async () => {
-      await cliparrClient.deleteSource(source.id);
-
-      return {
-        removeSourceId: source.id,
-        feedback: {
-          tone: "success",
-          message: `Removed ${source.name}.`,
-        },
-      };
-    });
-  }
-
-  async function refreshAllSources() {
-    if (sources.length === 0) {
-      return;
-    }
-
-    setFeedback(null);
-    setError("");
-    setRefreshingAll(true);
-    setBusyActions(Object.fromEntries(sources.map((source) => [source.id, "Refreshing..."])));
-
-    try {
-      const results = await Promise.allSettled(
-        sources.map(async (source) => {
-          const result = await cliparrClient.checkSource(source.id);
-          return { source, result };
-        })
-      );
-
-      const nextSources = new Map(sources.map((source) => [source.id, source]));
-      let healthyCount = 0;
-      let attentionCount = 0;
-      let failedCount = 0;
-
-      results.forEach((entry, index) => {
-        const currentSource = sources[index];
-        if (!currentSource) {
-          return;
-        }
-
-        if (entry.status === "fulfilled") {
-          nextSources.set(entry.value.result.source.id, entry.value.result.source);
-          if (entry.value.result.ok) {
-            healthyCount += 1;
-          } else {
-            attentionCount += 1;
-          }
-          return;
-        }
-
-        failedCount += 1;
-      });
-
-      const mergedSources = sortSources([...nextSources.values()]);
-      replaceSources(mergedSources);
-
-      const summaryParts = [
-        `${healthyCount} healthy`,
-        `${attentionCount} need attention`,
-      ];
-      if (failedCount > 0) {
-        summaryParts.push(`${failedCount} failed to refresh`);
-      }
-
-      setFeedback({
-        tone: attentionCount > 0 || failedCount > 0 ? "warning" : "success",
-        message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}: ${summaryParts.join(", ")}.`,
-      });
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to refresh sources";
-      setError(message);
-    } finally {
-      setRefreshingAll(false);
-      setBusyActions({});
-    }
-  }
-
-  useEffect(() => {
-    isOpenRef.current = isOpen;
-    if (!isOpen) {
-      latestLoadRequestIdRef.current += 1;
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setShowAddSource(false);
-      return;
-    }
-
-    setFeedback(null);
-    void loadSources();
-  }, [isOpen, loadSources]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    if (loading) {
-      return;
-    }
-
-    if (sources.length === 0) {
-      setShowAddSource(true);
-    }
-  }, [isOpen, loading, sources.length]);
+  const {
+    sources,
+    filteredSources,
+    draftBaseUrls,
+    draftNames,
+    query,
+    setQuery,
+    statusFilter,
+    setStatusFilter,
+    providerFilter,
+    setProviderFilter,
+    providerOptions,
+    loading,
+    reloading,
+    refreshingAll,
+    busyActions,
+    error,
+    feedback,
+    showConnectPanel,
+    forceAddSourceOpen,
+    hasBusyActions,
+    counts,
+    setShowAddSource,
+    loadSources,
+    refreshAllSources,
+    handleSourceConnected,
+    saveSourceEdits,
+    toggleSourceEnabled,
+    checkSource,
+    deleteSource,
+    updateDraftName,
+    updateDraftBaseUrl,
+  } = useSourcesModalState({
+    isOpen,
+    onSourcesChanged,
+  });
 
   useModalFocusTrap({
     isOpen,
@@ -378,65 +62,6 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
     initialFocusRef: searchInputRef,
     onEscape: onClose,
   });
-
-  const providerOptions = useMemo(() => {
-    const providers = [...new Set(sources.map((source) => source.providerId))];
-    return providers.sort(compareStrings);
-  }, [sources]);
-
-  useEffect(() => {
-    if (providerFilter === "all" || providerOptions.includes(providerFilter)) {
-      return;
-    }
-
-    setProviderFilter("all");
-  }, [providerFilter, providerOptions]);
-
-  const counts = useMemo(() => ({
-    all: sources.length,
-    enabled: sources.filter((source) => source.enabled).length,
-    disabled: sources.filter((source) => !source.enabled).length,
-    attention: sources.filter((source) => Boolean(source.lastError)).length,
-  }), [sources]);
-
-  const filteredSources = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-
-    return sources.filter((source) => {
-      if (providerFilter !== "all" && source.providerId !== providerFilter) {
-        return false;
-      }
-
-      if (statusFilter === "enabled" && !source.enabled) {
-        return false;
-      }
-
-      if (statusFilter === "disabled" && source.enabled) {
-        return false;
-      }
-
-      if (statusFilter === "attention" && !source.lastError) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      const haystack = [
-        source.name,
-        source.baseUrl,
-        source.providerId,
-        stringValue(source.metadata.product),
-        stringValue(source.metadata.platform),
-      ].filter(Boolean).join(" ").toLowerCase();
-
-      return haystack.includes(normalizedQuery);
-    });
-  }, [providerFilter, query, sources, statusFilter]);
-  const hasBusyActions = Object.keys(busyActions).length > 0;
-  const forceAddSourceOpen = !loading && sources.length === 0;
-  const showConnectPanel = showAddSource || forceAddSourceOpen;
 
   if (!isOpen) {
     return null;
@@ -524,14 +149,8 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
                     draftBaseUrl={draftBaseUrls[source.id] ?? source.baseUrl}
                     busyAction={busyActions[source.id]}
                     refreshingAll={refreshingAll}
-                    onDraftNameChange={(value) => setDraftNames((current) => ({
-                      ...current,
-                      [source.id]: value,
-                    }))}
-                    onDraftBaseUrlChange={(value) => setDraftBaseUrls((current) => ({
-                      ...current,
-                      [source.id]: value,
-                    }))}
+                    onDraftNameChange={(value) => updateDraftName(source.id, value)}
+                    onDraftBaseUrlChange={(value) => updateDraftBaseUrl(source.id, value)}
                     onSave={() => saveSourceEdits(source)}
                     onToggleEnabled={() => toggleSourceEnabled(source)}
                     onRefresh={() => checkSource(source)}

--- a/apps/frontend/src/components/SourcesModal.tsx
+++ b/apps/frontend/src/components/SourcesModal.tsx
@@ -22,6 +22,20 @@ interface Props {
   onSourcesChanged?: () => Promise<void> | void;
 }
 
+interface SourceActionResult {
+  feedback: Feedback;
+  source?: MediaSource;
+  removeSourceId?: string;
+}
+
+function draftBaseUrlsFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.baseUrl]));
+}
+
+function draftNamesFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.name]));
+}
+
 export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Props) {
   const auth = useAuth();
   const [sources, setSources] = useState<MediaSource[]>([]);
@@ -42,17 +56,21 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
   const latestLoadRequestIdRef = useRef(0);
   const isOpenRef = useRef(isOpen);
 
+  const replaceSources = useCallback((nextSources: MediaSource[]) => {
+    setSources(nextSources);
+    setDraftBaseUrls(draftBaseUrlsFor(nextSources));
+    setDraftNames(draftNamesFor(nextSources));
+  }, []);
+
   const applyLoadedSources = useCallback(async (requestId: number) => {
     const nextSources = sortSources(await cliparrClient.listSources());
     if (requestId !== latestLoadRequestIdRef.current || !isOpenRef.current) {
       return false;
     }
 
-    setSources(nextSources);
-    setDraftBaseUrls(Object.fromEntries(nextSources.map((source) => [source.id, source.baseUrl])));
-    setDraftNames(Object.fromEntries(nextSources.map((source) => [source.id, source.name])));
+    replaceSources(nextSources);
     return true;
-  }, []);
+  }, [replaceSources]);
 
   const loadSources = useCallback(async (mode: "initial" | "reload" = "initial") => {
     const requestId = latestLoadRequestIdRef.current + 1;
@@ -135,6 +153,34 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
     await onSourcesChanged?.();
   }
 
+  async function runSourceAction(
+    source: MediaSource,
+    busyAction: string,
+    fallbackError: string,
+    action: () => Promise<SourceActionResult>
+  ) {
+    setFeedback(null);
+    setError("");
+    updateBusyAction(source.id, busyAction);
+
+    try {
+      const result = await action();
+      if (result.source) {
+        upsertSource(result.source);
+      }
+      if (result.removeSourceId) {
+        removeSource(result.removeSourceId);
+      }
+      setFeedback(result.feedback);
+      await refreshPlaybackView();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : fallbackError;
+      setError(message);
+    } finally {
+      updateBusyAction(source.id);
+    }
+  }
+
   async function handleSourceConnected(session: ProviderSession) {
     auth.setProviderSession(session);
     setFeedback({
@@ -156,71 +202,55 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
       return;
     }
 
-    setFeedback(null);
-    setError("");
-    updateBusyAction(source.id, "Saving...");
-
-    try {
+    await runSourceAction(source, "Saving...", "Failed to update source", async () => {
       const updatedSource = await cliparrClient.updateSource(source.id, {
         ...(hasNameChange ? { name: nextName } : {}),
         ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
       });
-      upsertSource(updatedSource);
-      setFeedback({
-        tone: "success",
-        message: `Updated ${updatedSource.name}.`,
-      });
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to update source";
-      setError(message);
-    } finally {
-      updateBusyAction(source.id);
-    }
+
+      return {
+        source: updatedSource,
+        feedback: {
+          tone: "success",
+          message: `Updated ${updatedSource.name}.`,
+        },
+      };
+    });
   }
 
   async function toggleSourceEnabled(source: MediaSource) {
-    setFeedback(null);
-    setError("");
-    updateBusyAction(source.id, source.enabled ? "Disabling..." : "Enabling...");
+    await runSourceAction(
+      source,
+      source.enabled ? "Disabling..." : "Enabling...",
+      "Failed to update source",
+      async () => {
+        const updatedSource = await cliparrClient.updateSource(source.id, { enabled: !source.enabled });
 
-    try {
-      const updatedSource = await cliparrClient.updateSource(source.id, { enabled: !source.enabled });
-      upsertSource(updatedSource);
-      setFeedback({
-        tone: "success",
-        message: `${updatedSource.name} is now ${updatedSource.enabled ? "enabled" : "disabled"}.`,
-      });
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to update source";
-      setError(message);
-    } finally {
-      updateBusyAction(source.id);
-    }
+        return {
+          source: updatedSource,
+          feedback: {
+            tone: "success",
+            message: `${updatedSource.name} is now ${updatedSource.enabled ? "enabled" : "disabled"}.`,
+          },
+        };
+      },
+    );
   }
 
   async function checkSource(source: MediaSource) {
-    setFeedback(null);
-    setError("");
-    updateBusyAction(source.id, "Refreshing...");
-
-    try {
+    await runSourceAction(source, "Refreshing...", "Failed to refresh source", async () => {
       const result = await cliparrClient.checkSource(source.id);
-      upsertSource(result.source);
-      setFeedback({
-        tone: result.ok ? "success" : "warning",
-        message: result.ok
-          ? `${result.source.name} passed its health check.`
-          : `${result.source.name} still needs attention.`,
-      });
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to refresh source";
-      setError(message);
-    } finally {
-      updateBusyAction(source.id);
-    }
+
+      return {
+        source: result.source,
+        feedback: {
+          tone: result.ok ? "success" : "warning",
+          message: result.ok
+            ? `${result.source.name} passed its health check.`
+            : `${result.source.name} still needs attention.`,
+        },
+      };
+    });
   }
 
   async function deleteSource(source: MediaSource) {
@@ -231,24 +261,17 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
       return;
     }
 
-    setFeedback(null);
-    setError("");
-    updateBusyAction(source.id, "Removing...");
-
-    try {
+    await runSourceAction(source, "Removing...", "Failed to remove source", async () => {
       await cliparrClient.deleteSource(source.id);
-      removeSource(source.id);
-      setFeedback({
-        tone: "success",
-        message: `Removed ${source.name}.`,
-      });
-      await refreshPlaybackView();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to remove source";
-      setError(message);
-    } finally {
-      updateBusyAction(source.id);
-    }
+
+      return {
+        removeSourceId: source.id,
+        feedback: {
+          tone: "success",
+          message: `Removed ${source.name}.`,
+        },
+      };
+    });
   }
 
   async function refreshAllSources() {
@@ -294,9 +317,7 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
       });
 
       const mergedSources = sortSources([...nextSources.values()]);
-      setSources(mergedSources);
-      setDraftBaseUrls(Object.fromEntries(mergedSources.map((source) => [source.id, source.baseUrl])));
-      setDraftNames(Object.fromEntries(mergedSources.map((source) => [source.id, source.name])));
+      replaceSources(mergedSources);
 
       const summaryParts = [
         `${healthyCount} healthy`,

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -1,5 +1,5 @@
 import { Download, Info, X } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import {
   Select,
   SelectContent,
@@ -20,6 +20,7 @@ import {
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
 } from "../../lib/exportFileName";
+import { useModalFocusTrap } from "../useModalFocusTrap";
 import { formatTime } from "./EditorUtils";
 
 interface VideoDimensions {
@@ -200,7 +201,6 @@ export function EditorExportDialog({
   onExport,
 }: EditorExportDialogProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const clipLength = Math.max(0, clipEnd - clipStart);
   const selectedFormatOption = formatOptions.find((option) => option.value === selectedFormat) ?? formatOptions[0];
   const selectedSourceOption = sourceOptions.find((option) => option.value === selectedSourcePreference) ?? sourceOptions[0];
@@ -212,76 +212,11 @@ export function EditorExportDialog({
       ? "border-amber-500/30 bg-amber-500/8"
       : "border-border bg-background";
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-
-    const frameId = window.requestAnimationFrame(() => {
-      dialogRef.current?.focus();
-    });
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        if (!exporting) {
-          onClose();
-        }
-        return;
-      }
-
-      if (event.key !== "Tab") {
-        return;
-      }
-
-      const dialog = dialogRef.current;
-      if (!dialog) {
-        return;
-      }
-
-      const focusable = [...dialog.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )].filter((element) => element.getAttribute("aria-hidden") !== "true");
-
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialog.focus();
-        return;
-      }
-
-      const firstFocusable = focusable[0];
-      const lastFocusable = focusable[focusable.length - 1];
-      const activeElement = document.activeElement;
-
-      if (event.shiftKey) {
-        if (activeElement === firstFocusable || !dialog.contains(activeElement)) {
-          event.preventDefault();
-          lastFocusable?.focus();
-        }
-        return;
-      }
-
-      if (activeElement === lastFocusable) {
-        event.preventDefault();
-        firstFocusable?.focus();
-      }
-    }
-
-    window.addEventListener("keydown", onKeyDown);
-
-    return () => {
-      window.cancelAnimationFrame(frameId);
-      window.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = previousOverflow;
-      lastFocusedElementRef.current?.focus();
-    };
-  }, [exporting, isOpen, onClose]);
+  useModalFocusTrap({
+    isOpen,
+    dialogRef,
+    onEscape: exporting ? undefined : onClose,
+  });
 
   if (!isOpen) {
     return null;

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -1,27 +1,17 @@
-import { Download, Info, X } from "lucide-react";
+import { Download, X } from "lucide-react";
 import { useRef } from "react";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
 import {
-  getExportFileNameTemplateTokens,
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
 } from "../../lib/exportFileName";
 import { useModalFocusTrap } from "../useModalFocusTrap";
-import { formatTime } from "./EditorUtils";
+import {
+  EditorExportSettingsSection,
+  EditorExportSummaryPanel,
+  EditorFilenameTemplateSection,
+  formatOptionFor,
+} from "./EditorExportDialogSections";
 
 interface VideoDimensions {
   width: number;
@@ -67,103 +57,6 @@ interface EditorExportDialogProps {
   onExport: () => void;
 }
 
-const formatOptions: ReadonlyArray<{
-  value: ExportFormat;
-  label: string;
-  extension: string;
-  description: string;
-}> = [
-  {
-    value: "mp4",
-    label: "MP4",
-    extension: ".mp4",
-    description: "Best for everyday sharing, browser playback, and platform uploads.",
-  },
-  {
-    value: "webm",
-    label: "WEBM",
-    extension: ".webm",
-    description: "Modern web-first delivery with efficient browser-friendly playback.",
-  },
-  {
-    value: "mov",
-    label: "MOV",
-    extension: ".mov",
-    description: "A professional container that fits Adobe-style editorial workflows.",
-  },
-  {
-    value: "mkv",
-    label: "MKV",
-    extension: ".mkv",
-    description: "A flexible container for preserving a wider range of stream layouts.",
-  },
-];
-
-const resolutionOptions: ReadonlyArray<{
-  value: ExportResolution;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "original",
-    label: "Original",
-    description: "Keeps the source dimensions when possible.",
-  },
-  {
-    value: "1080",
-    label: "1080p",
-    description: "Balanced delivery size for full HD exports.",
-  },
-  {
-    value: "720",
-    label: "720p",
-    description: "Lighter output for faster downloads and sharing.",
-  },
-];
-
-const sourceOptions: ReadonlyArray<{
-  value: ExportSourcePreference;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "auto",
-    label: "Auto",
-    description: "Lets Cliparr choose the safest export path for this session.",
-  },
-  {
-    value: "direct",
-    label: "Direct/original",
-    description: "Uses the direct media path when available, usually best for preserving source quality.",
-  },
-  {
-    value: "hls",
-    label: "HLS playback",
-    description: "Uses the media server playback stream, which may include server-side transcoding.",
-  },
-];
-
-const templateOptions: ReadonlyArray<{
-  kind: ExportFileNameTemplateKind;
-  label: string;
-  description: string;
-}> = [
-  {
-    kind: "movie",
-    label: "Movies",
-    description: "Used for films and non-episode items.",
-  },
-  {
-    kind: "episode",
-    label: "TV Shows",
-    description: "Used for episode exports with series metadata.",
-  },
-];
-
-function compactSelectTriggerClassName() {
-  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
-}
-
 export function EditorExportDialog({
   isOpen,
   title,
@@ -201,16 +94,7 @@ export function EditorExportDialog({
   onExport,
 }: EditorExportDialogProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const clipLength = Math.max(0, clipEnd - clipStart);
-  const selectedFormatOption = formatOptions.find((option) => option.value === selectedFormat) ?? formatOptions[0];
-  const selectedSourceOption = sourceOptions.find((option) => option.value === selectedSourcePreference) ?? sourceOptions[0];
-  const editingTemplateOption = templateOptions.find((option) => option.kind === editingTemplateKind) ?? templateOptions[0];
-  const visibleTokens = getExportFileNameTemplateTokens(editingTemplateKind);
-  const subtitleSummaryClassName = subtitleSummaryTone === "ready"
-    ? "border-emerald-500/30 bg-emerald-500/8"
-    : subtitleSummaryTone === "warning"
-      ? "border-amber-500/30 bg-amber-500/8"
-      : "border-border bg-background";
+  const selectedFormatOption = formatOptionFor(selectedFormat);
 
   useModalFocusTrap({
     isOpen,
@@ -278,272 +162,43 @@ export function EditorExportDialog({
               </div>
             )}
 
-            <section className="rounded-md border border-border bg-card">
-              <div className="border-b border-border px-3 py-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                  Export Settings
-                </div>
-              </div>
-              <div className="grid gap-3 p-3 sm:grid-cols-2">
-                <label className="space-y-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                    Format
-                  </span>
-                  <Select value={selectedFormat} onValueChange={(value) => onFormatChange(value as ExportFormat)}>
-                    <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
-                      <SelectValue placeholder="Select format" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>Formats</SelectLabel>
-                        {formatOptions.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label} {option.extension}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">{selectedFormatOption.description}</p>
-                </label>
+            <EditorExportSettingsSection
+              selectedFormat={selectedFormat}
+              onFormatChange={onFormatChange}
+              selectedResolution={selectedResolution}
+              onResolutionChange={onResolutionChange}
+              selectedSourcePreference={selectedSourcePreference}
+              onSourcePreferenceChange={onSourcePreferenceChange}
+              includeAudio={includeAudio}
+              onIncludeAudioChange={onIncludeAudioChange}
+              hasHlsSource={hasHlsSource}
+              hasDirectSource={hasDirectSource}
+            />
 
-                <label className="space-y-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                    Resolution
-                  </span>
-                  <Select value={selectedResolution} onValueChange={(value) => onResolutionChange(value as ExportResolution)}>
-                    <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
-                      <SelectValue placeholder="Select resolution" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>Resolutions</SelectLabel>
-                        {resolutionOptions.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {resolutionOptions.find((option) => option.value === selectedResolution)?.description}
-                  </p>
-                </label>
-
-                <div className="space-y-1.5">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                      Source
-                    </span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          aria-label="Export source details"
-                          className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
-                        >
-                          <Info className="h-3.5 w-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" align="start">
-                        Track and timing detection can still use HLS metadata when Cliparr can read it. This only chooses which media path is used for the exported file.
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <Select
-                    value={selectedSourcePreference}
-                    onValueChange={(value) => onSourcePreferenceChange(value as ExportSourcePreference)}
-                  >
-                    <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
-                      <SelectValue placeholder="Select source" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>Sources</SelectLabel>
-                        {sourceOptions.map((option) => (
-                          <SelectItem
-                            key={option.value}
-                            value={option.value}
-                            disabled={
-                              (option.value === "direct" && !hasDirectSource)
-                              || (option.value === "hls" && !hasHlsSource)
-                            }
-                          >
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">{selectedSourceOption.description}</p>
-                </div>
-
-                <label className="space-y-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                    Audio
-                  </span>
-                  <Select
-                    value={includeAudio ? "included" : "video-only"}
-                    onValueChange={(value) => onIncludeAudioChange(value === "included")}
-                  >
-                    <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
-                      <SelectValue placeholder="Select audio option" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>Audio</SelectLabel>
-                        <SelectItem value="included">Include Audio</SelectItem>
-                        <SelectItem value="video-only">Video Only</SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {includeAudio ? "Keeps a stereo mix when source audio exists." : "Exports without an audio track."}
-                  </p>
-                </label>
-              </div>
-            </section>
-
-            <section className="rounded-md border border-border bg-card">
-              <div className="border-b border-border px-3 py-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                  Filename Template
-                </div>
-              </div>
-              <div className="space-y-3 p-3">
-                <div className="grid gap-3 sm:grid-cols-[12rem_auto] sm:items-end">
-                  <label className="space-y-1.5">
-                    <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                      Template Set
-                    </span>
-                    <Select
-                      value={editingTemplateKind}
-                      onValueChange={(value) => onEditingTemplateKindChange(value as ExportFileNameTemplateKind)}
-                    >
-                      <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
-                        <SelectValue placeholder="Select template set" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectLabel>Templates</SelectLabel>
-                          {templateOptions.map((option) => (
-                            <SelectItem key={option.kind} value={option.kind}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </label>
-
-                  <button
-                    type="button"
-                    onClick={() => onResetFileNameTemplate(editingTemplateKind)}
-                    className="inline-flex h-8 items-center justify-center rounded-md border border-border bg-background px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  >
-                    Reset
-                  </button>
-                </div>
-
-                <label className="block space-y-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                    Pattern
-                  </span>
-                  <input
-                    type="text"
-                    value={fileNameTemplates[editingTemplateKind]}
-                    onChange={(event) => onFileNameTemplateChange(editingTemplateKind, event.target.value)}
-                    className="h-8 w-full rounded-md border border-input bg-background px-2.5 font-mono text-xs text-foreground outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/40"
-                    spellCheck={false}
-                  />
-                </label>
-
-                <p className="text-xs text-muted-foreground">{editingTemplateOption.description}</p>
-
-                <div className="rounded-md border border-border bg-background px-3 py-2">
-                  <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                    Available Tokens
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {visibleTokens.map((token) => (
-                      <code
-                        key={token}
-                        className="rounded-md border border-border bg-card px-2 py-0.5 font-mono text-[11px] text-foreground"
-                      >
-                        {`{${token}}`}
-                      </code>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </section>
+            <EditorFilenameTemplateSection
+              editingTemplateKind={editingTemplateKind}
+              onEditingTemplateKindChange={onEditingTemplateKindChange}
+              fileNameTemplates={fileNameTemplates}
+              onFileNameTemplateChange={onFileNameTemplateChange}
+              onResetFileNameTemplate={onResetFileNameTemplate}
+            />
           </div>
 
-          <aside className="space-y-3 rounded-md border border-border bg-card p-3">
-            <div className="border-b border-border pb-2">
-              <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                Summary
-              </div>
-            </div>
-
-            <div className="text-sm font-medium text-foreground">{title}</div>
-
-            <dl className="grid gap-2 text-sm">
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Clip</dt>
-                <dd className="mt-1 font-mono text-xs text-foreground">
-                  {formatTime(clipStart)} to {formatTime(clipEnd)}
-                </dd>
-              </div>
-
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Duration</dt>
-                <dd className="mt-1 font-mono text-xs text-foreground">{formatTime(clipLength)}</dd>
-              </div>
-
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Source</dt>
-                <dd className="mt-1 text-xs text-foreground">
-                  {exportSourceLabel}
-                </dd>
-                {exportSourceSummaryMessage ? (
-                  <dd className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                    {exportSourceSummaryMessage}
-                  </dd>
-                ) : null}
-              </div>
-
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Output</dt>
-                <dd className="mt-1 text-xs text-foreground">{selectedFormatOption.label}</dd>
-                <dd className="mt-1 font-mono text-[11px] text-foreground">
-                  {outputDimensions ? `${outputDimensions.width} x ${outputDimensions.height}` : "Unknown size"}
-                </dd>
-              </div>
-
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Audio</dt>
-                <dd className="mt-1 text-xs text-foreground">
-                  {includeAudio ? "Included when available" : "Video only"}
-                </dd>
-              </div>
-
-              <div className={`rounded-md border px-3 py-2 ${subtitleSummaryClassName}`}>
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Subtitles</dt>
-                <dd className="mt-1 text-xs font-medium text-foreground">{subtitleSummaryLabel}</dd>
-                <dd className="mt-1 text-[11px] text-muted-foreground">{subtitleSummaryDetail}</dd>
-              </div>
-
-              <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">Filename</dt>
-                <dd className="mt-1 text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
-                  {activeTemplateKind === "episode" ? "TV show template" : "Movie template"}
-                </dd>
-                <dd className="mt-1 break-all font-mono text-[11px] text-foreground">{fileNamePreview}</dd>
-              </div>
-            </dl>
-          </aside>
+          <EditorExportSummaryPanel
+            title={title}
+            clipStart={clipStart}
+            clipEnd={clipEnd}
+            selectedFormat={selectedFormat}
+            outputDimensions={outputDimensions}
+            exportSourceLabel={exportSourceLabel}
+            exportSourceSummaryMessage={exportSourceSummaryMessage}
+            includeAudio={includeAudio}
+            subtitleSummaryLabel={subtitleSummaryLabel}
+            subtitleSummaryDetail={subtitleSummaryDetail}
+            subtitleSummaryTone={subtitleSummaryTone}
+            activeTemplateKind={activeTemplateKind}
+            fileNamePreview={fileNamePreview}
+          />
         </div>
 
         <footer className="flex flex-col-reverse gap-2 border-t border-border bg-card px-4 py-3 sm:flex-row sm:items-center sm:justify-end">

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -1,0 +1,499 @@
+import { Info } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
+import {
+  getExportFileNameTemplateTokens,
+  type ExportFileNameTemplateKind,
+  type ExportFileNameTemplateSettings,
+} from "../../lib/exportFileName";
+import type { ExportSourcePreference } from "./EditorExportDialog";
+import { formatTime } from "./EditorUtils";
+
+interface VideoDimensions {
+  width: number;
+  height: number;
+}
+
+interface ExportOption<T extends string> {
+  value: T;
+  label: string;
+  description: string;
+}
+
+export const formatOptions: ReadonlyArray<ExportOption<ExportFormat> & {
+  extension: string;
+}> = [
+  {
+    value: "mp4",
+    label: "MP4",
+    extension: ".mp4",
+    description: "Best for everyday sharing, browser playback, and platform uploads.",
+  },
+  {
+    value: "webm",
+    label: "WEBM",
+    extension: ".webm",
+    description: "Modern web-first delivery with efficient browser-friendly playback.",
+  },
+  {
+    value: "mov",
+    label: "MOV",
+    extension: ".mov",
+    description: "A professional container that fits Adobe-style editorial workflows.",
+  },
+  {
+    value: "mkv",
+    label: "MKV",
+    extension: ".mkv",
+    description: "A flexible container for preserving a wider range of stream layouts.",
+  },
+];
+
+const resolutionOptions: ReadonlyArray<ExportOption<ExportResolution>> = [
+  {
+    value: "original",
+    label: "Original",
+    description: "Keeps the source dimensions when possible.",
+  },
+  {
+    value: "1080",
+    label: "1080p",
+    description: "Balanced delivery size for full HD exports.",
+  },
+  {
+    value: "720",
+    label: "720p",
+    description: "Lighter output for faster downloads and sharing.",
+  },
+];
+
+const sourceOptions: ReadonlyArray<ExportOption<ExportSourcePreference>> = [
+  {
+    value: "auto",
+    label: "Auto",
+    description: "Lets Cliparr choose the safest export path for this session.",
+  },
+  {
+    value: "direct",
+    label: "Direct/original",
+    description: "Uses the direct media path when available, usually best for preserving source quality.",
+  },
+  {
+    value: "hls",
+    label: "HLS playback",
+    description: "Uses the media server playback stream, which may include server-side transcoding.",
+  },
+];
+
+const templateOptions: ReadonlyArray<{
+  kind: ExportFileNameTemplateKind;
+  label: string;
+  description: string;
+}> = [
+  {
+    kind: "movie",
+    label: "Movies",
+    description: "Used for films and non-episode items.",
+  },
+  {
+    kind: "episode",
+    label: "TV Shows",
+    description: "Used for episode exports with series metadata.",
+  },
+];
+
+function compactSelectTriggerClassName() {
+  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
+}
+
+function sectionLabelClassName() {
+  return "text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground";
+}
+
+export function formatOptionFor(format: ExportFormat) {
+  return formatOptions.find((option) => option.value === format) ?? formatOptions[0];
+}
+
+function resolutionOptionFor(resolution: ExportResolution) {
+  return resolutionOptions.find((option) => option.value === resolution) ?? resolutionOptions[0];
+}
+
+function sourceOptionFor(preference: ExportSourcePreference) {
+  return sourceOptions.find((option) => option.value === preference) ?? sourceOptions[0];
+}
+
+function templateOptionFor(kind: ExportFileNameTemplateKind) {
+  return templateOptions.find((option) => option.kind === kind) ?? templateOptions[0];
+}
+
+function SectionHeader({ children }: { children: string }) {
+  return (
+    <div className="border-b border-border px-3 py-2">
+      <div className={sectionLabelClassName()}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+interface EditorExportSettingsSectionProps {
+  selectedFormat: ExportFormat;
+  onFormatChange: (format: ExportFormat) => void;
+  selectedResolution: ExportResolution;
+  onResolutionChange: (resolution: ExportResolution) => void;
+  selectedSourcePreference: ExportSourcePreference;
+  onSourcePreferenceChange: (preference: ExportSourcePreference) => void;
+  includeAudio: boolean;
+  onIncludeAudioChange: (includeAudio: boolean) => void;
+  hasHlsSource: boolean;
+  hasDirectSource: boolean;
+}
+
+export function EditorExportSettingsSection({
+  selectedFormat,
+  onFormatChange,
+  selectedResolution,
+  onResolutionChange,
+  selectedSourcePreference,
+  onSourcePreferenceChange,
+  includeAudio,
+  onIncludeAudioChange,
+  hasHlsSource,
+  hasDirectSource,
+}: EditorExportSettingsSectionProps) {
+  return (
+    <section className="rounded-md border border-border bg-card">
+      <SectionHeader>Export Settings</SectionHeader>
+      <div className="grid gap-3 p-3 sm:grid-cols-2">
+        <label className="space-y-1.5">
+          <span className={sectionLabelClassName()}>
+            Format
+          </span>
+          <Select value={selectedFormat} onValueChange={(value) => onFormatChange(value as ExportFormat)}>
+            <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
+              <SelectValue placeholder="Select format" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Formats</SelectLabel>
+                {formatOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label} {option.extension}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{formatOptionFor(selectedFormat).description}</p>
+        </label>
+
+        <label className="space-y-1.5">
+          <span className={sectionLabelClassName()}>
+            Resolution
+          </span>
+          <Select value={selectedResolution} onValueChange={(value) => onResolutionChange(value as ExportResolution)}>
+            <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
+              <SelectValue placeholder="Select resolution" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Resolutions</SelectLabel>
+                {resolutionOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {resolutionOptionFor(selectedResolution).description}
+          </p>
+        </label>
+
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <span className={sectionLabelClassName()}>
+              Source
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Export source details"
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                >
+                  <Info className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                Track and timing detection can still use HLS metadata when Cliparr can read it. This only chooses which media path is used for the exported file.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <Select
+            value={selectedSourcePreference}
+            onValueChange={(value) => onSourcePreferenceChange(value as ExportSourcePreference)}
+          >
+            <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
+              <SelectValue placeholder="Select source" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Sources</SelectLabel>
+                {sourceOptions.map((option) => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                    disabled={
+                      (option.value === "direct" && !hasDirectSource)
+                      || (option.value === "hls" && !hasHlsSource)
+                    }
+                  >
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{sourceOptionFor(selectedSourcePreference).description}</p>
+        </div>
+
+        <label className="space-y-1.5">
+          <span className={sectionLabelClassName()}>
+            Audio
+          </span>
+          <Select
+            value={includeAudio ? "included" : "video-only"}
+            onValueChange={(value) => onIncludeAudioChange(value === "included")}
+          >
+            <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
+              <SelectValue placeholder="Select audio option" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Audio</SelectLabel>
+                <SelectItem value="included">Include Audio</SelectItem>
+                <SelectItem value="video-only">Video Only</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {includeAudio ? "Keeps a stereo mix when source audio exists." : "Exports without an audio track."}
+          </p>
+        </label>
+      </div>
+    </section>
+  );
+}
+
+interface EditorFilenameTemplateSectionProps {
+  editingTemplateKind: ExportFileNameTemplateKind;
+  onEditingTemplateKindChange: (kind: ExportFileNameTemplateKind) => void;
+  fileNameTemplates: ExportFileNameTemplateSettings;
+  onFileNameTemplateChange: (kind: ExportFileNameTemplateKind, template: string) => void;
+  onResetFileNameTemplate: (kind: ExportFileNameTemplateKind) => void;
+}
+
+export function EditorFilenameTemplateSection({
+  editingTemplateKind,
+  onEditingTemplateKindChange,
+  fileNameTemplates,
+  onFileNameTemplateChange,
+  onResetFileNameTemplate,
+}: EditorFilenameTemplateSectionProps) {
+  const editingTemplateOption = templateOptionFor(editingTemplateKind);
+  const visibleTokens = getExportFileNameTemplateTokens(editingTemplateKind);
+
+  return (
+    <section className="rounded-md border border-border bg-card">
+      <SectionHeader>Filename Template</SectionHeader>
+      <div className="space-y-3 p-3">
+        <div className="grid gap-3 sm:grid-cols-[12rem_auto] sm:items-end">
+          <label className="space-y-1.5">
+            <span className={sectionLabelClassName()}>
+              Template Set
+            </span>
+            <Select
+              value={editingTemplateKind}
+              onValueChange={(value) => onEditingTemplateKindChange(value as ExportFileNameTemplateKind)}
+            >
+              <SelectTrigger size="sm" className={compactSelectTriggerClassName()}>
+                <SelectValue placeholder="Select template set" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Templates</SelectLabel>
+                  {templateOptions.map((option) => (
+                    <SelectItem key={option.kind} value={option.kind}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </label>
+
+          <button
+            type="button"
+            onClick={() => onResetFileNameTemplate(editingTemplateKind)}
+            className="inline-flex h-8 items-center justify-center rounded-md border border-border bg-background px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            Reset
+          </button>
+        </div>
+
+        <label className="block space-y-1.5">
+          <span className={sectionLabelClassName()}>
+            Pattern
+          </span>
+          <input
+            type="text"
+            value={fileNameTemplates[editingTemplateKind]}
+            onChange={(event) => onFileNameTemplateChange(editingTemplateKind, event.target.value)}
+            className="h-8 w-full rounded-md border border-input bg-background px-2.5 font-mono text-xs text-foreground outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/40"
+            spellCheck={false}
+          />
+        </label>
+
+        <p className="text-xs text-muted-foreground">{editingTemplateOption.description}</p>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <div className={sectionLabelClassName()}>
+            Available Tokens
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {visibleTokens.map((token) => (
+              <code
+                key={token}
+                className="rounded-md border border-border bg-card px-2 py-0.5 font-mono text-[11px] text-foreground"
+              >
+                {`{${token}}`}
+              </code>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface EditorExportSummaryPanelProps {
+  title: string;
+  clipStart: number;
+  clipEnd: number;
+  selectedFormat: ExportFormat;
+  outputDimensions: VideoDimensions | null;
+  exportSourceLabel: string;
+  exportSourceSummaryMessage: string | null;
+  includeAudio: boolean;
+  subtitleSummaryLabel: string;
+  subtitleSummaryDetail: string;
+  subtitleSummaryTone: "muted" | "ready" | "warning";
+  activeTemplateKind: ExportFileNameTemplateKind;
+  fileNamePreview: string;
+}
+
+export function EditorExportSummaryPanel({
+  title,
+  clipStart,
+  clipEnd,
+  selectedFormat,
+  outputDimensions,
+  exportSourceLabel,
+  exportSourceSummaryMessage,
+  includeAudio,
+  subtitleSummaryLabel,
+  subtitleSummaryDetail,
+  subtitleSummaryTone,
+  activeTemplateKind,
+  fileNamePreview,
+}: EditorExportSummaryPanelProps) {
+  const clipLength = Math.max(0, clipEnd - clipStart);
+  const selectedFormatOption = formatOptionFor(selectedFormat);
+  const subtitleSummaryClassName = subtitleSummaryTone === "ready"
+    ? "border-emerald-500/30 bg-emerald-500/8"
+    : subtitleSummaryTone === "warning"
+      ? "border-amber-500/30 bg-amber-500/8"
+      : "border-border bg-background";
+
+  return (
+    <aside className="space-y-3 rounded-md border border-border bg-card p-3">
+      <div className="border-b border-border pb-2">
+        <div className={sectionLabelClassName()}>
+          Summary
+        </div>
+      </div>
+
+      <div className="text-sm font-medium text-foreground">{title}</div>
+
+      <dl className="grid gap-2 text-sm">
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Clip</dt>
+          <dd className="mt-1 font-mono text-xs text-foreground">
+            {formatTime(clipStart)} to {formatTime(clipEnd)}
+          </dd>
+        </div>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Duration</dt>
+          <dd className="mt-1 font-mono text-xs text-foreground">{formatTime(clipLength)}</dd>
+        </div>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Source</dt>
+          <dd className="mt-1 text-xs text-foreground">
+            {exportSourceLabel}
+          </dd>
+          {exportSourceSummaryMessage ? (
+            <dd className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {exportSourceSummaryMessage}
+            </dd>
+          ) : null}
+        </div>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Output</dt>
+          <dd className="mt-1 text-xs text-foreground">{selectedFormatOption.label}</dd>
+          <dd className="mt-1 font-mono text-[11px] text-foreground">
+            {outputDimensions ? `${outputDimensions.width} x ${outputDimensions.height}` : "Unknown size"}
+          </dd>
+        </div>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Audio</dt>
+          <dd className="mt-1 text-xs text-foreground">
+            {includeAudio ? "Included when available" : "Video only"}
+          </dd>
+        </div>
+
+        <div className={`rounded-md border px-3 py-2 ${subtitleSummaryClassName}`}>
+          <dt className={sectionLabelClassName()}>Subtitles</dt>
+          <dd className="mt-1 text-xs font-medium text-foreground">{subtitleSummaryLabel}</dd>
+          <dd className="mt-1 text-[11px] text-muted-foreground">{subtitleSummaryDetail}</dd>
+        </div>
+
+        <div className="rounded-md border border-border bg-background px-3 py-2">
+          <dt className={sectionLabelClassName()}>Filename</dt>
+          <dd className="mt-1 text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
+            {activeTemplateKind === "episode" ? "TV show template" : "Movie template"}
+          </dd>
+          <dd className="mt-1 break-all font-mono text-[11px] text-foreground">{fileNamePreview}</dd>
+        </div>
+      </dl>
+    </aside>
+  );
+}

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -33,7 +33,7 @@ interface ExportOption<T extends string> {
   description: string;
 }
 
-export const formatOptions: ReadonlyArray<ExportOption<ExportFormat> & {
+const formatOptions: ReadonlyArray<ExportOption<ExportFormat> & {
   extension: string;
 }> = [
   {

--- a/apps/frontend/src/components/editor/editorPlaybackAudio.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackAudio.ts
@@ -1,0 +1,143 @@
+import type { WrappedAudioBuffer } from "mediabunny";
+import { fromSourceTimelineTime } from "../../lib/mediabunnyTrackAccess";
+
+type RefValue<T> = {
+  current: T;
+};
+
+interface RunPlaybackAudioIteratorOptions {
+  iterator: AsyncGenerator<WrappedAudioBuffer, void, unknown> | null;
+  audioContext: AudioContext | null;
+  gainNode: GainNode | null;
+  queuedAudioNodes: Set<AudioBufferSourceNode>;
+  generation: number;
+  generationRef: RefValue<number>;
+  playingRef: RefValue<boolean>;
+  audioContextStartTimeRef: RefValue<number | null>;
+  playbackTimeAtStartRef: RefValue<number>;
+  sourceTimelineOffsetRef: RefValue<number>;
+  getPlaybackTime: () => number;
+  onError: (err: unknown) => void;
+}
+
+export function playbackGainValue(volume: number, muted: boolean) {
+  const actualVolume = muted || volume === 0 ? 0 : volume;
+  return actualVolume ** 2;
+}
+
+export function applyPlaybackGain(
+  gainNode: GainNode | null,
+  volume: number,
+  muted: boolean,
+) {
+  if (gainNode) {
+    gainNode.gain.value = playbackGainValue(volume, muted);
+  }
+}
+
+export function stopQueuedAudioNodes(queuedAudioNodes: Set<AudioBufferSourceNode>) {
+  for (const node of queuedAudioNodes) {
+    try {
+      node.stop();
+    } catch {
+      // The node may have already ended.
+    }
+  }
+  queuedAudioNodes.clear();
+}
+
+export async function runPlaybackAudioIterator({
+  iterator,
+  audioContext,
+  gainNode,
+  queuedAudioNodes,
+  generation,
+  generationRef,
+  playingRef,
+  audioContextStartTimeRef,
+  playbackTimeAtStartRef,
+  sourceTimelineOffsetRef,
+  getPlaybackTime,
+  onError,
+}: RunPlaybackAudioIteratorOptions) {
+  if (!iterator || !audioContext || !gainNode) {
+    return;
+  }
+
+  try {
+    for await (const { buffer, timestamp } of iterator) {
+      if (generation !== generationRef.current || !playingRef.current) {
+        break;
+      }
+
+      const node = audioContext.createBufferSource();
+      node.buffer = buffer;
+      node.connect(gainNode);
+      const displayTimestamp = fromSourceTimelineTime(timestamp, sourceTimelineOffsetRef.current);
+
+      const startTimestamp = (
+        audioContextStartTimeRef.current ?? audioContext.currentTime
+      ) + displayTimestamp - playbackTimeAtStartRef.current;
+
+      let started = false;
+      if (startTimestamp >= audioContext.currentTime) {
+        node.start(startTimestamp);
+        started = true;
+      } else {
+        const offset = audioContext.currentTime - startTimestamp;
+        if (offset < buffer.duration) {
+          node.start(audioContext.currentTime, offset);
+          started = true;
+        }
+      }
+
+      if (started) {
+        queuedAudioNodes.add(node);
+        node.onended = () => {
+          queuedAudioNodes.delete(node);
+        };
+      }
+
+      if (displayTimestamp - getPlaybackTime() >= 1) {
+        await waitForAudioLead({
+          generation,
+          generationRef,
+          playingRef,
+          displayTimestamp,
+          getPlaybackTime,
+        });
+      }
+    }
+  } catch (err) {
+    if (generation === generationRef.current) {
+      onError(err);
+    }
+  }
+}
+
+function waitForAudioLead({
+  generation,
+  generationRef,
+  playingRef,
+  displayTimestamp,
+  getPlaybackTime,
+}: {
+  generation: number;
+  generationRef: RefValue<number>;
+  playingRef: RefValue<boolean>;
+  displayTimestamp: number;
+  getPlaybackTime: () => number;
+}) {
+  return new Promise<void>((resolve) => {
+    const intervalId = window.setInterval(() => {
+      if (
+        generation !== generationRef.current ||
+        !playingRef.current ||
+        displayTimestamp - getPlaybackTime() < 1
+      ) {
+        window.clearInterval(intervalId);
+        resolve();
+      }
+    }, 100);
+  });
+}

--- a/apps/frontend/src/components/editor/editorPlaybackSinks.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSinks.ts
@@ -1,0 +1,119 @@
+import type {
+  AudioBufferSink,
+  CanvasSink,
+  Input,
+  InputAudioTrack,
+  InputVideoTrack,
+} from "mediabunny";
+import { playbackGainValue } from "./editorPlaybackAudio";
+import { PlaybackSourceError } from "./editorPlaybackSources";
+
+type RefValue<T> = {
+  current: T;
+};
+
+type WindowWithWebkitAudioContext = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+interface CanvasSinkConstructor {
+  new (
+    track: InputVideoTrack,
+    options: {
+      poolSize: number;
+      fit: "contain";
+      alpha: boolean;
+    }
+  ): CanvasSink;
+}
+
+interface AudioBufferSinkConstructor {
+  new (track: InputAudioTrack): AudioBufferSink;
+}
+
+interface CreatePlaybackSinkResourcesOptions {
+  CanvasSinkConstructor: CanvasSinkConstructor;
+  AudioBufferSinkConstructor: AudioBufferSinkConstructor;
+  previewVideoTrack: InputVideoTrack | null;
+  previewAudioTrack: InputAudioTrack | null;
+  audioTrackSampleRate?: number;
+  volume: number;
+  muted: boolean;
+}
+
+interface DisposePlaybackSinkResourcesOptions {
+  inputRef: RefValue<Input | null>;
+  videoSinkRef: RefValue<CanvasSink | null>;
+  audioSinkRef: RefValue<AudioBufferSink | null>;
+  audioContextRef: RefValue<AudioContext | null>;
+  gainNodeRef: RefValue<GainNode | null>;
+}
+
+export function getAudioContextConstructor() {
+  return window.AudioContext ?? (window as WindowWithWebkitAudioContext).webkitAudioContext;
+}
+
+export async function createPlaybackSinkResources({
+  CanvasSinkConstructor,
+  AudioBufferSinkConstructor,
+  previewVideoTrack,
+  previewAudioTrack,
+  audioTrackSampleRate,
+  volume,
+  muted,
+}: CreatePlaybackSinkResourcesOptions) {
+  const videoSink = previewVideoTrack
+    ? new CanvasSinkConstructor(previewVideoTrack, {
+        poolSize: 2,
+        fit: "contain",
+        alpha: await previewVideoTrack.canBeTransparent(),
+      })
+    : null;
+
+  if (!previewAudioTrack) {
+    return {
+      videoSink,
+      audioSink: null,
+      audioContext: null,
+      gainNode: null,
+    };
+  }
+
+  const AudioContextConstructor = getAudioContextConstructor();
+  if (!AudioContextConstructor) {
+    throw new PlaybackSourceError(
+      "preview-only",
+      "This browser does not provide Web Audio."
+    );
+  }
+
+  const audioContext = new AudioContextConstructor({
+    sampleRate: audioTrackSampleRate,
+  });
+  const gainNode = audioContext.createGain();
+  gainNode.gain.value = playbackGainValue(volume, muted);
+  gainNode.connect(audioContext.destination);
+
+  return {
+    videoSink,
+    audioSink: new AudioBufferSinkConstructor(previewAudioTrack),
+    audioContext,
+    gainNode,
+  };
+}
+
+export function disposePlaybackSinkResources({
+  inputRef,
+  videoSinkRef,
+  audioSinkRef,
+  audioContextRef,
+  gainNodeRef,
+}: DisposePlaybackSinkResourcesOptions) {
+  videoSinkRef.current = null;
+  audioSinkRef.current = null;
+  inputRef.current?.dispose();
+  inputRef.current = null;
+  void audioContextRef.current?.close().catch(() => undefined);
+  audioContextRef.current = null;
+  gainNodeRef.current = null;
+}

--- a/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildPlaybackFailure,
+  buildPlaybackLoadError,
+  buildPlaybackSourceCandidates,
+  PlaybackSourceError,
+  resolvePlaybackDuration,
+  shouldUseExportFallback,
+  type PlaybackLoadFailure,
+} from "./editorPlaybackSources";
+
+void test("builds playback source candidates in fallback order without duplicates", () => {
+  assert.deepEqual(buildPlaybackSourceCandidates("/playback/master.m3u8", "/media/movie.mp4"), [
+    { label: "hls stream", url: "/playback/master.m3u8" },
+    { label: "direct source", url: "/media/movie.mp4" },
+  ]);
+
+  assert.deepEqual(buildPlaybackSourceCandidates("/media/movie.mp4", "/media/movie.mp4"), [
+    { label: "hls stream", url: "/media/movie.mp4" },
+  ]);
+});
+
+void test("preserves server duration for HLS and uses computed direct duration when available", () => {
+  assert.equal(resolvePlaybackDuration(
+    { label: "hls stream", url: "/playback/master.m3u8" },
+    95,
+    100,
+  ), 100);
+
+  assert.equal(resolvePlaybackDuration(
+    { label: "direct source", url: "/media/movie.mp4" },
+    95,
+    100,
+  ), 95);
+
+  assert.equal(resolvePlaybackDuration(
+    { label: "direct source", url: "/media/movie.mp4" },
+    Number.NaN,
+    100,
+  ), 100);
+});
+
+void test("classifies source failures and export fallback eligibility", () => {
+  const failure = buildPlaybackFailure(
+    { label: "hls stream", url: "/playback/master.m3u8" },
+    new PlaybackSourceError("shared-export-blocking", "Decoder unavailable"),
+  );
+
+  assert.deepEqual(failure, {
+    label: "hls stream",
+    message: "Decoder unavailable",
+    classification: "hls-playlist",
+    category: "shared-export-blocking",
+  });
+  assert.equal(shouldUseExportFallback(failure), true);
+});
+
+void test("deduplicates playback load errors that share the same underlying message", () => {
+  const failures: PlaybackLoadFailure[] = [
+    {
+      label: "hls stream",
+      message: "Network denied",
+      classification: "hls-playlist",
+      category: "open-or-read",
+    },
+    {
+      label: "direct source",
+      message: "Network denied",
+      classification: "unknown",
+      category: "open-or-read",
+    },
+  ];
+
+  assert.equal(
+    buildPlaybackLoadError(failures),
+    "Cliparr could not open any playback stream. Network denied",
+  );
+});

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -65,7 +65,7 @@ export function buildPlaybackSourceCandidates(hlsUrl: string | undefined, mediaU
   return candidates;
 }
 
-export function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "url">): PlaybackLoadFailure["classification"] {
+function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "url">): PlaybackLoadFailure["classification"] {
   return source.label === "hls stream" || isHlsPlaylistUrl(source.url) ? "hls-playlist" : "unknown";
 }
 

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -1,0 +1,318 @@
+import type { InputAudioTrack, InputVideoTrack } from "mediabunny";
+import { isHlsPlaylistUrl } from "../../lib/mediabunnyInput";
+import {
+  getTrackCodec,
+  getTrackLanguageCode,
+  getTrackName,
+} from "../../lib/mediabunnyTrackAccess";
+import type { PlaybackAudioSelection } from "../../providers/types";
+import { errorMessage, isAc3FamilyCodec } from "./EditorUtils";
+
+export interface PlaybackSourceCandidate {
+  label: "hls stream" | "direct source";
+  url: string;
+}
+
+export interface PlaybackLoadFailure {
+  label: PlaybackSourceCandidate["label"];
+  message: string;
+  classification: "hls-playlist" | "unknown";
+  category: "open-or-read" | "preview-only" | "shared-export-blocking";
+}
+
+export interface PlaybackFallbackInfo {
+  category: PlaybackLoadFailure["category"];
+  message: string;
+}
+
+export interface PlaybackSourceAnalysisContext {
+  sessionId: string;
+  source: PlaybackSourceCandidate["label"];
+  url: string;
+  selectedAudioTrack?: PlaybackAudioSelection;
+  videoTracks: readonly InputVideoTrack[];
+  allAudioTracks: readonly InputAudioTrack[];
+  sourceVideoTrack: InputVideoTrack | null;
+  previewVideoTrack: InputVideoTrack | null;
+  sourceAudioTrack: InputAudioTrack | null;
+  previewAudioTrack: InputAudioTrack | null;
+  previewAudioWarning?: string;
+  warnings: string[];
+  isLivePlayback: boolean;
+}
+
+export class PlaybackSourceError extends Error {
+  category: PlaybackLoadFailure["category"];
+
+  constructor(category: PlaybackLoadFailure["category"], message: string) {
+    super(message);
+    this.name = "PlaybackSourceError";
+    this.category = category;
+  }
+}
+
+export function buildPlaybackSourceCandidates(hlsUrl: string | undefined, mediaUrl: string | undefined) {
+  const candidates: PlaybackSourceCandidate[] = [];
+
+  if (hlsUrl) {
+    candidates.push({ label: "hls stream", url: hlsUrl });
+  }
+
+  if (mediaUrl && !candidates.some((candidate) => candidate.url === mediaUrl)) {
+    candidates.push({ label: "direct source", url: mediaUrl });
+  }
+
+  return candidates;
+}
+
+export function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "url">): PlaybackLoadFailure["classification"] {
+  return source.label === "hls stream" || isHlsPlaylistUrl(source.url) ? "hls-playlist" : "unknown";
+}
+
+export function buildPlaybackFailure(source: PlaybackSourceCandidate, err: unknown): PlaybackLoadFailure {
+  return {
+    label: source.label,
+    message: errorMessage(err),
+    classification: classifyPlaybackSource(source),
+    category: err instanceof PlaybackSourceError ? err.category : "open-or-read",
+  };
+}
+
+export function shouldUseExportFallback(failure: PlaybackLoadFailure) {
+  return failure.category === "open-or-read" || failure.category === "shared-export-blocking";
+}
+
+export function describePlaybackFailure(failure: PlaybackLoadFailure) {
+  const prefix = failure.label === "hls stream" ? "HLS stream" : "Direct source";
+
+  return `${prefix} failed: ${failure.message}`;
+}
+
+export function formatPlaybackSourceLabel(label: PlaybackSourceCandidate["label"]) {
+  return label === "hls stream" ? "HLS stream" : "Direct source";
+}
+
+export function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function finiteNonNegativeDuration(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+export function resolvePlaybackDuration(
+  playbackSource: PlaybackSourceCandidate,
+  computedDuration: number,
+  initialDuration: number,
+) {
+  const fallbackDuration = finiteNonNegativeDuration(initialDuration);
+  const normalizedComputedDuration = finiteNonNegativeDuration(computedDuration);
+
+  if (playbackSource.label === "hls stream") {
+    return Math.max(fallbackDuration, normalizedComputedDuration);
+  }
+
+  return normalizedComputedDuration || fallbackDuration;
+}
+
+export function buildPlaybackLoadError(failures: PlaybackLoadFailure[]) {
+  if (failures.length === 0) {
+    return "Playback could not be loaded.";
+  }
+
+  if (failures.length === 1) {
+    return describePlaybackFailure(failures[0]);
+  }
+
+  const uniqueMessages = [...new Set(failures.map((failure) => failure.message))];
+  if (uniqueMessages.length === 1) {
+    return `Cliparr could not open any playback stream. ${uniqueMessages[0]}`;
+  }
+
+  return `Cliparr could not open any playback stream. ${failures.map(describePlaybackFailure).join(" ")}`;
+}
+
+export function browserDecoderEnvironmentWarning() {
+  const missingDecoders = [
+    "VideoDecoder" in window ? null : "video",
+    "AudioDecoder" in window ? null : "audio",
+  ].filter(isPresent);
+
+  if (missingDecoders.length === 0) {
+    return undefined;
+  }
+
+  if (!window.isSecureContext) {
+    return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable from ${window.location.origin}. Open Cliparr over HTTPS, localhost, or 127.0.0.1 so the editor can decode media. Jellyfin playback can still work on this origin because its native player does not use the same editor decoder APIs.`;
+  }
+
+  return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable in this browser.`;
+}
+
+async function assessPreviewVideoTrack(track: InputVideoTrack | null) {
+  if (!track) {
+    return { track: null, warning: undefined };
+  }
+
+  const videoCodec = await getTrackCodec(track);
+  if (videoCodec === null) {
+    return {
+      track: null,
+      warning: "Video codec is unknown.",
+    };
+  }
+
+  if (!(await track.canDecode())) {
+    return {
+      track: null,
+      warning: `Cannot decode ${videoCodec} video in this browser.`,
+    };
+  }
+
+  return { track, warning: undefined };
+}
+
+export async function selectPreviewVideoTrack(videoTracks: readonly InputVideoTrack[]) {
+  const sourceVideoTrack = videoTracks[0] ?? null;
+  if (!sourceVideoTrack) {
+    return {
+      sourceVideoTrack: null,
+      previewVideoTrack: null,
+      warnings: [] as string[],
+    };
+  }
+
+  const warnings: string[] = [];
+  const primaryAssessment = await assessPreviewVideoTrack(sourceVideoTrack);
+  if (primaryAssessment.track) {
+    return {
+      sourceVideoTrack,
+      previewVideoTrack: primaryAssessment.track,
+      warnings,
+    };
+  }
+
+  if (primaryAssessment.warning) {
+    warnings.push(primaryAssessment.warning);
+  }
+
+  for (const candidate of videoTracks.slice(1)) {
+    const candidateAssessment = await assessPreviewVideoTrack(candidate);
+    if (candidateAssessment.track) {
+      return {
+        sourceVideoTrack,
+        previewVideoTrack: candidateAssessment.track,
+        warnings,
+      };
+    }
+  }
+
+  return {
+    sourceVideoTrack,
+    previewVideoTrack: null,
+    warnings,
+  };
+}
+
+export async function assessPreviewAudioTrack(track: InputAudioTrack | null) {
+  if (!track) {
+    return { track: null, warning: undefined };
+  }
+
+  const audioCodec = await getTrackCodec(track);
+  if (audioCodec === null) {
+    return {
+      track: null,
+      warning: "Audio codec is unknown.",
+    };
+  }
+
+  if (!(await track.canDecode()) && !isAc3FamilyCodec(audioCodec)) {
+    return {
+      track: null,
+      warning: `Cannot decode ${audioCodec} audio in this browser.`,
+    };
+  }
+
+  return { track, warning: undefined };
+}
+
+async function summarizeVideoTrackForDebug(track: InputVideoTrack | null) {
+  if (!track) {
+    return null;
+  }
+
+  const [codec, title, canDecode] = await Promise.all([
+    getTrackCodec(track),
+    getTrackName(track),
+    track.canDecode().catch(() => null),
+  ]);
+
+  return {
+    trackNumber: track.number,
+    codec: codec ?? null,
+    title: title ?? null,
+    canDecode,
+  };
+}
+
+async function summarizeAudioTrackForDebug(track: InputAudioTrack | null) {
+  if (!track) {
+    return null;
+  }
+
+  const [codec, title, languageCode, canDecode] = await Promise.all([
+    getTrackCodec(track),
+    getTrackName(track),
+    getTrackLanguageCode(track),
+    track.canDecode().catch(() => null),
+  ]);
+
+  return {
+    trackNumber: track.number,
+    codec: codec ?? null,
+    title: title ?? null,
+    languageCode: languageCode ?? null,
+    canDecode,
+  };
+}
+
+async function summarizeAudioTracksForDebug(tracks: readonly InputAudioTrack[]) {
+  return Promise.all(tracks.map((track) => summarizeAudioTrackForDebug(track)));
+}
+
+export async function buildPlaybackSourceAnalysis(context: PlaybackSourceAnalysisContext) {
+  const [
+    allAudioTracks,
+    sourceVideoTrack,
+    previewVideoTrack,
+    sourceAudioTrack,
+    previewAudioTrack,
+  ] = await Promise.all([
+    summarizeAudioTracksForDebug(context.allAudioTracks),
+    summarizeVideoTrackForDebug(context.sourceVideoTrack),
+    summarizeVideoTrackForDebug(context.previewVideoTrack),
+    summarizeAudioTrackForDebug(context.sourceAudioTrack),
+    summarizeAudioTrackForDebug(context.previewAudioTrack),
+  ]);
+
+  return {
+    sessionId: context.sessionId,
+    source: context.source,
+    urlClassification: classifyPlaybackSource({
+      label: context.source,
+      url: context.url,
+    }),
+    selectedAudioTrack: context.selectedAudioTrack ?? null,
+    videoTrackCount: context.videoTracks.length,
+    audioTrackCount: context.allAudioTracks.length,
+    allAudioTracks,
+    sourceVideoTrack,
+    previewVideoTrack,
+    sourceAudioTrack,
+    previewAudioTrack,
+    previewAudioWarning: context.previewAudioWarning ?? null,
+    warnings: [...context.warnings],
+    isLivePlayback: context.isLivePlayback,
+  } satisfies Record<string, unknown>;
+}

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupTypes.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupTypes.ts
@@ -1,0 +1,14 @@
+export type RefValue<T> = {
+  current: T;
+};
+
+export interface PlaybackReadyRange {
+  startTime: number;
+  endTime: number;
+  readyUntilTime: number;
+  status: "idle" | "warming" | "ready";
+}
+
+export interface WarmClipSelectionOptions {
+  extendToSelectionEnd?: boolean;
+}

--- a/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PlaybackSubtitleTrack } from "../../providers/types";
+import { buildSubtitleExportSummary } from "./subtitleExportSummary";
+
+const supportedTrack = {
+  title: "English SDH",
+  languageCode: "en",
+  isText: true,
+  contentUrl: "/api/media/subtitles/en.srt",
+} satisfies PlaybackSubtitleTrack;
+
+void test("summarizes disabled subtitle burn-in with and without available tracks", () => {
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: supportedTrack,
+    subtitleEnabled: false,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 3,
+    subtitleLoading: false,
+    subtitleError: null,
+    providerId: "plex",
+  }), {
+    label: "Not included",
+    detail: "Subtitle burn-in is currently turned off for this export.",
+    tone: "muted",
+    disabledReason: null,
+  });
+
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: null,
+    subtitleEnabled: false,
+    subtitleTrackCount: 0,
+    clippedSubtitleCueCount: 0,
+    subtitleLoading: false,
+    subtitleError: null,
+    providerId: "plex",
+  }), {
+    label: "Not included",
+    detail: "No supported text subtitle tracks are available for this session.",
+    tone: "muted",
+    disabledReason: null,
+  });
+});
+
+void test("blocks export when the selected subtitle track is unsupported", () => {
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: {
+      title: "Embedded English",
+      languageCode: "en",
+      isText: true,
+    },
+    subtitleEnabled: true,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 0,
+    subtitleLoading: false,
+    subtitleError: null,
+    providerId: "plex",
+  }), {
+    label: "Unsupported track",
+    detail: "Plex detected this embedded text subtitle track, but only the currently selected embedded subtitle can be fetched for styled burn-in.",
+    tone: "warning",
+    disabledReason: "Choose a supported text subtitle track or turn subtitle burn-in off.",
+  });
+});
+
+void test("blocks export while subtitle cues are loading or errored", () => {
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: supportedTrack,
+    subtitleEnabled: true,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 0,
+    subtitleLoading: true,
+    subtitleError: null,
+    providerId: "jellyfin",
+  }), {
+    label: "Loading cues",
+    detail: "English SDH is still being prepared for burn-in.",
+    tone: "warning",
+    disabledReason: "Subtitles are still loading. Please wait for the cue list to finish loading.",
+  });
+
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: supportedTrack,
+    subtitleEnabled: true,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 0,
+    subtitleLoading: false,
+    subtitleError: "Subtitle request timed out. Please try again.",
+    providerId: "jellyfin",
+  }), {
+    label: "Subtitle issue",
+    detail: "Subtitle request timed out. Please try again.",
+    tone: "warning",
+    disabledReason: "Subtitle request timed out. Please try again.",
+  });
+});
+
+void test("summarizes empty and ready cue states", () => {
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: supportedTrack,
+    subtitleEnabled: true,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 0,
+    subtitleLoading: false,
+    subtitleError: null,
+    providerId: "jellyfin",
+  }), {
+    label: "No cues found",
+    detail: "English SDH has no subtitle cues inside the selected clip range.",
+    tone: "muted",
+    disabledReason: null,
+  });
+
+  assert.deepEqual(buildSubtitleExportSummary({
+    selectedSubtitleTrack: supportedTrack,
+    subtitleEnabled: true,
+    subtitleTrackCount: 1,
+    clippedSubtitleCueCount: 2,
+    subtitleLoading: false,
+    subtitleError: null,
+    providerId: "jellyfin",
+  }), {
+    label: "Burned in",
+    detail: "English SDH will be rendered into the exported video frames.",
+    tone: "ready",
+    disabledReason: null,
+  });
+});

--- a/apps/frontend/src/components/editor/subtitleExportSummary.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.ts
@@ -1,0 +1,99 @@
+import type { PlaybackSubtitleTrack } from "../../providers/types";
+import {
+  subtitleTrackSupportsBurnIn,
+  subtitleTrackUnavailableMessage,
+} from "../../lib/selectPreferredSubtitleTrack";
+
+interface BuildSubtitleExportSummaryOptions {
+  selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  subtitleEnabled: boolean;
+  subtitleTrackCount: number;
+  clippedSubtitleCueCount: number;
+  subtitleLoading: boolean;
+  subtitleError: string | null;
+  providerId: string;
+}
+
+export interface SubtitleExportSummary {
+  label: string;
+  detail: string;
+  tone: "muted" | "ready" | "warning";
+  disabledReason: string | null;
+}
+
+function subtitleTrackDisplayName(track: PlaybackSubtitleTrack | null) {
+  if (!track) {
+    return "No subtitle track selected";
+  }
+
+  return track.title?.trim()
+    || track.languageCode?.trim()?.toUpperCase()
+    || "Selected subtitle track";
+}
+
+export function buildSubtitleExportSummary({
+  selectedSubtitleTrack,
+  subtitleEnabled,
+  subtitleTrackCount,
+  clippedSubtitleCueCount,
+  subtitleLoading,
+  subtitleError,
+  providerId,
+}: BuildSubtitleExportSummaryOptions): SubtitleExportSummary {
+  if (!selectedSubtitleTrack || !subtitleEnabled) {
+    return {
+      label: "Not included",
+      detail: subtitleTrackCount > 0
+        ? "Subtitle burn-in is currently turned off for this export."
+        : "No supported text subtitle tracks are available for this session.",
+      tone: "muted",
+      disabledReason: null,
+    };
+  }
+
+  const trackName = subtitleTrackDisplayName(selectedSubtitleTrack);
+
+  if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
+    return {
+      label: "Unsupported track",
+      detail: subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId)
+        ?? `${trackName} cannot be burned in yet because it is not an exposed text subtitle stream.`,
+      tone: "warning",
+      disabledReason: "Choose a supported text subtitle track or turn subtitle burn-in off.",
+    };
+  }
+
+  if (subtitleLoading) {
+    return {
+      label: "Loading cues",
+      detail: `${trackName} is still being prepared for burn-in.`,
+      tone: "warning",
+      disabledReason: "Subtitles are still loading. Please wait for the cue list to finish loading.",
+    };
+  }
+
+  if (subtitleError) {
+    return {
+      label: "Subtitle issue",
+      detail: subtitleError,
+      tone: "warning",
+      disabledReason: subtitleError,
+    };
+  }
+
+  if (clippedSubtitleCueCount === 0) {
+    return {
+      label: "No cues found",
+      detail: `${trackName} has no subtitle cues inside the selected clip range.`,
+      tone: "muted",
+      disabledReason: null,
+    };
+  }
+
+  return {
+    label: "Burned in",
+    detail: `${trackName} will be rendered into the exported video frames.`,
+    tone: "ready",
+    disabledReason: null,
+  };
+}

--- a/apps/frontend/src/components/editor/timelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TimelineZoomLevel } from "./EditorUtils";
+import {
+  accumulateTimelineWheelZoomDelta,
+  resolveTimelineScrollWheelUpdate,
+  resolveTimelineZoomUpdate,
+} from "./timelineZoom";
+
+const zoomLevels = [
+  { scale: 5, scaleSplitCount: 5, scaleWidth: 100 },
+  { scale: 10, scaleSplitCount: 5, scaleWidth: 100 },
+] satisfies TimelineZoomLevel[];
+
+void test("keeps the cursor-anchored time stable when changing timeline zoom", () => {
+  const update = resolveTimelineZoomUpdate({
+    availableTimelineZoomLevels: zoomLevels,
+    currentZoomIndex: 1,
+    fallbackTimelineScale: zoomLevels[1],
+    zoomDelta: -1,
+    currentScrollLeft: 50,
+    duration: 100,
+    regionLeft: 100,
+    regionWidth: 200,
+    anchorClientX: 200,
+  });
+
+  assert.deepEqual(update, {
+    nextZoomIndex: 0,
+    nextScrollLeft: 176,
+  });
+});
+
+void test("does not zoom past the available timeline levels", () => {
+  assert.equal(resolveTimelineZoomUpdate({
+    availableTimelineZoomLevels: zoomLevels,
+    currentZoomIndex: 0,
+    fallbackTimelineScale: zoomLevels[0],
+    zoomDelta: -1,
+    currentScrollLeft: 0,
+    duration: 100,
+    regionLeft: 0,
+    regionWidth: 200,
+  }), null);
+});
+
+void test("combines horizontal and vertical wheel deltas for timeline scrolling", () => {
+  assert.equal(resolveTimelineScrollWheelUpdate({
+    deltaX: 20,
+    deltaY: 30,
+    deltaMode: 0,
+    containerWidth: 200,
+    containerHeight: 100,
+    currentScrollLeft: 10,
+    duration: 100,
+    timelineScale: zoomLevels[1],
+  }), 60);
+});
+
+void test("accumulates wheel zoom until the threshold is crossed", () => {
+  assert.deepEqual(accumulateTimelineWheelZoomDelta({
+    currentWheelDelta: 30,
+    deltaY: 40,
+    deltaMode: 0,
+    containerHeight: 100,
+  }), {
+    accumulatedWheelDelta: 70,
+    zoomDelta: 0,
+  });
+
+  assert.deepEqual(accumulateTimelineWheelZoomDelta({
+    currentWheelDelta: 70,
+    deltaY: 20,
+    deltaMode: 0,
+    containerHeight: 100,
+  }), {
+    accumulatedWheelDelta: 0,
+    zoomDelta: 1,
+  });
+});
+
+void test("resets accumulated wheel zoom when direction changes", () => {
+  assert.deepEqual(accumulateTimelineWheelZoomDelta({
+    currentWheelDelta: 50,
+    deltaY: -20,
+    deltaMode: 0,
+    containerHeight: 100,
+  }), {
+    accumulatedWheelDelta: -20,
+    zoomDelta: 0,
+  });
+});

--- a/apps/frontend/src/components/editor/timelineZoom.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.ts
@@ -1,0 +1,174 @@
+import {
+  getTimelineMaxScrollLeft,
+  getTimelineZoomLevel,
+  normalizeWheelDelta,
+  TIMELINE_START_LEFT,
+  TIMELINE_ZOOM_WHEEL_STEP,
+  timelinePixelToTime,
+  timelineTimeToPixel,
+  type TimelineZoomLevel,
+} from "./EditorUtils";
+
+interface ResolveTimelineZoomUpdateOptions {
+  availableTimelineZoomLevels: readonly TimelineZoomLevel[];
+  currentZoomIndex: number;
+  fallbackTimelineScale: TimelineZoomLevel;
+  zoomDelta: number;
+  currentScrollLeft: number;
+  duration: number;
+  regionLeft: number;
+  regionWidth: number;
+  anchorClientX?: number;
+}
+
+interface TimelineZoomUpdate {
+  nextZoomIndex: number;
+  nextScrollLeft: number;
+}
+
+interface ResolveTimelineScrollWheelUpdateOptions {
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;
+  containerWidth: number;
+  containerHeight: number;
+  currentScrollLeft: number;
+  duration: number;
+  timelineScale: TimelineZoomLevel;
+}
+
+interface AccumulateTimelineWheelZoomDeltaOptions {
+  currentWheelDelta: number;
+  deltaY: number;
+  deltaMode: number;
+  containerHeight: number;
+}
+
+export function resolveTimelineZoomUpdate({
+  availableTimelineZoomLevels,
+  currentZoomIndex,
+  fallbackTimelineScale,
+  zoomDelta,
+  currentScrollLeft,
+  duration,
+  regionLeft,
+  regionWidth,
+  anchorClientX,
+}: ResolveTimelineZoomUpdateOptions): TimelineZoomUpdate | null {
+  if (availableTimelineZoomLevels.length < 2 || zoomDelta === 0) {
+    return null;
+  }
+
+  const currentTimelineScale = getTimelineZoomLevel(
+    availableTimelineZoomLevels,
+    currentZoomIndex,
+    fallbackTimelineScale,
+  );
+  const nextZoomIndex = Math.min(
+    availableTimelineZoomLevels.length - 1,
+    Math.max(0, currentZoomIndex + Math.sign(zoomDelta)),
+  );
+  if (nextZoomIndex === currentZoomIndex) {
+    return null;
+  }
+
+  const nextTimelineScale = getTimelineZoomLevel(
+    availableTimelineZoomLevels,
+    nextZoomIndex,
+    currentTimelineScale,
+  );
+  const pointerX = typeof anchorClientX === "number"
+    ? Math.min(Math.max(anchorClientX - regionLeft, 0), regionWidth)
+    : regionWidth / 2;
+  const anchorPixel = Math.max(TIMELINE_START_LEFT, currentScrollLeft + pointerX);
+  const anchorTime = Math.min(
+    duration,
+    Math.max(
+      0,
+      timelinePixelToTime(
+        anchorPixel,
+        currentTimelineScale.scale,
+        currentTimelineScale.scaleWidth,
+        TIMELINE_START_LEFT,
+      ),
+    ),
+  );
+  const nextAnchorPixel = timelineTimeToPixel(
+    anchorTime,
+    nextTimelineScale.scale,
+    nextTimelineScale.scaleWidth,
+    TIMELINE_START_LEFT,
+  );
+  const nextMaxScrollLeft = getTimelineMaxScrollLeft(
+    duration,
+    nextTimelineScale.scale,
+    nextTimelineScale.scaleWidth,
+    regionWidth,
+  );
+
+  return {
+    nextZoomIndex,
+    nextScrollLeft: Math.min(nextMaxScrollLeft, Math.max(0, nextAnchorPixel - pointerX)),
+  };
+}
+
+export function resolveTimelineScrollWheelUpdate({
+  deltaX,
+  deltaY,
+  deltaMode,
+  containerWidth,
+  containerHeight,
+  currentScrollLeft,
+  duration,
+  timelineScale,
+}: ResolveTimelineScrollWheelUpdateOptions) {
+  const horizontalWheelDelta = normalizeWheelDelta(deltaX, deltaMode, containerWidth);
+  const verticalWheelDelta = normalizeWheelDelta(deltaY, deltaMode, containerHeight);
+  const nextScrollDelta = horizontalWheelDelta + verticalWheelDelta;
+  const maxScrollLeft = getTimelineMaxScrollLeft(
+    duration,
+    timelineScale.scale,
+    timelineScale.scaleWidth,
+    containerWidth,
+  );
+
+  if (nextScrollDelta === 0 || maxScrollLeft <= 0) {
+    return null;
+  }
+
+  return Math.min(
+    maxScrollLeft,
+    Math.max(0, currentScrollLeft + nextScrollDelta),
+  );
+}
+
+export function accumulateTimelineWheelZoomDelta({
+  currentWheelDelta,
+  deltaY,
+  deltaMode,
+  containerHeight,
+}: AccumulateTimelineWheelZoomDeltaOptions) {
+  const normalizedDeltaY = normalizeWheelDelta(deltaY, deltaMode, containerHeight);
+  if (normalizedDeltaY === 0) {
+    return { accumulatedWheelDelta: currentWheelDelta, zoomDelta: 0 };
+  }
+
+  let accumulatedWheelDelta = currentWheelDelta;
+  if (
+    accumulatedWheelDelta !== 0
+    && Math.sign(accumulatedWheelDelta) !== Math.sign(normalizedDeltaY)
+  ) {
+    accumulatedWheelDelta = 0;
+  }
+
+  accumulatedWheelDelta += normalizedDeltaY;
+  const accumulatedZoomDelta = Math.trunc(accumulatedWheelDelta / TIMELINE_ZOOM_WHEEL_STEP);
+  if (accumulatedZoomDelta === 0) {
+    return { accumulatedWheelDelta, zoomDelta: 0 };
+  }
+
+  return {
+    accumulatedWheelDelta: 0,
+    zoomDelta: Math.sign(accumulatedZoomDelta),
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
+import {
+  buildExportFileName,
+  defaultExportFileNameTemplates,
+  loadExportFileNameTemplates,
+  saveExportFileNameTemplates,
+  type ExportFileNameTemplateKind,
+  type ExportFileNameTemplateSettings,
+} from "../../lib/exportFileName";
+import { subtitleTrackSupportsBurnIn } from "../../lib/selectPreferredSubtitleTrack";
+import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
+import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../../providers/types";
+import type { ExportSourcePreference } from "./EditorExportDialog";
+import type { PlaybackFallbackInfo } from "./useEditorPlayback";
+
+interface VideoDimensions {
+  width: number;
+  height: number;
+}
+
+type ResolvedExportSourceKind = "hls" | "direct" | "none";
+
+interface ResolvedExportSource {
+  url: string;
+  kind: ResolvedExportSourceKind;
+}
+
+interface UseEditorExportProps {
+  session: CurrentlyPlayingItem;
+  startTime: number;
+  endTime: number;
+  sourceVideoDimensions: VideoDimensions | null;
+  exportFallbackSourceUrl?: string;
+  hlsFallbackInfo: PlaybackFallbackInfo | null;
+  subtitleEnabled: boolean;
+  selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  clippedSubtitleCues: readonly SubtitleCue[];
+  subtitleLoading: boolean;
+  subtitleCues: readonly SubtitleCue[];
+  subtitleStyleSettings: SubtitleStyleSettings;
+}
+
+export function useEditorExport({
+  session,
+  startTime,
+  endTime,
+  sourceVideoDimensions,
+  exportFallbackSourceUrl,
+  hlsFallbackInfo,
+  subtitleEnabled,
+  selectedSubtitleTrack,
+  clippedSubtitleCues,
+  subtitleLoading,
+  subtitleCues,
+  subtitleStyleSettings,
+}: UseEditorExportProps) {
+  const [resolution, setResolution] = useState<ExportResolution>("original");
+  const [exportFormat, setExportFormat] = useState<ExportFormat>("mp4");
+  const [exportSourcePreference, setExportSourcePreference] = useState<ExportSourcePreference>("auto");
+  const [includeAudio, setIncludeAudio] = useState(true);
+  const [fileNameTemplates, setFileNameTemplates] = useState<ExportFileNameTemplateSettings>(() => loadExportFileNameTemplates());
+  const [templateEditorKind, setTemplateEditorKind] = useState<ExportFileNameTemplateKind>("movie");
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const effectiveExportSourcePreference =
+    exportSourcePreference === "direct" && !session.mediaUrl
+      ? "auto"
+      : exportSourcePreference === "hls" && !session.hlsUrl
+        ? "auto"
+        : exportSourcePreference;
+
+  const exportSource = useMemo(() => resolveExportSource({
+    preference: effectiveExportSourcePreference,
+    hlsUrl: session.hlsUrl,
+    mediaUrl: session.mediaUrl,
+    exportFallbackSourceUrl,
+  }), [
+    effectiveExportSourcePreference,
+    exportFallbackSourceUrl,
+    session.hlsUrl,
+    session.mediaUrl,
+  ]);
+
+  const exportSourceMessage = useMemo(() => buildExportSourceMessage({
+    preference: effectiveExportSourcePreference,
+    resolvedSourceKind: exportSource.kind,
+    hlsUrl: session.hlsUrl,
+    mediaUrl: session.mediaUrl,
+    hlsFallbackInfo,
+  }), [
+    effectiveExportSourcePreference,
+    exportSource.kind,
+    hlsFallbackInfo,
+    session.hlsUrl,
+    session.mediaUrl,
+  ]);
+
+  const exportSourceSummaryMessage = useMemo(() => buildExportSourceSummaryMessage({
+    preference: effectiveExportSourcePreference,
+    resolvedSourceKind: exportSource.kind,
+    hlsUrl: session.hlsUrl,
+  }), [
+    effectiveExportSourcePreference,
+    exportSource.kind,
+    session.hlsUrl,
+  ]);
+
+  const exportSourceLabel = useMemo(() => buildExportSourceLabel({
+    preference: effectiveExportSourcePreference,
+    resolvedSourceKind: exportSource.kind,
+    exportFallbackSourceUrl,
+  }), [
+    effectiveExportSourcePreference,
+    exportFallbackSourceUrl,
+    exportSource.kind,
+  ]);
+
+  const fileName = useMemo(() => buildExportFileName({
+    title: session.title,
+    sessionType: session.type,
+    metadata: session.exportMetadata,
+    startTime,
+    endTime,
+    format: exportFormat,
+    templates: fileNameTemplates,
+  }), [
+    endTime,
+    exportFormat,
+    fileNameTemplates,
+    session.exportMetadata,
+    session.title,
+    session.type,
+    startTime,
+  ]);
+
+  const outputDimensions = useMemo(
+    () => getOutputDimensions(sourceVideoDimensions, resolution),
+    [resolution, sourceVideoDimensions],
+  );
+
+  useEffect(() => {
+    saveExportFileNameTemplates(fileNameTemplates);
+  }, [fileNameTemplates]);
+
+  const handleOpenExportDialog = useCallback(() => {
+    setExportError(null);
+    setTemplateEditorKind(fileName.templateKind);
+    setExportDialogOpen(true);
+  }, [fileName.templateKind]);
+
+  const handleCloseExportDialog = useCallback(() => {
+    if (exporting) {
+      return;
+    }
+
+    setExportDialogOpen(false);
+  }, [exporting]);
+
+  const handleFormatChange = useCallback((nextFormat: ExportFormat) => {
+    setExportFormat(nextFormat);
+    setExportError(null);
+  }, []);
+
+  const handleResolutionChange = useCallback((nextResolution: ExportResolution) => {
+    setResolution(nextResolution);
+    setExportError(null);
+  }, []);
+
+  const handleExportSourceChange = useCallback((nextSourcePreference: ExportSourcePreference) => {
+    setExportSourcePreference(nextSourcePreference);
+    setExportError(null);
+  }, []);
+
+  const handleAudioChange = useCallback((nextIncludeAudio: boolean) => {
+    setIncludeAudio(nextIncludeAudio);
+    setExportError(null);
+  }, []);
+
+  const handleFileNameTemplateChange = useCallback((
+    kind: ExportFileNameTemplateKind,
+    nextTemplate: string
+  ) => {
+    setFileNameTemplates((current) => ({
+      ...current,
+      [kind]: nextTemplate,
+    }));
+    setExportError(null);
+  }, []);
+
+  const handleResetFileNameTemplate = useCallback((kind: ExportFileNameTemplateKind) => {
+    const defaults = defaultExportFileNameTemplates();
+
+    setFileNameTemplates((current) => ({
+      ...current,
+      [kind]: defaults[kind],
+    }));
+    setExportError(null);
+  }, []);
+
+  const handleExport = useCallback(async () => {
+    if (!exportSource.url) return;
+    if (exporting) return;
+
+    const shouldBurnSubtitles = subtitleEnabled
+      && selectedSubtitleTrack !== null
+      && clippedSubtitleCues.length > 0;
+
+    if (shouldBurnSubtitles && subtitleLoading) {
+      setExportError("Subtitles are still loading. Please wait a moment and try again.");
+      return;
+    }
+
+    if (shouldBurnSubtitles && !subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
+      setExportError("This subtitle track cannot be burned in yet.");
+      return;
+    }
+
+    setExportError(null);
+    setExporting(true);
+    setProgress(0);
+
+    try {
+      const { exportClip } = await import("../../lib/exportClip");
+      const blob = await exportClip({
+        mediaUrl: exportSource.url,
+        hls: exportSource.kind === "hls",
+        startTime,
+        endTime,
+        format: exportFormat,
+        resolution,
+        includeAudio,
+        selectedAudioTrack: session.selectedAudioTrack,
+        metadata: session.exportMetadata,
+        includeBurnedSubtitles: shouldBurnSubtitles,
+        subtitleCues,
+        subtitleStyleSettings,
+        onProgress: setProgress,
+      });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fileName.fullName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+      setExportDialogOpen(false);
+    } catch (err) {
+      console.error(err);
+      setExportError(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }, [
+    clippedSubtitleCues,
+    endTime,
+    exportFormat,
+    exportSource.kind,
+    exportSource.url,
+    exporting,
+    fileName.fullName,
+    includeAudio,
+    resolution,
+    selectedSubtitleTrack,
+    session.exportMetadata,
+    session.selectedAudioTrack,
+    startTime,
+    subtitleCues,
+    subtitleEnabled,
+    subtitleLoading,
+    subtitleStyleSettings,
+  ]);
+
+  return {
+    resolution,
+    exportFormat,
+    effectiveExportSourcePreference,
+    includeAudio,
+    fileNameTemplates,
+    templateEditorKind,
+    setTemplateEditorKind,
+    exportDialogOpen,
+    exporting,
+    progress,
+    exportError,
+    fileName,
+    outputDimensions,
+    exportSource,
+    exportSourceMessage,
+    exportSourceSummaryMessage,
+    exportSourceLabel,
+    handleOpenExportDialog,
+    handleCloseExportDialog,
+    handleFormatChange,
+    handleResolutionChange,
+    handleExportSourceChange,
+    handleAudioChange,
+    handleFileNameTemplateChange,
+    handleResetFileNameTemplate,
+    handleExport,
+  };
+}
+
+function getOutputDimensions(
+  sourceVideoDimensions: VideoDimensions | null,
+  resolution: ExportResolution
+) {
+  if (!sourceVideoDimensions || sourceVideoDimensions.width <= 0 || sourceVideoDimensions.height <= 0) {
+    return null;
+  }
+
+  if (resolution === "original") {
+    return sourceVideoDimensions;
+  }
+
+  const height = parseInt(resolution, 10);
+  if (!Number.isFinite(height) || height <= 0) {
+    return sourceVideoDimensions;
+  }
+
+  const width = Math.max(1, Math.round((sourceVideoDimensions.width / sourceVideoDimensions.height) * height));
+
+  return { width, height };
+}
+
+function resolveExportSource({
+  preference,
+  hlsUrl,
+  mediaUrl,
+  exportFallbackSourceUrl,
+}: {
+  preference: ExportSourcePreference;
+  hlsUrl?: string;
+  mediaUrl?: string;
+  exportFallbackSourceUrl?: string;
+}): ResolvedExportSource {
+  if (preference === "direct") {
+    return mediaUrl
+      ? { url: mediaUrl, kind: "direct" }
+      : { url: "", kind: "none" };
+  }
+
+  if (preference === "hls") {
+    return hlsUrl
+      ? { url: hlsUrl, kind: "hls" }
+      : { url: "", kind: "none" };
+  }
+
+  if (exportFallbackSourceUrl) {
+    return { url: exportFallbackSourceUrl, kind: "direct" };
+  }
+
+  if (hlsUrl) {
+    return { url: hlsUrl, kind: "hls" };
+  }
+
+  if (mediaUrl) {
+    return { url: mediaUrl, kind: "direct" };
+  }
+
+  return { url: "", kind: "none" };
+}
+
+function buildExportSourceLabel({
+  preference,
+  resolvedSourceKind,
+  exportFallbackSourceUrl,
+}: {
+  preference: ExportSourcePreference;
+  resolvedSourceKind: ResolvedExportSourceKind;
+  exportFallbackSourceUrl?: string;
+}) {
+  if (resolvedSourceKind === "hls") {
+    return preference === "auto" ? "Auto: HLS playback" : "HLS playback";
+  }
+
+  if (resolvedSourceKind === "direct") {
+    if (preference === "auto" && exportFallbackSourceUrl) {
+      return "Auto: direct fallback";
+    }
+
+    return preference === "auto" ? "Auto: direct/original" : "Direct/original";
+  }
+
+  return "Unavailable";
+}
+
+function buildExportSourceMessage({
+  preference,
+  resolvedSourceKind,
+  hlsUrl,
+  mediaUrl,
+  hlsFallbackInfo,
+}: {
+  preference: ExportSourcePreference;
+  resolvedSourceKind: ResolvedExportSourceKind;
+  hlsUrl?: string;
+  mediaUrl?: string;
+  hlsFallbackInfo: PlaybackFallbackInfo | null;
+}) {
+  if (resolvedSourceKind === "none") {
+    return null;
+  }
+
+  if (preference === "hls" && resolvedSourceKind === "hls" && !hlsFallbackInfo) {
+    return "Export will use the HLS playback stream. This follows the media server playback path and can include server-side transcoding.";
+  }
+
+  if (resolvedSourceKind === "direct" && !hlsUrl && mediaUrl) {
+    return "This session only exposed a direct/original media path, so export will use that source.";
+  }
+
+  if (resolvedSourceKind === "direct" && preference !== "auto") {
+    return null;
+  }
+
+  if (!hlsFallbackInfo) {
+    return null;
+  }
+
+  const exportUsesDirectSource = resolvedSourceKind === "direct";
+  const prefix = exportUsesDirectSource
+    ? ({
+        "open-or-read": "Export is using the direct media source because Cliparr could not open or read the HLS stream",
+        "preview-only": "Export is using the direct media source because Cliparr could not use the HLS stream for this export path",
+        "shared-export-blocking": "Export is using the direct media source because Cliparr cannot currently use this HLS stream for export",
+      } as const)[hlsFallbackInfo.category]
+    : ({
+        "open-or-read": "Export will still try the HLS stream even though preview fell back while opening or reading it",
+        "preview-only": "Export will still try the HLS stream because this limitation only affects preview in the current browser",
+        "shared-export-blocking": "Export cannot currently use this HLS stream",
+      } as const)[hlsFallbackInfo.category];
+
+  return `${prefix}: ${hlsFallbackInfo.message}`;
+}
+
+function buildExportSourceSummaryMessage({
+  preference,
+  resolvedSourceKind,
+  hlsUrl,
+}: {
+  preference: ExportSourcePreference;
+  resolvedSourceKind: ResolvedExportSourceKind;
+  hlsUrl?: string;
+}) {
+  if (preference === "direct" && resolvedSourceKind === "direct" && hlsUrl) {
+    return "Export will use the direct/original media path. Cliparr still uses playback metadata for track and timing hints when it is available.";
+  }
+
+  return null;
+}

--- a/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
+++ b/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+
+interface UseEditorKeyboardShortcutsProps {
+  togglePlay: () => void;
+}
+
+export function useEditorKeyboardShortcuts({ togglePlay }: UseEditorKeyboardShortcutsProps) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.code !== "Space") {
+        return;
+      }
+
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      if (isInteractiveKeyboardTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      togglePlay();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [togglePlay]);
+}
+
+function isInteractiveKeyboardTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  return Boolean(
+    target.closest("input, textarea, select, button, [contenteditable=\"true\"], [role=\"slider\"]"),
+  );
+}

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -49,8 +49,13 @@ import {
   getAudioContextConstructor,
 } from "./editorPlaybackSinks";
 import { useEditorPlaybackRenderLoop } from "./useEditorPlaybackRenderLoop";
+import {
+  useEditorPlaybackWarmup,
+  type PlaybackReadyRange,
+} from "./useEditorPlaybackWarmup";
 
 export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
+export type { PlaybackReadyRange } from "./useEditorPlaybackWarmup";
 
 interface UseEditorPlaybackProps {
   hlsUrl?: string;
@@ -68,32 +73,6 @@ interface UseEditorPlaybackProps {
 interface VideoDimensions {
   width: number;
   height: number;
-}
-
-const INITIAL_SELECTION_WARMUP_SECONDS = 8;
-const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
-
-export interface PlaybackReadyRange {
-  startTime: number;
-  endTime: number;
-  readyUntilTime: number;
-  status: "idle" | "warming" | "ready";
-}
-
-interface WarmClipSelectionOptions {
-  extendToSelectionEnd?: boolean;
-}
-
-function samePlaybackRange(
-  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
-  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
-) {
-  return (
-    left !== null
-    && left !== undefined
-    && Math.abs(left.startTime - right.startTime) < 1e-6
-    && Math.abs(left.endTime - right.endTime) < 1e-6
-  );
 }
 
 export function useEditorPlayback({
@@ -273,22 +252,42 @@ export function useEditorPlayback({
     setError,
   });
 
-  const cancelScheduledSelectionWarmupExtension = useCallback(() => {
-    if (selectionWarmupExtensionTimeoutRef.current !== null) {
-      window.clearTimeout(selectionWarmupExtensionTimeoutRef.current);
-      selectionWarmupExtensionTimeoutRef.current = null;
-    }
-  }, []);
-
-  const cancelSelectionWarmup = useCallback(() => {
-    cancelScheduledSelectionWarmupExtension();
-    selectionWarmupGenerationRef.current++;
-    selectionWarmupPromiseRef.current = null;
-    void selectionWarmupVideoIteratorRef.current?.return();
-    void selectionWarmupAudioIteratorRef.current?.return();
-    selectionWarmupVideoIteratorRef.current = null;
-    selectionWarmupAudioIteratorRef.current = null;
-  }, [cancelScheduledSelectionWarmupExtension]);
+  const {
+    cancelSelectionWarmup,
+    warmClipStart,
+    warmClipSelection,
+    scheduleSelectionWarmupExtension,
+  } = useEditorPlaybackWarmup({
+    loadingPreview,
+    activeSourceLabel,
+    playing,
+    currentTime,
+    startTime,
+    endTime,
+    sessionId,
+    videoSinkRef,
+    audioSinkRef,
+    generationRef,
+    warmupGenerationRef,
+    warmupPromiseRef,
+    warmupTargetTimeRef,
+    selectionWarmupGenerationRef,
+    selectionWarmupPromiseRef,
+    selectionWarmupVideoIteratorRef,
+    selectionWarmupAudioIteratorRef,
+    selectionWarmupExtensionTimeoutRef,
+    autoWarmupSessionKeyRef,
+    wasPlayingRef,
+    playingRef,
+    activeSourceLabelRef,
+    playbackReadyRangeRef,
+    sourceTimelineOffsetRef,
+    skipLiveWaitRef,
+    startTimeRef,
+    endTimeRef,
+    clampTime,
+    setPlaybackReadyRange,
+  });
 
   const resetPreview = useCallback((advanceGeneration = false, clearActiveSource = false) => {
     if (advanceGeneration) {
@@ -430,378 +429,6 @@ export function useEditorPlayback({
     });
   }, [pausePlayback, playPreview]);
 
-  const warmClipStart = useCallback(async (clipStart: number) => {
-    if (
-      loadingPreview ||
-      playingRef.current ||
-      activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    const videoSink = videoSinkRef.current;
-    const audioSink = audioSinkRef.current;
-    if (!videoSink && !audioSink) {
-      return;
-    }
-
-    const displayTimestamp = Number(clampTime(clipStart).toFixed(6));
-    if (!Number.isFinite(displayTimestamp)) {
-      return;
-    }
-    if (
-      warmupPromiseRef.current
-      && warmupTargetTimeRef.current !== null
-      && Math.abs(warmupTargetTimeRef.current - displayTimestamp) < 1e-6
-    ) {
-      return warmupPromiseRef.current;
-    }
-
-    const sourceTimestamp = toSourceTimelineTime(displayTimestamp, sourceTimelineOffsetRef.current);
-    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
-    const warmupGeneration = ++warmupGenerationRef.current;
-    const playbackGeneration = generationRef.current;
-    warmupTargetTimeRef.current = displayTimestamp;
-
-    const warmupPromise = (async () => {
-      if (
-        warmupGeneration !== warmupGenerationRef.current ||
-        playbackGeneration !== generationRef.current ||
-        playingRef.current
-      ) {
-        return;
-      }
-
-      try {
-        await Promise.allSettled([
-          videoSink ? videoSink.getCanvas(sourceTimestamp, packetRetrievalOptions) : Promise.resolve(null),
-          audioSink ? audioSink.getBuffer(sourceTimestamp, packetRetrievalOptions) : Promise.resolve(null),
-        ]);
-      } catch {
-        // Warmup is opportunistic; playback still works without it.
-      }
-    })();
-
-    warmupPromiseRef.current = warmupPromise;
-    try {
-      await warmupPromise;
-    } finally {
-      if (warmupPromiseRef.current === warmupPromise) {
-        warmupPromiseRef.current = null;
-        warmupTargetTimeRef.current = null;
-      }
-    }
-  }, [clampTime, loadingPreview]);
-
-  const warmClipSelection = useCallback(async (
-    clipStart: number,
-    clipEnd: number,
-    options: WarmClipSelectionOptions = {},
-  ) => {
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    const extendToSelectionEnd = options.extendToSelectionEnd ?? true;
-    const videoSink = videoSinkRef.current;
-    const audioSink = audioSinkRef.current;
-    if (!videoSink && !audioSink) {
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
-    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      return;
-    }
-
-    const nextRange: PlaybackReadyRange = {
-      startTime: normalizedStart,
-      endTime: normalizedEnd,
-      readyUntilTime: normalizedStart,
-      status: "warming",
-    };
-    const currentReadyRange = playbackReadyRangeRef.current;
-    if (
-      samePlaybackRange(currentReadyRange, nextRange)
-      && currentReadyRange?.status === "ready"
-      && currentReadyRange.readyUntilTime >= normalizedEnd
-    ) {
-      return;
-    }
-
-    setPlaybackReadyRange((current) => {
-      if (samePlaybackRange(current, nextRange) && current) {
-        return {
-          ...current,
-          status: current.status === "ready" ? "ready" : "warming",
-        };
-      }
-
-      return nextRange;
-    });
-
-    await warmClipStart(normalizedStart);
-
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    cancelSelectionWarmup();
-    const warmupGeneration = selectionWarmupGenerationRef.current;
-    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
-    const initialReadyEnd = Math.min(normalizedEnd, normalizedStart + INITIAL_SELECTION_WARMUP_SECONDS);
-
-    let lastPublishedReadyUntil = normalizedStart;
-    let videoReadyUntil = normalizedStart;
-    let audioReadyUntil = normalizedStart;
-    let videoReachedSelectionEnd = !videoSink;
-    let audioReachedSelectionEnd = !audioSink;
-
-    const computeReadyUntil = () => {
-      const readyTimes = [
-        videoSink ? videoReadyUntil : null,
-        audioSink ? audioReadyUntil : null,
-      ].filter(isPresent);
-
-      return readyTimes.length > 0 ? Math.min(...readyTimes) : normalizedStart;
-    };
-
-    const publishReadyUntil = (
-      nextReadyUntil: number,
-      status: PlaybackReadyRange["status"],
-      force = false,
-    ) => {
-      const clampedReadyUntil = Math.max(
-        normalizedStart,
-        Math.min(normalizedEnd, Number(nextReadyUntil.toFixed(6))),
-      );
-
-      if (
-        !force
-        && clampedReadyUntil < normalizedEnd
-        && clampedReadyUntil - lastPublishedReadyUntil < 0.25
-      ) {
-        return;
-      }
-
-      lastPublishedReadyUntil = Math.max(lastPublishedReadyUntil, clampedReadyUntil);
-      setPlaybackReadyRange((current) => {
-        const baseRange: PlaybackReadyRange = samePlaybackRange(current, nextRange) && current
-          ? current
-          : {
-              ...nextRange,
-              status: "idle",
-            };
-        const readyUntilTime = Math.max(baseRange.readyUntilTime, clampedReadyUntil);
-
-        if (
-          baseRange.status === status
-          && Math.abs(baseRange.readyUntilTime - readyUntilTime) < 1e-6
-        ) {
-          return current ?? baseRange;
-        }
-
-        return {
-          startTime: normalizedStart,
-          endTime: normalizedEnd,
-          readyUntilTime,
-          status,
-        };
-      });
-    };
-
-    const selectionWarmupPromise = (async () => {
-      const isCancelled = () => (
-        warmupGeneration !== selectionWarmupGenerationRef.current
-        || playingRef.current
-        || activeSourceLabelRef.current !== "HLS stream"
-      );
-
-      const warmVideoRange = async (rangeStart: number, rangeEnd: number) => {
-        if (!videoSink || rangeEnd <= rangeStart) {
-          return true;
-        }
-
-        const iterator = videoSink.canvases(
-          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
-          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
-          packetRetrievalOptions,
-        );
-        selectionWarmupVideoIteratorRef.current = iterator;
-        let completedRange = false;
-
-        try {
-          for await (const frame of iterator) {
-            if (isCancelled()) {
-              break;
-            }
-
-            videoReadyUntil = Math.max(
-              videoReadyUntil,
-              clampTime(fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)),
-            );
-            publishReadyUntil(computeReadyUntil(), "warming");
-
-            if (videoReadyUntil >= rangeEnd) {
-              completedRange = true;
-              break;
-            }
-          }
-        } catch {
-          // Selection warmup is best-effort; playback still works without it.
-        } finally {
-          if (selectionWarmupVideoIteratorRef.current === iterator) {
-            selectionWarmupVideoIteratorRef.current = null;
-          }
-        }
-
-        if (!isCancelled() && !completedRange && rangeEnd - videoReadyUntil <= 0.5) {
-          completedRange = true;
-        }
-
-        if (!isCancelled() && completedRange) {
-          videoReadyUntil = Math.max(videoReadyUntil, rangeEnd);
-          if (rangeEnd >= normalizedEnd) {
-            videoReachedSelectionEnd = true;
-          }
-          publishReadyUntil(computeReadyUntil(), "warming", true);
-        }
-
-        return completedRange;
-      };
-
-      const warmAudioRange = async (rangeStart: number, rangeEnd: number) => {
-        if (!audioSink || rangeEnd <= rangeStart) {
-          return true;
-        }
-
-        const iterator = audioSink.buffers(
-          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
-          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
-          packetRetrievalOptions,
-        );
-        selectionWarmupAudioIteratorRef.current = iterator;
-        let completedRange = false;
-
-        try {
-          for await (const { buffer, timestamp } of iterator) {
-            if (isCancelled()) {
-              break;
-            }
-
-            audioReadyUntil = Math.max(
-              audioReadyUntil,
-              clampTime(
-                fromSourceTimelineTime(
-                  timestamp + buffer.duration,
-                  sourceTimelineOffsetRef.current,
-                ),
-              ),
-            );
-            publishReadyUntil(computeReadyUntil(), "warming");
-
-            if (audioReadyUntil >= rangeEnd) {
-              completedRange = true;
-              break;
-            }
-          }
-        } catch {
-          // Selection warmup is best-effort; playback still works without it.
-        } finally {
-          if (selectionWarmupAudioIteratorRef.current === iterator) {
-            selectionWarmupAudioIteratorRef.current = null;
-          }
-        }
-
-        if (!isCancelled() && !completedRange && rangeEnd - audioReadyUntil <= 0.05) {
-          completedRange = true;
-        }
-
-        if (!isCancelled() && completedRange) {
-          audioReadyUntil = Math.max(audioReadyUntil, rangeEnd);
-          if (rangeEnd >= normalizedEnd) {
-            audioReachedSelectionEnd = true;
-          }
-          publishReadyUntil(computeReadyUntil(), "warming", true);
-        }
-
-        return completedRange;
-      };
-
-      await Promise.allSettled([
-        warmVideoRange(normalizedStart, initialReadyEnd),
-        warmAudioRange(normalizedStart, initialReadyEnd),
-      ]);
-
-      if (!isCancelled() && extendToSelectionEnd && normalizedEnd > initialReadyEnd) {
-        await Promise.allSettled([
-          warmVideoRange(Math.max(videoReadyUntil, initialReadyEnd), normalizedEnd),
-          warmAudioRange(Math.max(audioReadyUntil, initialReadyEnd), normalizedEnd),
-        ]);
-      }
-
-      if (!isCancelled()) {
-        publishReadyUntil(
-          videoReachedSelectionEnd && audioReachedSelectionEnd
-            ? normalizedEnd
-            : computeReadyUntil(),
-          videoReachedSelectionEnd && audioReachedSelectionEnd ? "ready" : "idle",
-          true,
-        );
-      }
-    })();
-
-    selectionWarmupPromiseRef.current = selectionWarmupPromise;
-    try {
-      await selectionWarmupPromise;
-    } finally {
-      if (selectionWarmupPromiseRef.current === selectionWarmupPromise) {
-        selectionWarmupPromiseRef.current = null;
-      }
-    }
-  }, [cancelSelectionWarmup, clampTime, loadingPreview, warmClipStart]);
-
-  const scheduleSelectionWarmupExtension = useCallback((clipStart: number, clipEnd: number) => {
-    cancelScheduledSelectionWarmupExtension();
-
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
-    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      return;
-    }
-
-    selectionWarmupExtensionTimeoutRef.current = window.setTimeout(() => {
-      selectionWarmupExtensionTimeoutRef.current = null;
-
-      if (
-        loadingPreview
-        || playingRef.current
-        || activeSourceLabelRef.current !== "HLS stream"
-      ) {
-        return;
-      }
-
-      void warmClipSelection(normalizedStart, normalizedEnd);
-    }, SEEK_SELECTION_EXTENSION_DELAY_MS);
-  }, [cancelScheduledSelectionWarmupExtension, clampTime, loadingPreview, warmClipSelection]);
-
   const seekToTime = useCallback(async (seconds: number) => {
     const nextTime = clampTime(seconds);
     const wasPlaying = playingRef.current;
@@ -844,114 +471,6 @@ export function useEditorPlayback({
     warmClipStart,
     warmClipSelection,
   ]);
-
-  useEffect(() => {
-    if (loadingPreview || activeSourceLabel !== "HLS stream") {
-      autoWarmupSessionKeyRef.current = null;
-      setPlaybackReadyRange(null);
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(startTime).toFixed(6));
-    const normalizedEnd = Number(clampTime(endTime).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      setPlaybackReadyRange(null);
-      return;
-    }
-
-    const nextRange: PlaybackReadyRange = {
-      startTime: normalizedStart,
-      endTime: normalizedEnd,
-      readyUntilTime: normalizedStart,
-      status: "idle",
-    };
-
-    setPlaybackReadyRange((current) => (
-      samePlaybackRange(current, nextRange) ? current : nextRange
-    ));
-
-    const warmupSessionKey = `${sessionId}:hls:${normalizedStart}:${normalizedEnd}`;
-    if (autoWarmupSessionKeyRef.current === warmupSessionKey) {
-      return;
-    }
-
-    autoWarmupSessionKeyRef.current = warmupSessionKey;
-    void warmClipSelection(startTimeRef.current, endTimeRef.current, {
-      extendToSelectionEnd: false,
-    });
-    scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
-  }, [
-    activeSourceLabel,
-    clampTime,
-    endTime,
-    loadingPreview,
-    scheduleSelectionWarmupExtension,
-    sessionId,
-    startTime,
-    warmClipSelection,
-  ]);
-
-  useEffect(() => {
-    if (
-      wasPlayingRef.current
-      && !playing
-      && !loadingPreview
-      && activeSourceLabel === "HLS stream"
-    ) {
-      const currentReadyRange = playbackReadyRangeRef.current;
-      if (currentReadyRange && currentReadyRange.status !== "ready") {
-        const selectionStart = clampTime(startTimeRef.current);
-        if (selectionStart < endTimeRef.current) {
-          void warmClipSelection(selectionStart, endTimeRef.current, {
-            extendToSelectionEnd: false,
-          });
-          scheduleSelectionWarmupExtension(selectionStart, endTimeRef.current);
-        }
-      }
-    }
-
-    wasPlayingRef.current = playing;
-  }, [
-    activeSourceLabel,
-    clampTime,
-    currentTime,
-    loadingPreview,
-    playing,
-    scheduleSelectionWarmupExtension,
-    warmClipSelection,
-  ]);
-
-  useEffect(() => {
-    if (!playing || activeSourceLabel !== "HLS stream") {
-      return;
-    }
-
-    const normalizedCurrent = Number(clampTime(currentTime).toFixed(6));
-    setPlaybackReadyRange((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const readyUntilTime = Math.max(
-        current.readyUntilTime,
-        Math.min(current.endTime, normalizedCurrent),
-      );
-      const status = readyUntilTime >= current.endTime ? "ready" : "warming";
-
-      if (
-        current.status === status
-        && Math.abs(current.readyUntilTime - readyUntilTime) < 1e-6
-      ) {
-        return current;
-      }
-
-      return {
-        ...current,
-        readyUntilTime,
-        status,
-      };
-    });
-  }, [activeSourceLabel, clampTime, currentTime, playing]);
 
   useEffect(() => {
     const playbackSources = buildPlaybackSourceCandidates(hlsUrl, mediaUrl);

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -22,7 +22,6 @@ import type { PlaybackAudioSelection } from "../../providers/types";
 import { errorMessage } from "./EditorUtils";
 import {
   applyPlaybackGain,
-  playbackGainValue,
   runPlaybackAudioIterator,
   stopQueuedAudioNodes,
 } from "./editorPlaybackAudio";
@@ -44,6 +43,11 @@ import {
   type PlaybackLoadFailure,
   type PlaybackSourceAnalysisContext,
 } from "./editorPlaybackSources";
+import {
+  createPlaybackSinkResources,
+  disposePlaybackSinkResources,
+  getAudioContextConstructor,
+} from "./editorPlaybackSinks";
 import { useEditorPlaybackRenderLoop } from "./useEditorPlaybackRenderLoop";
 
 export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
@@ -66,16 +70,8 @@ interface VideoDimensions {
   height: number;
 }
 
-type WindowWithWebkitAudioContext = Window & {
-  webkitAudioContext?: typeof AudioContext;
-};
-
 const INITIAL_SELECTION_WARMUP_SECONDS = 8;
 const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
-
-function getAudioContextConstructor() {
-  return window.AudioContext ?? (window as WindowWithWebkitAudioContext).webkitAudioContext;
-}
 
 export interface PlaybackReadyRange {
   startTime: number;
@@ -316,13 +312,13 @@ export function useEditorPlayback({
     warmupPromiseRef.current = null;
     warmupTargetTimeRef.current = null;
     displayedFrameRef.current = null;
-    videoSinkRef.current = null;
-    audioSinkRef.current = null;
-    inputRef.current?.dispose();
-    inputRef.current = null;
-    void audioContextRef.current?.close().catch(() => undefined);
-    audioContextRef.current = null;
-    gainNodeRef.current = null;
+    disposePlaybackSinkResources({
+      inputRef,
+      videoSinkRef,
+      audioSinkRef,
+      audioContextRef,
+      gainNodeRef,
+    });
     setPlaybackReadyRange(null);
   }, [cancelSelectionWarmup, pausePlayback, stopRenderLoop]);
 
@@ -1135,32 +1131,20 @@ export function useEditorPlayback({
             }
 
             try {
-              if (previewVideoTrack) {
-                videoSinkRef.current = new CanvasSink(previewVideoTrack, {
-                  poolSize: 2,
-                  fit: "contain",
-                  alpha: await previewVideoTrack.canBeTransparent(),
-                });
-              }
+              const sinkResources = await createPlaybackSinkResources({
+                CanvasSinkConstructor: CanvasSink,
+                AudioBufferSinkConstructor: AudioBufferSink,
+                previewVideoTrack,
+                previewAudioTrack,
+                audioTrackSampleRate,
+                volume: volumeRef.current,
+                muted: mutedRef.current,
+              });
 
-              if (previewAudioTrack) {
-                const AudioContextConstructor = getAudioContextConstructor();
-                if (!AudioContextConstructor) {
-                  throw new PlaybackSourceError(
-                    "preview-only",
-                    "This browser does not provide Web Audio."
-                  );
-                }
-                const audioContext = new AudioContextConstructor({
-                  sampleRate: audioTrackSampleRate,
-                });
-                const gainNode = audioContext.createGain();
-                gainNode.gain.value = playbackGainValue(volumeRef.current, mutedRef.current);
-                gainNode.connect(audioContext.destination);
-                audioContextRef.current = audioContext;
-                gainNodeRef.current = gainNode;
-                audioSinkRef.current = new AudioBufferSink(previewAudioTrack);
-              }
+              videoSinkRef.current = sinkResources.videoSink;
+              audioSinkRef.current = sinkResources.audioSink;
+              audioContextRef.current = sinkResources.audioContext;
+              gainNodeRef.current = sinkResources.gainNode;
 
               await startVideoIterator();
             } catch (err) {

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -3,9 +3,7 @@ import type {
   AudioBufferSink,
   CanvasSink,
   Input,
-  InputAudioTrack,
   InputTrack,
-  InputVideoTrack,
   WrappedAudioBuffer,
   WrappedCanvas,
 } from "mediabunny";
@@ -13,20 +11,37 @@ import { getActiveSubtitleCue } from "../../lib/subtitles/getActiveSubtitleCue";
 import { renderSubtitleCue } from "../../lib/subtitles/renderSubtitleCue";
 import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
 import { ensureMediabunnyCodecs } from "../../lib/mediabunnyCodecs";
-import { createCliparrInputFromUrl, isHlsPlaylistUrl } from "../../lib/mediabunnyInput";
+import { createCliparrInputFromUrl } from "../../lib/mediabunnyInput";
 import {
   fromSourceTimelineTime,
   getAudioTrackSampleRate,
-  getTrackCodec,
-  getTrackLanguageCode,
-  getTrackName,
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
   toSourceTimelineTime,
 } from "../../lib/mediabunnyTrackAccess";
 import { selectPreferredPairableAudioTrack } from "../../lib/selectPreferredAudioTrack";
 import type { PlaybackAudioSelection } from "../../providers/types";
-import { errorMessage, isAc3FamilyCodec, themeValue } from "./EditorUtils";
+import { errorMessage, themeValue } from "./EditorUtils";
+import {
+  assessPreviewAudioTrack,
+  browserDecoderEnvironmentWarning,
+  buildPlaybackFailure,
+  buildPlaybackLoadError,
+  buildPlaybackSourceAnalysis,
+  buildPlaybackSourceCandidates,
+  describePlaybackFailure,
+  formatPlaybackSourceLabel,
+  isPresent,
+  PlaybackSourceError,
+  resolvePlaybackDuration,
+  selectPreviewVideoTrack,
+  shouldUseExportFallback,
+  type PlaybackFallbackInfo,
+  type PlaybackLoadFailure,
+  type PlaybackSourceAnalysisContext,
+} from "./editorPlaybackSources";
+
+export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
 
 interface UseEditorPlaybackProps {
   hlsUrl?: string;
@@ -53,21 +68,8 @@ type WindowWithWebkitAudioContext = Window & {
 const INITIAL_SELECTION_WARMUP_SECONDS = 8;
 const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
 
-interface PlaybackSourceCandidate {
-  label: "hls stream" | "direct source";
-  url: string;
-}
-
-interface PlaybackLoadFailure {
-  label: PlaybackSourceCandidate["label"];
-  message: string;
-  classification: "hls-playlist" | "unknown";
-  category: "open-or-read" | "preview-only" | "shared-export-blocking";
-}
-
-export interface PlaybackFallbackInfo {
-  category: PlaybackLoadFailure["category"];
-  message: string;
+function getAudioContextConstructor() {
+  return window.AudioContext ?? (window as WindowWithWebkitAudioContext).webkitAudioContext;
 }
 
 export interface PlaybackReadyRange {
@@ -81,81 +83,6 @@ interface WarmClipSelectionOptions {
   extendToSelectionEnd?: boolean;
 }
 
-interface PlaybackSourceAnalysisContext {
-  sessionId: string;
-  source: PlaybackSourceCandidate["label"];
-  url: string;
-  selectedAudioTrack?: PlaybackAudioSelection;
-  videoTracks: readonly InputVideoTrack[];
-  allAudioTracks: readonly InputAudioTrack[];
-  sourceVideoTrack: InputVideoTrack | null;
-  previewVideoTrack: InputVideoTrack | null;
-  sourceAudioTrack: InputAudioTrack | null;
-  previewAudioTrack: InputAudioTrack | null;
-  previewAudioWarning?: string;
-  warnings: string[];
-  isLivePlayback: boolean;
-}
-
-class PlaybackSourceError extends Error {
-  category: PlaybackLoadFailure["category"];
-
-  constructor(category: PlaybackLoadFailure["category"], message: string) {
-    super(message);
-    this.name = "PlaybackSourceError";
-    this.category = category;
-  }
-}
-
-function getAudioContextConstructor() {
-  return window.AudioContext ?? (window as WindowWithWebkitAudioContext).webkitAudioContext;
-}
-
-function buildPlaybackSourceCandidates(hlsUrl: string | undefined, mediaUrl: string | undefined) {
-  const candidates: PlaybackSourceCandidate[] = [];
-
-  if (hlsUrl) {
-    candidates.push({ label: "hls stream", url: hlsUrl });
-  }
-
-  if (mediaUrl && !candidates.some((candidate) => candidate.url === mediaUrl)) {
-    candidates.push({ label: "direct source", url: mediaUrl });
-  }
-
-  return candidates;
-}
-
-function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "url">): PlaybackLoadFailure["classification"] {
-  return source.label === "hls stream" || isHlsPlaylistUrl(source.url) ? "hls-playlist" : "unknown";
-}
-
-function buildPlaybackFailure(source: PlaybackSourceCandidate, err: unknown): PlaybackLoadFailure {
-  return {
-    label: source.label,
-    message: errorMessage(err),
-    classification: classifyPlaybackSource(source),
-    category: err instanceof PlaybackSourceError ? err.category : "open-or-read",
-  };
-}
-
-function shouldUseExportFallback(failure: PlaybackLoadFailure) {
-  return failure.category === "open-or-read" || failure.category === "shared-export-blocking";
-}
-
-function describePlaybackFailure(failure: PlaybackLoadFailure) {
-  const prefix = failure.label === "hls stream" ? "HLS stream" : "Direct source";
-
-  return `${prefix} failed: ${failure.message}`;
-}
-
-function formatPlaybackSourceLabel(label: PlaybackSourceCandidate["label"]) {
-  return label === "hls stream" ? "HLS stream" : "Direct source";
-}
-
-function isPresent<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined;
-}
-
 function samePlaybackRange(
   left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
   right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
@@ -166,227 +93,6 @@ function samePlaybackRange(
     && Math.abs(left.startTime - right.startTime) < 1e-6
     && Math.abs(left.endTime - right.endTime) < 1e-6
   );
-}
-
-function finiteNonNegativeDuration(value: number) {
-  return Number.isFinite(value) ? Math.max(0, value) : 0;
-}
-
-function resolvePlaybackDuration(
-  playbackSource: PlaybackSourceCandidate,
-  computedDuration: number,
-  initialDuration: number,
-) {
-  const fallbackDuration = finiteNonNegativeDuration(initialDuration);
-  const normalizedComputedDuration = finiteNonNegativeDuration(computedDuration);
-
-  if (playbackSource.label === "hls stream") {
-    return Math.max(fallbackDuration, normalizedComputedDuration);
-  }
-
-  return normalizedComputedDuration || fallbackDuration;
-}
-
-function buildPlaybackLoadError(failures: PlaybackLoadFailure[]) {
-  if (failures.length === 0) {
-    return "Playback could not be loaded.";
-  }
-
-  if (failures.length === 1) {
-    return describePlaybackFailure(failures[0]);
-  }
-
-  const uniqueMessages = [...new Set(failures.map((failure) => failure.message))];
-  if (uniqueMessages.length === 1) {
-    return `Cliparr could not open any playback stream. ${uniqueMessages[0]}`;
-  }
-
-  return `Cliparr could not open any playback stream. ${failures.map(describePlaybackFailure).join(" ")}`;
-}
-
-function browserDecoderEnvironmentWarning() {
-  const missingDecoders = [
-    "VideoDecoder" in window ? null : "video",
-    "AudioDecoder" in window ? null : "audio",
-  ].filter(isPresent);
-
-  if (missingDecoders.length === 0) {
-    return undefined;
-  }
-
-  if (!window.isSecureContext) {
-    return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable from ${window.location.origin}. Open Cliparr over HTTPS, localhost, or 127.0.0.1 so the editor can decode media. Jellyfin playback can still work on this origin because its native player does not use the same editor decoder APIs.`;
-  }
-
-  return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable in this browser.`;
-}
-
-async function assessPreviewVideoTrack(track: InputVideoTrack | null) {
-  if (!track) {
-    return { track: null, warning: undefined };
-  }
-
-  const videoCodec = await getTrackCodec(track);
-  if (videoCodec === null) {
-    return {
-      track: null,
-      warning: "Video codec is unknown.",
-    };
-  }
-
-  if (!(await track.canDecode())) {
-    return {
-      track: null,
-      warning: `Cannot decode ${videoCodec} video in this browser.`,
-    };
-  }
-
-  return { track, warning: undefined };
-}
-
-async function selectPreviewVideoTrack(videoTracks: readonly InputVideoTrack[]) {
-  const sourceVideoTrack = videoTracks[0] ?? null;
-  if (!sourceVideoTrack) {
-    return {
-      sourceVideoTrack: null,
-      previewVideoTrack: null,
-      warnings: [] as string[],
-    };
-  }
-
-  const warnings: string[] = [];
-  const primaryAssessment = await assessPreviewVideoTrack(sourceVideoTrack);
-  if (primaryAssessment.track) {
-    return {
-      sourceVideoTrack,
-      previewVideoTrack: primaryAssessment.track,
-      warnings,
-    };
-  }
-
-  if (primaryAssessment.warning) {
-    warnings.push(primaryAssessment.warning);
-  }
-
-  for (const candidate of videoTracks.slice(1)) {
-    const candidateAssessment = await assessPreviewVideoTrack(candidate);
-    if (candidateAssessment.track) {
-      return {
-        sourceVideoTrack,
-        previewVideoTrack: candidateAssessment.track,
-        warnings,
-      };
-    }
-  }
-
-  return {
-    sourceVideoTrack,
-    previewVideoTrack: null,
-    warnings,
-  };
-}
-
-async function assessPreviewAudioTrack(track: InputAudioTrack | null) {
-  if (!track) {
-    return { track: null, warning: undefined };
-  }
-
-  const audioCodec = await getTrackCodec(track);
-  if (audioCodec === null) {
-    return {
-      track: null,
-      warning: "Audio codec is unknown.",
-    };
-  }
-
-  if (!(await track.canDecode()) && !isAc3FamilyCodec(audioCodec)) {
-    return {
-      track: null,
-      warning: `Cannot decode ${audioCodec} audio in this browser.`,
-    };
-  }
-
-  return { track, warning: undefined };
-}
-
-async function summarizeVideoTrackForDebug(track: InputVideoTrack | null) {
-  if (!track) {
-    return null;
-  }
-
-  const [codec, title, canDecode] = await Promise.all([
-    getTrackCodec(track),
-    getTrackName(track),
-    track.canDecode().catch(() => null),
-  ]);
-
-  return {
-    trackNumber: track.number,
-    codec: codec ?? null,
-    title: title ?? null,
-    canDecode,
-  };
-}
-
-async function summarizeAudioTrackForDebug(track: InputAudioTrack | null) {
-  if (!track) {
-    return null;
-  }
-
-  const [codec, title, languageCode, canDecode] = await Promise.all([
-    getTrackCodec(track),
-    getTrackName(track),
-    getTrackLanguageCode(track),
-    track.canDecode().catch(() => null),
-  ]);
-
-  return {
-    trackNumber: track.number,
-    codec: codec ?? null,
-    title: title ?? null,
-    languageCode: languageCode ?? null,
-    canDecode,
-  };
-}
-
-async function summarizeAudioTracksForDebug(tracks: readonly InputAudioTrack[]) {
-  return Promise.all(tracks.map((track) => summarizeAudioTrackForDebug(track)));
-}
-
-async function buildPlaybackSourceAnalysis(context: PlaybackSourceAnalysisContext) {
-  const [
-    allAudioTracks,
-    sourceVideoTrack,
-    previewVideoTrack,
-    sourceAudioTrack,
-    previewAudioTrack,
-  ] = await Promise.all([
-    summarizeAudioTracksForDebug(context.allAudioTracks),
-    summarizeVideoTrackForDebug(context.sourceVideoTrack),
-    summarizeVideoTrackForDebug(context.previewVideoTrack),
-    summarizeAudioTrackForDebug(context.sourceAudioTrack),
-    summarizeAudioTrackForDebug(context.previewAudioTrack),
-  ]);
-
-  return {
-    sessionId: context.sessionId,
-    source: context.source,
-    urlClassification: classifyPlaybackSource({
-      label: context.source,
-      url: context.url,
-    }),
-    selectedAudioTrack: context.selectedAudioTrack ?? null,
-    videoTrackCount: context.videoTracks.length,
-    audioTrackCount: context.allAudioTracks.length,
-    allAudioTracks,
-    sourceVideoTrack,
-    previewVideoTrack,
-    sourceAudioTrack,
-    previewAudioTrack,
-    previewAudioWarning: context.previewAudioWarning ?? null,
-    warnings: [...context.warnings],
-    isLivePlayback: context.isLivePlayback,
-  } satisfies Record<string, unknown>;
 }
 
 export function useEditorPlayback({

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -21,6 +21,12 @@ import { selectPreferredPairableAudioTrack } from "../../lib/selectPreferredAudi
 import type { PlaybackAudioSelection } from "../../providers/types";
 import { errorMessage } from "./EditorUtils";
 import {
+  applyPlaybackGain,
+  playbackGainValue,
+  runPlaybackAudioIterator,
+  stopQueuedAudioNodes,
+} from "./editorPlaybackAudio";
+import {
   assessPreviewAudioTrack,
   browserDecoderEnvironmentWarning,
   buildPlaybackFailure,
@@ -184,10 +190,7 @@ export function useEditorPlayback({
   useEffect(() => {
     volumeRef.current = volume;
     mutedRef.current = muted;
-    if (gainNodeRef.current) {
-      const actualVolume = muted || volume === 0 ? 0 : volume;
-      gainNodeRef.current.gain.value = actualVolume ** 2;
-    }
+    applyPlaybackGain(gainNodeRef.current, volume, muted);
   }, [volume, muted]);
 
   useEffect(() => {
@@ -226,14 +229,7 @@ export function useEditorPlayback({
   }, [clampTime]);
 
   const stopAudioNodes = useCallback(() => {
-    for (const node of queuedAudioNodesRef.current) {
-      try {
-        node.stop();
-      } catch {
-        // The node may have already ended.
-      }
-    }
-    queuedAudioNodesRef.current.clear();
+    stopQueuedAudioNodes(queuedAudioNodesRef.current);
   }, []);
 
   const pausePlayback = useCallback((storeCurrentTime = true) => {
@@ -342,68 +338,23 @@ export function useEditorPlayback({
   }, [resetPreview]);
 
   const runAudioIterator = useCallback(async (generation: number) => {
-    const iterator = audioBufferIteratorRef.current;
-    const audioContext = audioContextRef.current;
-    const gainNode = gainNodeRef.current;
-    if (!iterator || !audioContext || !gainNode) {
-      return;
-    }
-
-    try {
-      for await (const { buffer, timestamp } of iterator) {
-        if (generation !== generationRef.current || !playingRef.current) {
-          break;
-        }
-
-        const node = audioContext.createBufferSource();
-        node.buffer = buffer;
-        node.connect(gainNode);
-        const displayTimestamp = fromSourceTimelineTime(timestamp, sourceTimelineOffsetRef.current);
-
-        const startTimestamp = (
-          audioContextStartTimeRef.current ?? audioContext.currentTime
-        ) + displayTimestamp - playbackTimeAtStartRef.current;
-
-        let started = false;
-        if (startTimestamp >= audioContext.currentTime) {
-          node.start(startTimestamp);
-          started = true;
-        } else {
-          const offset = audioContext.currentTime - startTimestamp;
-          if (offset < buffer.duration) {
-            node.start(audioContext.currentTime, offset);
-            started = true;
-          }
-        }
-
-        if (started) {
-          queuedAudioNodesRef.current.add(node);
-          node.onended = () => {
-            queuedAudioNodesRef.current.delete(node);
-          };
-        }
-
-        if (displayTimestamp - getPlaybackTime() >= 1) {
-          await new Promise<void>((resolve) => {
-            const intervalId = window.setInterval(() => {
-              if (
-                generation !== generationRef.current ||
-                !playingRef.current ||
-                displayTimestamp - getPlaybackTime() < 1
-              ) {
-                window.clearInterval(intervalId);
-                resolve();
-              }
-            }, 100);
-          });
-        }
-      }
-    } catch (err) {
-      if (generation === generationRef.current) {
+    await runPlaybackAudioIterator({
+      iterator: audioBufferIteratorRef.current,
+      audioContext: audioContextRef.current,
+      gainNode: gainNodeRef.current,
+      queuedAudioNodes: queuedAudioNodesRef.current,
+      generation,
+      generationRef,
+      playingRef,
+      audioContextStartTimeRef,
+      playbackTimeAtStartRef,
+      sourceTimelineOffsetRef,
+      getPlaybackTime,
+      onError: (err) => {
         setError(errorMessage(err));
         pausePlayback();
-      }
-    }
+      },
+    });
   }, [getPlaybackTime, pausePlayback]);
 
   const playPreview = useCallback(async () => {
@@ -1204,8 +1155,7 @@ export function useEditorPlayback({
                   sampleRate: audioTrackSampleRate,
                 });
                 const gainNode = audioContext.createGain();
-                const actualVolume = mutedRef.current || volumeRef.current === 0 ? 0 : volumeRef.current;
-                gainNode.gain.value = actualVolume ** 2;
+                gainNode.gain.value = playbackGainValue(volumeRef.current, mutedRef.current);
                 gainNode.connect(audioContext.destination);
                 audioContextRef.current = audioContext;
                 gainNodeRef.current = gainNode;

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -7,8 +7,6 @@ import type {
   WrappedAudioBuffer,
   WrappedCanvas,
 } from "mediabunny";
-import { getActiveSubtitleCue } from "../../lib/subtitles/getActiveSubtitleCue";
-import { renderSubtitleCue } from "../../lib/subtitles/renderSubtitleCue";
 import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
 import { ensureMediabunnyCodecs } from "../../lib/mediabunnyCodecs";
 import { createCliparrInputFromUrl } from "../../lib/mediabunnyInput";
@@ -21,7 +19,7 @@ import {
 } from "../../lib/mediabunnyTrackAccess";
 import { selectPreferredPairableAudioTrack } from "../../lib/selectPreferredAudioTrack";
 import type { PlaybackAudioSelection } from "../../providers/types";
-import { errorMessage, themeValue } from "./EditorUtils";
+import { errorMessage } from "./EditorUtils";
 import {
   assessPreviewAudioTrack,
   browserDecoderEnvironmentWarning,
@@ -40,6 +38,7 @@ import {
   type PlaybackLoadFailure,
   type PlaybackSourceAnalysisContext,
 } from "./editorPlaybackSources";
+import { useEditorPlaybackRenderLoop } from "./useEditorPlaybackRenderLoop";
 
 export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
 
@@ -250,63 +249,37 @@ export function useEditorPlayback({
     stopAudioNodes();
   }, [getPlaybackTime, stopAudioNodes]);
 
-  const stopRenderLoop = useCallback(() => {
-    if (animationFrameRef.current !== null) {
-      cancelAnimationFrame(animationFrameRef.current);
-      animationFrameRef.current = null;
-    }
-    if (renderIntervalRef.current !== null) {
-      window.clearInterval(renderIntervalRef.current);
-      renderIntervalRef.current = null;
-    }
-  }, []);
-
-  const drawFrame = useCallback((frame: WrappedCanvas) => {
-    const canvas = canvasRef.current;
-    const context = canvas?.getContext("2d");
-    if (!canvas || !context) {
-      return;
-    }
-    context.clearRect(0, 0, canvas.width, canvas.height);
-    context.drawImage(frame.canvas, 0, 0, canvas.width, canvas.height);
-
-    if (subtitlesEnabledRef.current && subtitleStyleSettingsRef.current) {
-      const cue = getActiveSubtitleCue(
-        subtitleCuesRef.current,
-        fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)
-      );
-      if (cue) {
-        renderSubtitleCue(
-          context,
-          cue,
-          subtitleStyleSettingsRef.current,
-          canvas.width,
-          canvas.height
-        );
-      }
-    }
-
-    displayedFrameRef.current = frame;
-  }, []);
-
-  const drawPlaceholder = useCallback((message: string) => {
-    const canvas = canvasRef.current;
-    const context = canvas?.getContext("2d");
-    if (!canvas || !context) {
-      return;
-    }
-    if (!canvas.width || !canvas.height) {
-      canvas.width = 1280;
-      canvas.height = 720;
-    }
-    const bodyStyles = getComputedStyle(document.body);
-    context.fillStyle = themeValue("--editor-preview-stage", bodyStyles.backgroundColor);
-    context.fillRect(0, 0, canvas.width, canvas.height);
-    context.fillStyle = themeValue("--editor-preview-overlay-foreground", bodyStyles.color);
-    context.font = "24px sans-serif";
-    context.textAlign = "center";
-    context.fillText(message, canvas.width / 2, canvas.height / 2);
-  }, []);
+  const {
+    drawFrame,
+    startVideoIterator,
+    startRenderLoop,
+    stopRenderLoop,
+  } = useEditorPlaybackRenderLoop({
+    canvasRef,
+    inputRef,
+    videoSinkRef,
+    videoFrameIteratorRef,
+    nextFrameRef,
+    displayedFrameRef,
+    animationFrameRef,
+    renderIntervalRef,
+    generationRef,
+    playingRef,
+    playbackTimeAtStartRef,
+    sourceTimelineOffsetRef,
+    skipLiveWaitRef,
+    durationRef,
+    startTimeRef,
+    endTimeRef,
+    subtitleCuesRef,
+    subtitlesEnabledRef,
+    subtitleStyleSettingsRef,
+    getPlaybackTime,
+    clampTime,
+    pausePlayback,
+    setCurrentTime,
+    setError,
+  });
 
   const cancelScheduledSelectionWarmupExtension = useCallback(() => {
     if (selectionWarmupExtensionTimeoutRef.current !== null) {
@@ -324,111 +297,6 @@ export function useEditorPlayback({
     selectionWarmupVideoIteratorRef.current = null;
     selectionWarmupAudioIteratorRef.current = null;
   }, [cancelScheduledSelectionWarmupExtension]);
-
-  const startVideoIterator = useCallback(async () => {
-    const videoSink = videoSinkRef.current;
-    const generation = ++generationRef.current;
-    void videoFrameIteratorRef.current?.return();
-    videoFrameIteratorRef.current = null;
-    nextFrameRef.current = null;
-
-    if (!videoSink) {
-      drawPlaceholder("Audio only");
-      return;
-    }
-
-    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
-    videoFrameIteratorRef.current = videoSink.canvases(
-      toSourceTimelineTime(getPlaybackTime(), sourceTimelineOffsetRef.current),
-      Infinity,
-      packetRetrievalOptions,
-    );
-    const firstResult = await videoFrameIteratorRef.current.next();
-    const secondResult = await videoFrameIteratorRef.current.next();
-    const firstFrame = firstResult.done ? null : (firstResult.value as WrappedCanvas);
-    const secondFrame = secondResult.done ? null : (secondResult.value as WrappedCanvas);
-
-    if (generation !== generationRef.current) {
-      return;
-    }
-
-    nextFrameRef.current = secondFrame;
-    if (firstFrame) {
-      drawFrame(firstFrame);
-    }
-  }, [drawFrame, drawPlaceholder, getPlaybackTime]);
-
-  const updateNextFrame = useCallback(async (generation: number) => {
-    const iterator = videoFrameIteratorRef.current;
-    if (!iterator) {
-      return;
-    }
-
-    try {
-      while (generation === generationRef.current) {
-        const result = await iterator.next();
-        const newNextFrame = result.done ? null : (result.value as WrappedCanvas);
-        if (!newNextFrame || generation !== generationRef.current) {
-          break;
-        }
-
-        const playbackTime = getPlaybackTime();
-        if (
-          fromSourceTimelineTime(newNextFrame.timestamp, sourceTimelineOffsetRef.current)
-            <= playbackTime
-        ) {
-          drawFrame(newNextFrame);
-        } else {
-          nextFrameRef.current = newNextFrame;
-          break;
-        }
-      }
-    } catch (err) {
-      if (generation === generationRef.current) {
-        setError(errorMessage(err));
-      }
-    }
-  }, [drawFrame, getPlaybackTime]);
-
-  const renderFrame = useCallback(() => {
-    if (!inputRef.current) {
-      return;
-    }
-
-    const playbackTime = getPlaybackTime();
-    const clipEnd = Math.min(endTimeRef.current || durationRef.current, durationRef.current);
-
-    if (playingRef.current && playbackTime >= clipEnd) {
-      pausePlayback(false);
-      const nextTime = clampTime(startTimeRef.current);
-      playbackTimeAtStartRef.current = nextTime;
-      setCurrentTime(nextTime);
-      void startVideoIterator();
-      return;
-    }
-
-    const nextFrame = nextFrameRef.current;
-    if (
-      nextFrame
-      && fromSourceTimelineTime(nextFrame.timestamp, sourceTimelineOffsetRef.current) <= playbackTime
-    ) {
-      drawFrame(nextFrame);
-      nextFrameRef.current = null;
-      void updateNextFrame(generationRef.current);
-    }
-
-    setCurrentTime(playbackTime);
-  }, [clampTime, drawFrame, getPlaybackTime, pausePlayback, startVideoIterator, updateNextFrame]);
-
-  const startRenderLoop = useCallback(() => {
-    stopRenderLoop();
-    const tick = () => {
-      renderFrame();
-      animationFrameRef.current = requestAnimationFrame(tick);
-    };
-    animationFrameRef.current = requestAnimationFrame(tick);
-    renderIntervalRef.current = window.setInterval(renderFrame, 500);
-  }, [renderFrame, stopRenderLoop]);
 
   const resetPreview = useCallback((advanceGeneration = false, clearActiveSource = false) => {
     if (advanceGeneration) {

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -1,0 +1,278 @@
+import { useCallback } from "react";
+import type { CanvasSink, Input, WrappedCanvas } from "mediabunny";
+import { fromSourceTimelineTime, toSourceTimelineTime } from "../../lib/mediabunnyTrackAccess";
+import { getActiveSubtitleCue } from "../../lib/subtitles/getActiveSubtitleCue";
+import { renderSubtitleCue } from "../../lib/subtitles/renderSubtitleCue";
+import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
+import { errorMessage, themeValue } from "./EditorUtils";
+
+type RefValue<T> = {
+  current: T;
+};
+
+interface UseEditorPlaybackRenderLoopOptions {
+  canvasRef: RefValue<HTMLCanvasElement | null>;
+  inputRef: RefValue<Input | null>;
+  videoSinkRef: RefValue<CanvasSink | null>;
+  videoFrameIteratorRef: RefValue<AsyncGenerator<WrappedCanvas, void, unknown> | null>;
+  nextFrameRef: RefValue<WrappedCanvas | null>;
+  displayedFrameRef: RefValue<WrappedCanvas | null>;
+  animationFrameRef: RefValue<number | null>;
+  renderIntervalRef: RefValue<number | null>;
+  generationRef: RefValue<number>;
+  playingRef: RefValue<boolean>;
+  playbackTimeAtStartRef: RefValue<number>;
+  sourceTimelineOffsetRef: RefValue<number>;
+  skipLiveWaitRef: RefValue<boolean>;
+  durationRef: RefValue<number>;
+  startTimeRef: RefValue<number>;
+  endTimeRef: RefValue<number>;
+  subtitleCuesRef: RefValue<readonly SubtitleCue[]>;
+  subtitlesEnabledRef: RefValue<boolean>;
+  subtitleStyleSettingsRef: RefValue<SubtitleStyleSettings | undefined>;
+  getPlaybackTime: () => number;
+  clampTime: (seconds: number) => number;
+  pausePlayback: (storeCurrentTime?: boolean) => void;
+  setCurrentTime: (seconds: number) => void;
+  setError: (message: string) => void;
+}
+
+export function useEditorPlaybackRenderLoop({
+  canvasRef,
+  inputRef,
+  videoSinkRef,
+  videoFrameIteratorRef,
+  nextFrameRef,
+  displayedFrameRef,
+  animationFrameRef,
+  renderIntervalRef,
+  generationRef,
+  playingRef,
+  playbackTimeAtStartRef,
+  sourceTimelineOffsetRef,
+  skipLiveWaitRef,
+  durationRef,
+  startTimeRef,
+  endTimeRef,
+  subtitleCuesRef,
+  subtitlesEnabledRef,
+  subtitleStyleSettingsRef,
+  getPlaybackTime,
+  clampTime,
+  pausePlayback,
+  setCurrentTime,
+  setError,
+}: UseEditorPlaybackRenderLoopOptions) {
+  const drawFrame = useCallback((frame: WrappedCanvas) => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) {
+      return;
+    }
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(frame.canvas, 0, 0, canvas.width, canvas.height);
+
+    if (subtitlesEnabledRef.current && subtitleStyleSettingsRef.current) {
+      const cue = getActiveSubtitleCue(
+        subtitleCuesRef.current,
+        fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)
+      );
+      if (cue) {
+        renderSubtitleCue(
+          context,
+          cue,
+          subtitleStyleSettingsRef.current,
+          canvas.width,
+          canvas.height
+        );
+      }
+    }
+
+    displayedFrameRef.current = frame;
+  }, [
+    canvasRef,
+    displayedFrameRef,
+    sourceTimelineOffsetRef,
+    subtitleCuesRef,
+    subtitleStyleSettingsRef,
+    subtitlesEnabledRef,
+  ]);
+
+  const drawPlaceholder = useCallback((message: string) => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) {
+      return;
+    }
+    if (!canvas.width || !canvas.height) {
+      canvas.width = 1280;
+      canvas.height = 720;
+    }
+    const bodyStyles = getComputedStyle(document.body);
+    context.fillStyle = themeValue("--editor-preview-stage", bodyStyles.backgroundColor);
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = themeValue("--editor-preview-overlay-foreground", bodyStyles.color);
+    context.font = "24px sans-serif";
+    context.textAlign = "center";
+    context.fillText(message, canvas.width / 2, canvas.height / 2);
+  }, [canvasRef]);
+
+  const startVideoIterator = useCallback(async () => {
+    const videoSink = videoSinkRef.current;
+    const generation = ++generationRef.current;
+    void videoFrameIteratorRef.current?.return();
+    videoFrameIteratorRef.current = null;
+    nextFrameRef.current = null;
+
+    if (!videoSink) {
+      drawPlaceholder("Audio only");
+      return;
+    }
+
+    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
+    videoFrameIteratorRef.current = videoSink.canvases(
+      toSourceTimelineTime(getPlaybackTime(), sourceTimelineOffsetRef.current),
+      Infinity,
+      packetRetrievalOptions,
+    );
+    const firstResult = await videoFrameIteratorRef.current.next();
+    const secondResult = await videoFrameIteratorRef.current.next();
+    const firstFrame = firstResult.done ? null : (firstResult.value as WrappedCanvas);
+    const secondFrame = secondResult.done ? null : (secondResult.value as WrappedCanvas);
+
+    if (generation !== generationRef.current) {
+      return;
+    }
+
+    nextFrameRef.current = secondFrame;
+    if (firstFrame) {
+      drawFrame(firstFrame);
+    }
+  }, [
+    drawFrame,
+    drawPlaceholder,
+    generationRef,
+    getPlaybackTime,
+    nextFrameRef,
+    skipLiveWaitRef,
+    sourceTimelineOffsetRef,
+    videoFrameIteratorRef,
+    videoSinkRef,
+  ]);
+
+  const updateNextFrame = useCallback(async (generation: number) => {
+    const iterator = videoFrameIteratorRef.current;
+    if (!iterator) {
+      return;
+    }
+
+    try {
+      while (generation === generationRef.current) {
+        const result = await iterator.next();
+        const newNextFrame = result.done ? null : (result.value as WrappedCanvas);
+        if (!newNextFrame || generation !== generationRef.current) {
+          break;
+        }
+
+        const playbackTime = getPlaybackTime();
+        if (
+          fromSourceTimelineTime(newNextFrame.timestamp, sourceTimelineOffsetRef.current)
+            <= playbackTime
+        ) {
+          drawFrame(newNextFrame);
+        } else {
+          nextFrameRef.current = newNextFrame;
+          break;
+        }
+      }
+    } catch (err) {
+      if (generation === generationRef.current) {
+        setError(errorMessage(err));
+      }
+    }
+  }, [
+    drawFrame,
+    generationRef,
+    getPlaybackTime,
+    nextFrameRef,
+    setError,
+    sourceTimelineOffsetRef,
+    videoFrameIteratorRef,
+  ]);
+
+  const renderFrame = useCallback(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const playbackTime = getPlaybackTime();
+    const clipEnd = Math.min(endTimeRef.current || durationRef.current, durationRef.current);
+
+    if (playingRef.current && playbackTime >= clipEnd) {
+      pausePlayback(false);
+      const nextTime = clampTime(startTimeRef.current);
+      playbackTimeAtStartRef.current = nextTime;
+      setCurrentTime(nextTime);
+      void startVideoIterator();
+      return;
+    }
+
+    const nextFrame = nextFrameRef.current;
+    if (
+      nextFrame
+      && fromSourceTimelineTime(nextFrame.timestamp, sourceTimelineOffsetRef.current) <= playbackTime
+    ) {
+      drawFrame(nextFrame);
+      nextFrameRef.current = null;
+      void updateNextFrame(generationRef.current);
+    }
+
+    setCurrentTime(playbackTime);
+  }, [
+    clampTime,
+    drawFrame,
+    durationRef,
+    endTimeRef,
+    generationRef,
+    getPlaybackTime,
+    inputRef,
+    nextFrameRef,
+    pausePlayback,
+    playbackTimeAtStartRef,
+    playingRef,
+    setCurrentTime,
+    sourceTimelineOffsetRef,
+    startTimeRef,
+    startVideoIterator,
+    updateNextFrame,
+  ]);
+
+  const stopRenderLoop = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+    if (renderIntervalRef.current !== null) {
+      window.clearInterval(renderIntervalRef.current);
+      renderIntervalRef.current = null;
+    }
+  }, [animationFrameRef, renderIntervalRef]);
+
+  const startRenderLoop = useCallback(() => {
+    stopRenderLoop();
+    const tick = () => {
+      renderFrame();
+      animationFrameRef.current = requestAnimationFrame(tick);
+    };
+    animationFrameRef.current = requestAnimationFrame(tick);
+    renderIntervalRef.current = window.setInterval(renderFrame, 500);
+  }, [animationFrameRef, renderFrame, renderIntervalRef, stopRenderLoop]);
+
+  return {
+    drawFrame,
+    drawPlaceholder,
+    startVideoIterator,
+    startRenderLoop,
+    stopRenderLoop,
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
@@ -1,0 +1,569 @@
+import { useCallback, useEffect, type Dispatch, type SetStateAction } from "react";
+import type {
+  AudioBufferSink,
+  CanvasSink,
+  WrappedAudioBuffer,
+  WrappedCanvas,
+} from "mediabunny";
+import {
+  fromSourceTimelineTime,
+  toSourceTimelineTime,
+} from "../../lib/mediabunnyTrackAccess";
+import { isPresent } from "./editorPlaybackSources";
+import type {
+  PlaybackReadyRange,
+  RefValue,
+  WarmClipSelectionOptions,
+} from "./editorPlaybackWarmupTypes";
+
+interface UseEditorPlaybackSelectionWarmupOptions {
+  loadingPreview: boolean;
+  activeSourceLabel: string;
+  playing: boolean;
+  currentTime: number;
+  startTime: number;
+  endTime: number;
+  sessionId: string;
+  videoSinkRef: RefValue<CanvasSink | null>;
+  audioSinkRef: RefValue<AudioBufferSink | null>;
+  selectionWarmupGenerationRef: RefValue<number>;
+  selectionWarmupPromiseRef: RefValue<Promise<void> | null>;
+  selectionWarmupVideoIteratorRef: RefValue<AsyncGenerator<WrappedCanvas, void, unknown> | null>;
+  selectionWarmupAudioIteratorRef: RefValue<AsyncGenerator<WrappedAudioBuffer, void, unknown> | null>;
+  selectionWarmupExtensionTimeoutRef: RefValue<number | null>;
+  autoWarmupSessionKeyRef: RefValue<string | null>;
+  wasPlayingRef: RefValue<boolean>;
+  playingRef: RefValue<boolean>;
+  activeSourceLabelRef: RefValue<string>;
+  playbackReadyRangeRef: RefValue<PlaybackReadyRange | null>;
+  sourceTimelineOffsetRef: RefValue<number>;
+  skipLiveWaitRef: RefValue<boolean>;
+  startTimeRef: RefValue<number>;
+  endTimeRef: RefValue<number>;
+  clampTime: (seconds: number) => number;
+  setPlaybackReadyRange: Dispatch<SetStateAction<PlaybackReadyRange | null>>;
+  warmClipStart: (clipStart: number) => Promise<void> | undefined;
+}
+
+const INITIAL_SELECTION_WARMUP_SECONDS = 8;
+const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
+
+export function useEditorPlaybackSelectionWarmup({
+  loadingPreview,
+  activeSourceLabel,
+  playing,
+  currentTime,
+  startTime,
+  endTime,
+  sessionId,
+  videoSinkRef,
+  audioSinkRef,
+  selectionWarmupGenerationRef,
+  selectionWarmupPromiseRef,
+  selectionWarmupVideoIteratorRef,
+  selectionWarmupAudioIteratorRef,
+  selectionWarmupExtensionTimeoutRef,
+  autoWarmupSessionKeyRef,
+  wasPlayingRef,
+  playingRef,
+  activeSourceLabelRef,
+  playbackReadyRangeRef,
+  sourceTimelineOffsetRef,
+  skipLiveWaitRef,
+  startTimeRef,
+  endTimeRef,
+  clampTime,
+  setPlaybackReadyRange,
+  warmClipStart,
+}: UseEditorPlaybackSelectionWarmupOptions) {
+  const cancelScheduledSelectionWarmupExtension = useCallback(() => {
+    if (selectionWarmupExtensionTimeoutRef.current !== null) {
+      window.clearTimeout(selectionWarmupExtensionTimeoutRef.current);
+      selectionWarmupExtensionTimeoutRef.current = null;
+    }
+  }, [selectionWarmupExtensionTimeoutRef]);
+
+  const cancelSelectionWarmup = useCallback(() => {
+    cancelScheduledSelectionWarmupExtension();
+    selectionWarmupGenerationRef.current++;
+    selectionWarmupPromiseRef.current = null;
+    void selectionWarmupVideoIteratorRef.current?.return();
+    void selectionWarmupAudioIteratorRef.current?.return();
+    selectionWarmupVideoIteratorRef.current = null;
+    selectionWarmupAudioIteratorRef.current = null;
+  }, [
+    cancelScheduledSelectionWarmupExtension,
+    selectionWarmupAudioIteratorRef,
+    selectionWarmupGenerationRef,
+    selectionWarmupPromiseRef,
+    selectionWarmupVideoIteratorRef,
+  ]);
+
+  const warmClipSelection = useCallback(async (
+    clipStart: number,
+    clipEnd: number,
+    options: WarmClipSelectionOptions = {},
+  ) => {
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    const extendToSelectionEnd = options.extendToSelectionEnd ?? true;
+    const videoSink = videoSinkRef.current;
+    const audioSink = audioSinkRef.current;
+    if (!videoSink && !audioSink) {
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
+    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      return;
+    }
+
+    const nextRange: PlaybackReadyRange = {
+      startTime: normalizedStart,
+      endTime: normalizedEnd,
+      readyUntilTime: normalizedStart,
+      status: "warming",
+    };
+    const currentReadyRange = playbackReadyRangeRef.current;
+    if (
+      samePlaybackRange(currentReadyRange, nextRange)
+      && currentReadyRange?.status === "ready"
+      && currentReadyRange.readyUntilTime >= normalizedEnd
+    ) {
+      return;
+    }
+
+    setPlaybackReadyRange((current) => {
+      if (samePlaybackRange(current, nextRange) && current) {
+        return {
+          ...current,
+          status: current.status === "ready" ? "ready" : "warming",
+        };
+      }
+
+      return nextRange;
+    });
+
+    await warmClipStart(normalizedStart);
+
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    cancelSelectionWarmup();
+    const warmupGeneration = selectionWarmupGenerationRef.current;
+    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
+    const initialReadyEnd = Math.min(normalizedEnd, normalizedStart + INITIAL_SELECTION_WARMUP_SECONDS);
+
+    let lastPublishedReadyUntil = normalizedStart;
+    let videoReadyUntil = normalizedStart;
+    let audioReadyUntil = normalizedStart;
+    let videoReachedSelectionEnd = !videoSink;
+    let audioReachedSelectionEnd = !audioSink;
+
+    const computeReadyUntil = () => {
+      const readyTimes = [
+        videoSink ? videoReadyUntil : null,
+        audioSink ? audioReadyUntil : null,
+      ].filter(isPresent);
+
+      return readyTimes.length > 0 ? Math.min(...readyTimes) : normalizedStart;
+    };
+
+    const publishReadyUntil = (
+      nextReadyUntil: number,
+      status: PlaybackReadyRange["status"],
+      force = false,
+    ) => {
+      const clampedReadyUntil = Math.max(
+        normalizedStart,
+        Math.min(normalizedEnd, Number(nextReadyUntil.toFixed(6))),
+      );
+
+      if (
+        !force
+        && clampedReadyUntil < normalizedEnd
+        && clampedReadyUntil - lastPublishedReadyUntil < 0.25
+      ) {
+        return;
+      }
+
+      lastPublishedReadyUntil = Math.max(lastPublishedReadyUntil, clampedReadyUntil);
+      setPlaybackReadyRange((current) => {
+        const baseRange: PlaybackReadyRange = samePlaybackRange(current, nextRange) && current
+          ? current
+          : {
+              ...nextRange,
+              status: "idle",
+            };
+        const readyUntilTime = Math.max(baseRange.readyUntilTime, clampedReadyUntil);
+
+        if (
+          baseRange.status === status
+          && Math.abs(baseRange.readyUntilTime - readyUntilTime) < 1e-6
+        ) {
+          return current ?? baseRange;
+        }
+
+        return {
+          startTime: normalizedStart,
+          endTime: normalizedEnd,
+          readyUntilTime,
+          status,
+        };
+      });
+    };
+
+    const selectionWarmupPromise = (async () => {
+      const isCancelled = () => (
+        warmupGeneration !== selectionWarmupGenerationRef.current
+        || playingRef.current
+        || activeSourceLabelRef.current !== "HLS stream"
+      );
+
+      const warmVideoRange = async (rangeStart: number, rangeEnd: number) => {
+        if (!videoSink || rangeEnd <= rangeStart) {
+          return true;
+        }
+
+        const iterator = videoSink.canvases(
+          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
+          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
+          packetRetrievalOptions,
+        );
+        selectionWarmupVideoIteratorRef.current = iterator;
+        let completedRange = false;
+
+        try {
+          for await (const frame of iterator) {
+            if (isCancelled()) {
+              break;
+            }
+
+            videoReadyUntil = Math.max(
+              videoReadyUntil,
+              clampTime(fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)),
+            );
+            publishReadyUntil(computeReadyUntil(), "warming");
+
+            if (videoReadyUntil >= rangeEnd) {
+              completedRange = true;
+              break;
+            }
+          }
+        } catch {
+          // Selection warmup is best-effort; playback still works without it.
+        } finally {
+          if (selectionWarmupVideoIteratorRef.current === iterator) {
+            selectionWarmupVideoIteratorRef.current = null;
+          }
+        }
+
+        if (!isCancelled() && !completedRange && rangeEnd - videoReadyUntil <= 0.5) {
+          completedRange = true;
+        }
+
+        if (!isCancelled() && completedRange) {
+          videoReadyUntil = Math.max(videoReadyUntil, rangeEnd);
+          if (rangeEnd >= normalizedEnd) {
+            videoReachedSelectionEnd = true;
+          }
+          publishReadyUntil(computeReadyUntil(), "warming", true);
+        }
+
+        return completedRange;
+      };
+
+      const warmAudioRange = async (rangeStart: number, rangeEnd: number) => {
+        if (!audioSink || rangeEnd <= rangeStart) {
+          return true;
+        }
+
+        const iterator = audioSink.buffers(
+          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
+          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
+          packetRetrievalOptions,
+        );
+        selectionWarmupAudioIteratorRef.current = iterator;
+        let completedRange = false;
+
+        try {
+          for await (const { buffer, timestamp } of iterator) {
+            if (isCancelled()) {
+              break;
+            }
+
+            audioReadyUntil = Math.max(
+              audioReadyUntil,
+              clampTime(
+                fromSourceTimelineTime(
+                  timestamp + buffer.duration,
+                  sourceTimelineOffsetRef.current,
+                ),
+              ),
+            );
+            publishReadyUntil(computeReadyUntil(), "warming");
+
+            if (audioReadyUntil >= rangeEnd) {
+              completedRange = true;
+              break;
+            }
+          }
+        } catch {
+          // Selection warmup is best-effort; playback still works without it.
+        } finally {
+          if (selectionWarmupAudioIteratorRef.current === iterator) {
+            selectionWarmupAudioIteratorRef.current = null;
+          }
+        }
+
+        if (!isCancelled() && !completedRange && rangeEnd - audioReadyUntil <= 0.05) {
+          completedRange = true;
+        }
+
+        if (!isCancelled() && completedRange) {
+          audioReadyUntil = Math.max(audioReadyUntil, rangeEnd);
+          if (rangeEnd >= normalizedEnd) {
+            audioReachedSelectionEnd = true;
+          }
+          publishReadyUntil(computeReadyUntil(), "warming", true);
+        }
+
+        return completedRange;
+      };
+
+      await Promise.allSettled([
+        warmVideoRange(normalizedStart, initialReadyEnd),
+        warmAudioRange(normalizedStart, initialReadyEnd),
+      ]);
+
+      if (!isCancelled() && extendToSelectionEnd && normalizedEnd > initialReadyEnd) {
+        await Promise.allSettled([
+          warmVideoRange(Math.max(videoReadyUntil, initialReadyEnd), normalizedEnd),
+          warmAudioRange(Math.max(audioReadyUntil, initialReadyEnd), normalizedEnd),
+        ]);
+      }
+
+      if (!isCancelled()) {
+        publishReadyUntil(
+          videoReachedSelectionEnd && audioReachedSelectionEnd
+            ? normalizedEnd
+            : computeReadyUntil(),
+          videoReachedSelectionEnd && audioReachedSelectionEnd ? "ready" : "idle",
+          true,
+        );
+      }
+    })();
+
+    selectionWarmupPromiseRef.current = selectionWarmupPromise;
+    try {
+      await selectionWarmupPromise;
+    } finally {
+      if (selectionWarmupPromiseRef.current === selectionWarmupPromise) {
+        selectionWarmupPromiseRef.current = null;
+      }
+    }
+  }, [
+    activeSourceLabelRef,
+    audioSinkRef,
+    cancelSelectionWarmup,
+    clampTime,
+    loadingPreview,
+    playbackReadyRangeRef,
+    playingRef,
+    selectionWarmupAudioIteratorRef,
+    selectionWarmupGenerationRef,
+    selectionWarmupPromiseRef,
+    selectionWarmupVideoIteratorRef,
+    setPlaybackReadyRange,
+    skipLiveWaitRef,
+    sourceTimelineOffsetRef,
+    videoSinkRef,
+    warmClipStart,
+  ]);
+
+  const scheduleSelectionWarmupExtension = useCallback((clipStart: number, clipEnd: number) => {
+    cancelScheduledSelectionWarmupExtension();
+
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
+    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      return;
+    }
+
+    selectionWarmupExtensionTimeoutRef.current = window.setTimeout(() => {
+      selectionWarmupExtensionTimeoutRef.current = null;
+
+      if (
+        loadingPreview
+        || playingRef.current
+        || activeSourceLabelRef.current !== "HLS stream"
+      ) {
+        return;
+      }
+
+      void warmClipSelection(normalizedStart, normalizedEnd);
+    }, SEEK_SELECTION_EXTENSION_DELAY_MS);
+  }, [
+    activeSourceLabelRef,
+    cancelScheduledSelectionWarmupExtension,
+    clampTime,
+    loadingPreview,
+    playingRef,
+    selectionWarmupExtensionTimeoutRef,
+    warmClipSelection,
+  ]);
+
+  useEffect(() => {
+    if (loadingPreview || activeSourceLabel !== "HLS stream") {
+      autoWarmupSessionKeyRef.current = null;
+      setPlaybackReadyRange(null);
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(startTime).toFixed(6));
+    const normalizedEnd = Number(clampTime(endTime).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      setPlaybackReadyRange(null);
+      return;
+    }
+
+    const nextRange: PlaybackReadyRange = {
+      startTime: normalizedStart,
+      endTime: normalizedEnd,
+      readyUntilTime: normalizedStart,
+      status: "idle",
+    };
+
+    setPlaybackReadyRange((current) => (
+      samePlaybackRange(current, nextRange) ? current : nextRange
+    ));
+
+    const warmupSessionKey = `${sessionId}:hls:${normalizedStart}:${normalizedEnd}`;
+    if (autoWarmupSessionKeyRef.current === warmupSessionKey) {
+      return;
+    }
+
+    autoWarmupSessionKeyRef.current = warmupSessionKey;
+    void warmClipSelection(startTimeRef.current, endTimeRef.current, {
+      extendToSelectionEnd: false,
+    });
+    scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
+  }, [
+    activeSourceLabel,
+    autoWarmupSessionKeyRef,
+    clampTime,
+    endTime,
+    endTimeRef,
+    loadingPreview,
+    scheduleSelectionWarmupExtension,
+    sessionId,
+    setPlaybackReadyRange,
+    startTime,
+    startTimeRef,
+    warmClipSelection,
+  ]);
+
+  useEffect(() => {
+    if (
+      wasPlayingRef.current
+      && !playing
+      && !loadingPreview
+      && activeSourceLabel === "HLS stream"
+    ) {
+      const currentReadyRange = playbackReadyRangeRef.current;
+      if (currentReadyRange && currentReadyRange.status !== "ready") {
+        const selectionStart = clampTime(startTimeRef.current);
+        if (selectionStart < endTimeRef.current) {
+          void warmClipSelection(selectionStart, endTimeRef.current, {
+            extendToSelectionEnd: false,
+          });
+          scheduleSelectionWarmupExtension(selectionStart, endTimeRef.current);
+        }
+      }
+    }
+
+    wasPlayingRef.current = playing;
+  }, [
+    activeSourceLabel,
+    clampTime,
+    currentTime,
+    endTimeRef,
+    loadingPreview,
+    playbackReadyRangeRef,
+    playing,
+    scheduleSelectionWarmupExtension,
+    startTimeRef,
+    warmClipSelection,
+    wasPlayingRef,
+  ]);
+
+  useEffect(() => {
+    if (!playing || activeSourceLabel !== "HLS stream") {
+      return;
+    }
+
+    const normalizedCurrent = Number(clampTime(currentTime).toFixed(6));
+    setPlaybackReadyRange((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const readyUntilTime = Math.max(
+        current.readyUntilTime,
+        Math.min(current.endTime, normalizedCurrent),
+      );
+      const status = readyUntilTime >= current.endTime ? "ready" : "warming";
+
+      if (
+        current.status === status
+        && Math.abs(current.readyUntilTime - readyUntilTime) < 1e-6
+      ) {
+        return current;
+      }
+
+      return {
+        ...current,
+        readyUntilTime,
+        status,
+      };
+    });
+  }, [activeSourceLabel, clampTime, currentTime, playing, setPlaybackReadyRange]);
+
+  return {
+    cancelSelectionWarmup,
+    warmClipSelection,
+    scheduleSelectionWarmupExtension,
+  };
+}
+
+function samePlaybackRange(
+  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
+  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
+) {
+  return (
+    left !== null
+    && left !== undefined
+    && Math.abs(left.startTime - right.startTime) < 1e-6
+    && Math.abs(left.endTime - right.endTime) < 1e-6
+  );
+}

--- a/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
@@ -1,0 +1,662 @@
+import { useCallback, useEffect, type Dispatch, type SetStateAction } from "react";
+import type {
+  AudioBufferSink,
+  CanvasSink,
+  WrappedAudioBuffer,
+  WrappedCanvas,
+} from "mediabunny";
+import {
+  fromSourceTimelineTime,
+  toSourceTimelineTime,
+} from "../../lib/mediabunnyTrackAccess";
+import { isPresent } from "./editorPlaybackSources";
+
+type RefValue<T> = {
+  current: T;
+};
+
+export interface PlaybackReadyRange {
+  startTime: number;
+  endTime: number;
+  readyUntilTime: number;
+  status: "idle" | "warming" | "ready";
+}
+
+interface WarmClipSelectionOptions {
+  extendToSelectionEnd?: boolean;
+}
+
+interface UseEditorPlaybackWarmupOptions {
+  loadingPreview: boolean;
+  activeSourceLabel: string;
+  playing: boolean;
+  currentTime: number;
+  startTime: number;
+  endTime: number;
+  sessionId: string;
+  videoSinkRef: RefValue<CanvasSink | null>;
+  audioSinkRef: RefValue<AudioBufferSink | null>;
+  generationRef: RefValue<number>;
+  warmupGenerationRef: RefValue<number>;
+  warmupPromiseRef: RefValue<Promise<void> | null>;
+  warmupTargetTimeRef: RefValue<number | null>;
+  selectionWarmupGenerationRef: RefValue<number>;
+  selectionWarmupPromiseRef: RefValue<Promise<void> | null>;
+  selectionWarmupVideoIteratorRef: RefValue<AsyncGenerator<WrappedCanvas, void, unknown> | null>;
+  selectionWarmupAudioIteratorRef: RefValue<AsyncGenerator<WrappedAudioBuffer, void, unknown> | null>;
+  selectionWarmupExtensionTimeoutRef: RefValue<number | null>;
+  autoWarmupSessionKeyRef: RefValue<string | null>;
+  wasPlayingRef: RefValue<boolean>;
+  playingRef: RefValue<boolean>;
+  activeSourceLabelRef: RefValue<string>;
+  playbackReadyRangeRef: RefValue<PlaybackReadyRange | null>;
+  sourceTimelineOffsetRef: RefValue<number>;
+  skipLiveWaitRef: RefValue<boolean>;
+  startTimeRef: RefValue<number>;
+  endTimeRef: RefValue<number>;
+  clampTime: (seconds: number) => number;
+  setPlaybackReadyRange: Dispatch<SetStateAction<PlaybackReadyRange | null>>;
+}
+
+const INITIAL_SELECTION_WARMUP_SECONDS = 8;
+const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
+
+export function useEditorPlaybackWarmup({
+  loadingPreview,
+  activeSourceLabel,
+  playing,
+  currentTime,
+  startTime,
+  endTime,
+  sessionId,
+  videoSinkRef,
+  audioSinkRef,
+  generationRef,
+  warmupGenerationRef,
+  warmupPromiseRef,
+  warmupTargetTimeRef,
+  selectionWarmupGenerationRef,
+  selectionWarmupPromiseRef,
+  selectionWarmupVideoIteratorRef,
+  selectionWarmupAudioIteratorRef,
+  selectionWarmupExtensionTimeoutRef,
+  autoWarmupSessionKeyRef,
+  wasPlayingRef,
+  playingRef,
+  activeSourceLabelRef,
+  playbackReadyRangeRef,
+  sourceTimelineOffsetRef,
+  skipLiveWaitRef,
+  startTimeRef,
+  endTimeRef,
+  clampTime,
+  setPlaybackReadyRange,
+}: UseEditorPlaybackWarmupOptions) {
+  const cancelScheduledSelectionWarmupExtension = useCallback(() => {
+    if (selectionWarmupExtensionTimeoutRef.current !== null) {
+      window.clearTimeout(selectionWarmupExtensionTimeoutRef.current);
+      selectionWarmupExtensionTimeoutRef.current = null;
+    }
+  }, [selectionWarmupExtensionTimeoutRef]);
+
+  const cancelSelectionWarmup = useCallback(() => {
+    cancelScheduledSelectionWarmupExtension();
+    selectionWarmupGenerationRef.current++;
+    selectionWarmupPromiseRef.current = null;
+    void selectionWarmupVideoIteratorRef.current?.return();
+    void selectionWarmupAudioIteratorRef.current?.return();
+    selectionWarmupVideoIteratorRef.current = null;
+    selectionWarmupAudioIteratorRef.current = null;
+  }, [
+    cancelScheduledSelectionWarmupExtension,
+    selectionWarmupAudioIteratorRef,
+    selectionWarmupGenerationRef,
+    selectionWarmupPromiseRef,
+    selectionWarmupVideoIteratorRef,
+  ]);
+
+  const warmClipStart = useCallback(async (clipStart: number) => {
+    if (
+      loadingPreview ||
+      playingRef.current ||
+      activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    const videoSink = videoSinkRef.current;
+    const audioSink = audioSinkRef.current;
+    if (!videoSink && !audioSink) {
+      return;
+    }
+
+    const displayTimestamp = Number(clampTime(clipStart).toFixed(6));
+    if (!Number.isFinite(displayTimestamp)) {
+      return;
+    }
+    if (
+      warmupPromiseRef.current
+      && warmupTargetTimeRef.current !== null
+      && Math.abs(warmupTargetTimeRef.current - displayTimestamp) < 1e-6
+    ) {
+      return warmupPromiseRef.current;
+    }
+
+    const sourceTimestamp = toSourceTimelineTime(displayTimestamp, sourceTimelineOffsetRef.current);
+    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
+    const warmupGeneration = ++warmupGenerationRef.current;
+    const playbackGeneration = generationRef.current;
+    warmupTargetTimeRef.current = displayTimestamp;
+
+    const warmupPromise = (async () => {
+      if (
+        warmupGeneration !== warmupGenerationRef.current ||
+        playbackGeneration !== generationRef.current ||
+        playingRef.current
+      ) {
+        return;
+      }
+
+      try {
+        await Promise.allSettled([
+          videoSink ? videoSink.getCanvas(sourceTimestamp, packetRetrievalOptions) : Promise.resolve(null),
+          audioSink ? audioSink.getBuffer(sourceTimestamp, packetRetrievalOptions) : Promise.resolve(null),
+        ]);
+      } catch {
+        // Warmup is opportunistic; playback still works without it.
+      }
+    })();
+
+    warmupPromiseRef.current = warmupPromise;
+    try {
+      await warmupPromise;
+    } finally {
+      if (warmupPromiseRef.current === warmupPromise) {
+        warmupPromiseRef.current = null;
+        warmupTargetTimeRef.current = null;
+      }
+    }
+  }, [
+    activeSourceLabelRef,
+    audioSinkRef,
+    clampTime,
+    generationRef,
+    loadingPreview,
+    playingRef,
+    skipLiveWaitRef,
+    sourceTimelineOffsetRef,
+    videoSinkRef,
+    warmupGenerationRef,
+    warmupPromiseRef,
+    warmupTargetTimeRef,
+  ]);
+
+  const warmClipSelection = useCallback(async (
+    clipStart: number,
+    clipEnd: number,
+    options: WarmClipSelectionOptions = {},
+  ) => {
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    const extendToSelectionEnd = options.extendToSelectionEnd ?? true;
+    const videoSink = videoSinkRef.current;
+    const audioSink = audioSinkRef.current;
+    if (!videoSink && !audioSink) {
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
+    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      return;
+    }
+
+    const nextRange: PlaybackReadyRange = {
+      startTime: normalizedStart,
+      endTime: normalizedEnd,
+      readyUntilTime: normalizedStart,
+      status: "warming",
+    };
+    const currentReadyRange = playbackReadyRangeRef.current;
+    if (
+      samePlaybackRange(currentReadyRange, nextRange)
+      && currentReadyRange?.status === "ready"
+      && currentReadyRange.readyUntilTime >= normalizedEnd
+    ) {
+      return;
+    }
+
+    setPlaybackReadyRange((current) => {
+      if (samePlaybackRange(current, nextRange) && current) {
+        return {
+          ...current,
+          status: current.status === "ready" ? "ready" : "warming",
+        };
+      }
+
+      return nextRange;
+    });
+
+    await warmClipStart(normalizedStart);
+
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    cancelSelectionWarmup();
+    const warmupGeneration = selectionWarmupGenerationRef.current;
+    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
+    const initialReadyEnd = Math.min(normalizedEnd, normalizedStart + INITIAL_SELECTION_WARMUP_SECONDS);
+
+    let lastPublishedReadyUntil = normalizedStart;
+    let videoReadyUntil = normalizedStart;
+    let audioReadyUntil = normalizedStart;
+    let videoReachedSelectionEnd = !videoSink;
+    let audioReachedSelectionEnd = !audioSink;
+
+    const computeReadyUntil = () => {
+      const readyTimes = [
+        videoSink ? videoReadyUntil : null,
+        audioSink ? audioReadyUntil : null,
+      ].filter(isPresent);
+
+      return readyTimes.length > 0 ? Math.min(...readyTimes) : normalizedStart;
+    };
+
+    const publishReadyUntil = (
+      nextReadyUntil: number,
+      status: PlaybackReadyRange["status"],
+      force = false,
+    ) => {
+      const clampedReadyUntil = Math.max(
+        normalizedStart,
+        Math.min(normalizedEnd, Number(nextReadyUntil.toFixed(6))),
+      );
+
+      if (
+        !force
+        && clampedReadyUntil < normalizedEnd
+        && clampedReadyUntil - lastPublishedReadyUntil < 0.25
+      ) {
+        return;
+      }
+
+      lastPublishedReadyUntil = Math.max(lastPublishedReadyUntil, clampedReadyUntil);
+      setPlaybackReadyRange((current) => {
+        const baseRange: PlaybackReadyRange = samePlaybackRange(current, nextRange) && current
+          ? current
+          : {
+              ...nextRange,
+              status: "idle",
+            };
+        const readyUntilTime = Math.max(baseRange.readyUntilTime, clampedReadyUntil);
+
+        if (
+          baseRange.status === status
+          && Math.abs(baseRange.readyUntilTime - readyUntilTime) < 1e-6
+        ) {
+          return current ?? baseRange;
+        }
+
+        return {
+          startTime: normalizedStart,
+          endTime: normalizedEnd,
+          readyUntilTime,
+          status,
+        };
+      });
+    };
+
+    const selectionWarmupPromise = (async () => {
+      const isCancelled = () => (
+        warmupGeneration !== selectionWarmupGenerationRef.current
+        || playingRef.current
+        || activeSourceLabelRef.current !== "HLS stream"
+      );
+
+      const warmVideoRange = async (rangeStart: number, rangeEnd: number) => {
+        if (!videoSink || rangeEnd <= rangeStart) {
+          return true;
+        }
+
+        const iterator = videoSink.canvases(
+          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
+          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
+          packetRetrievalOptions,
+        );
+        selectionWarmupVideoIteratorRef.current = iterator;
+        let completedRange = false;
+
+        try {
+          for await (const frame of iterator) {
+            if (isCancelled()) {
+              break;
+            }
+
+            videoReadyUntil = Math.max(
+              videoReadyUntil,
+              clampTime(fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)),
+            );
+            publishReadyUntil(computeReadyUntil(), "warming");
+
+            if (videoReadyUntil >= rangeEnd) {
+              completedRange = true;
+              break;
+            }
+          }
+        } catch {
+          // Selection warmup is best-effort; playback still works without it.
+        } finally {
+          if (selectionWarmupVideoIteratorRef.current === iterator) {
+            selectionWarmupVideoIteratorRef.current = null;
+          }
+        }
+
+        if (!isCancelled() && !completedRange && rangeEnd - videoReadyUntil <= 0.5) {
+          completedRange = true;
+        }
+
+        if (!isCancelled() && completedRange) {
+          videoReadyUntil = Math.max(videoReadyUntil, rangeEnd);
+          if (rangeEnd >= normalizedEnd) {
+            videoReachedSelectionEnd = true;
+          }
+          publishReadyUntil(computeReadyUntil(), "warming", true);
+        }
+
+        return completedRange;
+      };
+
+      const warmAudioRange = async (rangeStart: number, rangeEnd: number) => {
+        if (!audioSink || rangeEnd <= rangeStart) {
+          return true;
+        }
+
+        const iterator = audioSink.buffers(
+          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
+          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
+          packetRetrievalOptions,
+        );
+        selectionWarmupAudioIteratorRef.current = iterator;
+        let completedRange = false;
+
+        try {
+          for await (const { buffer, timestamp } of iterator) {
+            if (isCancelled()) {
+              break;
+            }
+
+            audioReadyUntil = Math.max(
+              audioReadyUntil,
+              clampTime(
+                fromSourceTimelineTime(
+                  timestamp + buffer.duration,
+                  sourceTimelineOffsetRef.current,
+                ),
+              ),
+            );
+            publishReadyUntil(computeReadyUntil(), "warming");
+
+            if (audioReadyUntil >= rangeEnd) {
+              completedRange = true;
+              break;
+            }
+          }
+        } catch {
+          // Selection warmup is best-effort; playback still works without it.
+        } finally {
+          if (selectionWarmupAudioIteratorRef.current === iterator) {
+            selectionWarmupAudioIteratorRef.current = null;
+          }
+        }
+
+        if (!isCancelled() && !completedRange && rangeEnd - audioReadyUntil <= 0.05) {
+          completedRange = true;
+        }
+
+        if (!isCancelled() && completedRange) {
+          audioReadyUntil = Math.max(audioReadyUntil, rangeEnd);
+          if (rangeEnd >= normalizedEnd) {
+            audioReachedSelectionEnd = true;
+          }
+          publishReadyUntil(computeReadyUntil(), "warming", true);
+        }
+
+        return completedRange;
+      };
+
+      await Promise.allSettled([
+        warmVideoRange(normalizedStart, initialReadyEnd),
+        warmAudioRange(normalizedStart, initialReadyEnd),
+      ]);
+
+      if (!isCancelled() && extendToSelectionEnd && normalizedEnd > initialReadyEnd) {
+        await Promise.allSettled([
+          warmVideoRange(Math.max(videoReadyUntil, initialReadyEnd), normalizedEnd),
+          warmAudioRange(Math.max(audioReadyUntil, initialReadyEnd), normalizedEnd),
+        ]);
+      }
+
+      if (!isCancelled()) {
+        publishReadyUntil(
+          videoReachedSelectionEnd && audioReachedSelectionEnd
+            ? normalizedEnd
+            : computeReadyUntil(),
+          videoReachedSelectionEnd && audioReachedSelectionEnd ? "ready" : "idle",
+          true,
+        );
+      }
+    })();
+
+    selectionWarmupPromiseRef.current = selectionWarmupPromise;
+    try {
+      await selectionWarmupPromise;
+    } finally {
+      if (selectionWarmupPromiseRef.current === selectionWarmupPromise) {
+        selectionWarmupPromiseRef.current = null;
+      }
+    }
+  }, [
+    activeSourceLabelRef,
+    audioSinkRef,
+    cancelSelectionWarmup,
+    clampTime,
+    loadingPreview,
+    playbackReadyRangeRef,
+    playingRef,
+    selectionWarmupAudioIteratorRef,
+    selectionWarmupGenerationRef,
+    selectionWarmupPromiseRef,
+    selectionWarmupVideoIteratorRef,
+    setPlaybackReadyRange,
+    skipLiveWaitRef,
+    sourceTimelineOffsetRef,
+    videoSinkRef,
+    warmClipStart,
+  ]);
+
+  const scheduleSelectionWarmupExtension = useCallback((clipStart: number, clipEnd: number) => {
+    cancelScheduledSelectionWarmupExtension();
+
+    if (
+      loadingPreview
+      || playingRef.current
+      || activeSourceLabelRef.current !== "HLS stream"
+    ) {
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
+    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      return;
+    }
+
+    selectionWarmupExtensionTimeoutRef.current = window.setTimeout(() => {
+      selectionWarmupExtensionTimeoutRef.current = null;
+
+      if (
+        loadingPreview
+        || playingRef.current
+        || activeSourceLabelRef.current !== "HLS stream"
+      ) {
+        return;
+      }
+
+      void warmClipSelection(normalizedStart, normalizedEnd);
+    }, SEEK_SELECTION_EXTENSION_DELAY_MS);
+  }, [
+    activeSourceLabelRef,
+    cancelScheduledSelectionWarmupExtension,
+    clampTime,
+    loadingPreview,
+    playingRef,
+    selectionWarmupExtensionTimeoutRef,
+    warmClipSelection,
+  ]);
+
+  useEffect(() => {
+    if (loadingPreview || activeSourceLabel !== "HLS stream") {
+      autoWarmupSessionKeyRef.current = null;
+      setPlaybackReadyRange(null);
+      return;
+    }
+
+    const normalizedStart = Number(clampTime(startTime).toFixed(6));
+    const normalizedEnd = Number(clampTime(endTime).toFixed(6));
+    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
+      setPlaybackReadyRange(null);
+      return;
+    }
+
+    const nextRange: PlaybackReadyRange = {
+      startTime: normalizedStart,
+      endTime: normalizedEnd,
+      readyUntilTime: normalizedStart,
+      status: "idle",
+    };
+
+    setPlaybackReadyRange((current) => (
+      samePlaybackRange(current, nextRange) ? current : nextRange
+    ));
+
+    const warmupSessionKey = `${sessionId}:hls:${normalizedStart}:${normalizedEnd}`;
+    if (autoWarmupSessionKeyRef.current === warmupSessionKey) {
+      return;
+    }
+
+    autoWarmupSessionKeyRef.current = warmupSessionKey;
+    void warmClipSelection(startTimeRef.current, endTimeRef.current, {
+      extendToSelectionEnd: false,
+    });
+    scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
+  }, [
+    activeSourceLabel,
+    autoWarmupSessionKeyRef,
+    clampTime,
+    endTime,
+    endTimeRef,
+    loadingPreview,
+    scheduleSelectionWarmupExtension,
+    sessionId,
+    setPlaybackReadyRange,
+    startTime,
+    startTimeRef,
+    warmClipSelection,
+  ]);
+
+  useEffect(() => {
+    if (
+      wasPlayingRef.current
+      && !playing
+      && !loadingPreview
+      && activeSourceLabel === "HLS stream"
+    ) {
+      const currentReadyRange = playbackReadyRangeRef.current;
+      if (currentReadyRange && currentReadyRange.status !== "ready") {
+        const selectionStart = clampTime(startTimeRef.current);
+        if (selectionStart < endTimeRef.current) {
+          void warmClipSelection(selectionStart, endTimeRef.current, {
+            extendToSelectionEnd: false,
+          });
+          scheduleSelectionWarmupExtension(selectionStart, endTimeRef.current);
+        }
+      }
+    }
+
+    wasPlayingRef.current = playing;
+  }, [
+    activeSourceLabel,
+    clampTime,
+    currentTime,
+    endTimeRef,
+    loadingPreview,
+    playbackReadyRangeRef,
+    playing,
+    scheduleSelectionWarmupExtension,
+    startTimeRef,
+    warmClipSelection,
+    wasPlayingRef,
+  ]);
+
+  useEffect(() => {
+    if (!playing || activeSourceLabel !== "HLS stream") {
+      return;
+    }
+
+    const normalizedCurrent = Number(clampTime(currentTime).toFixed(6));
+    setPlaybackReadyRange((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const readyUntilTime = Math.max(
+        current.readyUntilTime,
+        Math.min(current.endTime, normalizedCurrent),
+      );
+      const status = readyUntilTime >= current.endTime ? "ready" : "warming";
+
+      if (
+        current.status === status
+        && Math.abs(current.readyUntilTime - readyUntilTime) < 1e-6
+      ) {
+        return current;
+      }
+
+      return {
+        ...current,
+        readyUntilTime,
+        status,
+      };
+    });
+  }, [activeSourceLabel, clampTime, currentTime, playing, setPlaybackReadyRange]);
+
+  return {
+    cancelSelectionWarmup,
+    warmClipStart,
+    warmClipSelection,
+    scheduleSelectionWarmupExtension,
+  };
+}
+
+function samePlaybackRange(
+  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
+  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
+) {
+  return (
+    left !== null
+    && left !== undefined
+    && Math.abs(left.startTime - right.startTime) < 1e-6
+    && Math.abs(left.endTime - right.endTime) < 1e-6
+  );
+}

--- a/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
@@ -1,30 +1,10 @@
-import { useCallback, useEffect, type Dispatch, type SetStateAction } from "react";
-import type {
-  AudioBufferSink,
-  CanvasSink,
-  WrappedAudioBuffer,
-  WrappedCanvas,
-} from "mediabunny";
-import {
-  fromSourceTimelineTime,
-  toSourceTimelineTime,
-} from "../../lib/mediabunnyTrackAccess";
-import { isPresent } from "./editorPlaybackSources";
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import type { AudioBufferSink, CanvasSink, WrappedAudioBuffer, WrappedCanvas } from "mediabunny";
+import { toSourceTimelineTime } from "../../lib/mediabunnyTrackAccess";
+import { useEditorPlaybackSelectionWarmup } from "./useEditorPlaybackSelectionWarmup";
+import type { PlaybackReadyRange, RefValue } from "./editorPlaybackWarmupTypes";
 
-type RefValue<T> = {
-  current: T;
-};
-
-export interface PlaybackReadyRange {
-  startTime: number;
-  endTime: number;
-  readyUntilTime: number;
-  status: "idle" | "warming" | "ready";
-}
-
-interface WarmClipSelectionOptions {
-  extendToSelectionEnd?: boolean;
-}
+export type { PlaybackReadyRange } from "./editorPlaybackWarmupTypes";
 
 interface UseEditorPlaybackWarmupOptions {
   loadingPreview: boolean;
@@ -58,9 +38,6 @@ interface UseEditorPlaybackWarmupOptions {
   setPlaybackReadyRange: Dispatch<SetStateAction<PlaybackReadyRange | null>>;
 }
 
-const INITIAL_SELECTION_WARMUP_SECONDS = 8;
-const SEEK_SELECTION_EXTENSION_DELAY_MS = 900;
-
 export function useEditorPlaybackWarmup({
   loadingPreview,
   activeSourceLabel,
@@ -92,29 +69,6 @@ export function useEditorPlaybackWarmup({
   clampTime,
   setPlaybackReadyRange,
 }: UseEditorPlaybackWarmupOptions) {
-  const cancelScheduledSelectionWarmupExtension = useCallback(() => {
-    if (selectionWarmupExtensionTimeoutRef.current !== null) {
-      window.clearTimeout(selectionWarmupExtensionTimeoutRef.current);
-      selectionWarmupExtensionTimeoutRef.current = null;
-    }
-  }, [selectionWarmupExtensionTimeoutRef]);
-
-  const cancelSelectionWarmup = useCallback(() => {
-    cancelScheduledSelectionWarmupExtension();
-    selectionWarmupGenerationRef.current++;
-    selectionWarmupPromiseRef.current = null;
-    void selectionWarmupVideoIteratorRef.current?.return();
-    void selectionWarmupAudioIteratorRef.current?.return();
-    selectionWarmupVideoIteratorRef.current = null;
-    selectionWarmupAudioIteratorRef.current = null;
-  }, [
-    cancelScheduledSelectionWarmupExtension,
-    selectionWarmupAudioIteratorRef,
-    selectionWarmupGenerationRef,
-    selectionWarmupPromiseRef,
-    selectionWarmupVideoIteratorRef,
-  ]);
-
   const warmClipStart = useCallback(async (clipStart: number) => {
     if (
       loadingPreview ||
@@ -191,455 +145,38 @@ export function useEditorPlaybackWarmup({
     warmupTargetTimeRef,
   ]);
 
-  const warmClipSelection = useCallback(async (
-    clipStart: number,
-    clipEnd: number,
-    options: WarmClipSelectionOptions = {},
-  ) => {
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    const extendToSelectionEnd = options.extendToSelectionEnd ?? true;
-    const videoSink = videoSinkRef.current;
-    const audioSink = audioSinkRef.current;
-    if (!videoSink && !audioSink) {
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
-    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      return;
-    }
-
-    const nextRange: PlaybackReadyRange = {
-      startTime: normalizedStart,
-      endTime: normalizedEnd,
-      readyUntilTime: normalizedStart,
-      status: "warming",
-    };
-    const currentReadyRange = playbackReadyRangeRef.current;
-    if (
-      samePlaybackRange(currentReadyRange, nextRange)
-      && currentReadyRange?.status === "ready"
-      && currentReadyRange.readyUntilTime >= normalizedEnd
-    ) {
-      return;
-    }
-
-    setPlaybackReadyRange((current) => {
-      if (samePlaybackRange(current, nextRange) && current) {
-        return {
-          ...current,
-          status: current.status === "ready" ? "ready" : "warming",
-        };
-      }
-
-      return nextRange;
-    });
-
-    await warmClipStart(normalizedStart);
-
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    cancelSelectionWarmup();
-    const warmupGeneration = selectionWarmupGenerationRef.current;
-    const packetRetrievalOptions = skipLiveWaitRef.current ? { skipLiveWait: true } : undefined;
-    const initialReadyEnd = Math.min(normalizedEnd, normalizedStart + INITIAL_SELECTION_WARMUP_SECONDS);
-
-    let lastPublishedReadyUntil = normalizedStart;
-    let videoReadyUntil = normalizedStart;
-    let audioReadyUntil = normalizedStart;
-    let videoReachedSelectionEnd = !videoSink;
-    let audioReachedSelectionEnd = !audioSink;
-
-    const computeReadyUntil = () => {
-      const readyTimes = [
-        videoSink ? videoReadyUntil : null,
-        audioSink ? audioReadyUntil : null,
-      ].filter(isPresent);
-
-      return readyTimes.length > 0 ? Math.min(...readyTimes) : normalizedStart;
-    };
-
-    const publishReadyUntil = (
-      nextReadyUntil: number,
-      status: PlaybackReadyRange["status"],
-      force = false,
-    ) => {
-      const clampedReadyUntil = Math.max(
-        normalizedStart,
-        Math.min(normalizedEnd, Number(nextReadyUntil.toFixed(6))),
-      );
-
-      if (
-        !force
-        && clampedReadyUntil < normalizedEnd
-        && clampedReadyUntil - lastPublishedReadyUntil < 0.25
-      ) {
-        return;
-      }
-
-      lastPublishedReadyUntil = Math.max(lastPublishedReadyUntil, clampedReadyUntil);
-      setPlaybackReadyRange((current) => {
-        const baseRange: PlaybackReadyRange = samePlaybackRange(current, nextRange) && current
-          ? current
-          : {
-              ...nextRange,
-              status: "idle",
-            };
-        const readyUntilTime = Math.max(baseRange.readyUntilTime, clampedReadyUntil);
-
-        if (
-          baseRange.status === status
-          && Math.abs(baseRange.readyUntilTime - readyUntilTime) < 1e-6
-        ) {
-          return current ?? baseRange;
-        }
-
-        return {
-          startTime: normalizedStart,
-          endTime: normalizedEnd,
-          readyUntilTime,
-          status,
-        };
-      });
-    };
-
-    const selectionWarmupPromise = (async () => {
-      const isCancelled = () => (
-        warmupGeneration !== selectionWarmupGenerationRef.current
-        || playingRef.current
-        || activeSourceLabelRef.current !== "HLS stream"
-      );
-
-      const warmVideoRange = async (rangeStart: number, rangeEnd: number) => {
-        if (!videoSink || rangeEnd <= rangeStart) {
-          return true;
-        }
-
-        const iterator = videoSink.canvases(
-          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
-          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
-          packetRetrievalOptions,
-        );
-        selectionWarmupVideoIteratorRef.current = iterator;
-        let completedRange = false;
-
-        try {
-          for await (const frame of iterator) {
-            if (isCancelled()) {
-              break;
-            }
-
-            videoReadyUntil = Math.max(
-              videoReadyUntil,
-              clampTime(fromSourceTimelineTime(frame.timestamp, sourceTimelineOffsetRef.current)),
-            );
-            publishReadyUntil(computeReadyUntil(), "warming");
-
-            if (videoReadyUntil >= rangeEnd) {
-              completedRange = true;
-              break;
-            }
-          }
-        } catch {
-          // Selection warmup is best-effort; playback still works without it.
-        } finally {
-          if (selectionWarmupVideoIteratorRef.current === iterator) {
-            selectionWarmupVideoIteratorRef.current = null;
-          }
-        }
-
-        if (!isCancelled() && !completedRange && rangeEnd - videoReadyUntil <= 0.5) {
-          completedRange = true;
-        }
-
-        if (!isCancelled() && completedRange) {
-          videoReadyUntil = Math.max(videoReadyUntil, rangeEnd);
-          if (rangeEnd >= normalizedEnd) {
-            videoReachedSelectionEnd = true;
-          }
-          publishReadyUntil(computeReadyUntil(), "warming", true);
-        }
-
-        return completedRange;
-      };
-
-      const warmAudioRange = async (rangeStart: number, rangeEnd: number) => {
-        if (!audioSink || rangeEnd <= rangeStart) {
-          return true;
-        }
-
-        const iterator = audioSink.buffers(
-          toSourceTimelineTime(rangeStart, sourceTimelineOffsetRef.current),
-          toSourceTimelineTime(rangeEnd, sourceTimelineOffsetRef.current),
-          packetRetrievalOptions,
-        );
-        selectionWarmupAudioIteratorRef.current = iterator;
-        let completedRange = false;
-
-        try {
-          for await (const { buffer, timestamp } of iterator) {
-            if (isCancelled()) {
-              break;
-            }
-
-            audioReadyUntil = Math.max(
-              audioReadyUntil,
-              clampTime(
-                fromSourceTimelineTime(
-                  timestamp + buffer.duration,
-                  sourceTimelineOffsetRef.current,
-                ),
-              ),
-            );
-            publishReadyUntil(computeReadyUntil(), "warming");
-
-            if (audioReadyUntil >= rangeEnd) {
-              completedRange = true;
-              break;
-            }
-          }
-        } catch {
-          // Selection warmup is best-effort; playback still works without it.
-        } finally {
-          if (selectionWarmupAudioIteratorRef.current === iterator) {
-            selectionWarmupAudioIteratorRef.current = null;
-          }
-        }
-
-        if (!isCancelled() && !completedRange && rangeEnd - audioReadyUntil <= 0.05) {
-          completedRange = true;
-        }
-
-        if (!isCancelled() && completedRange) {
-          audioReadyUntil = Math.max(audioReadyUntil, rangeEnd);
-          if (rangeEnd >= normalizedEnd) {
-            audioReachedSelectionEnd = true;
-          }
-          publishReadyUntil(computeReadyUntil(), "warming", true);
-        }
-
-        return completedRange;
-      };
-
-      await Promise.allSettled([
-        warmVideoRange(normalizedStart, initialReadyEnd),
-        warmAudioRange(normalizedStart, initialReadyEnd),
-      ]);
-
-      if (!isCancelled() && extendToSelectionEnd && normalizedEnd > initialReadyEnd) {
-        await Promise.allSettled([
-          warmVideoRange(Math.max(videoReadyUntil, initialReadyEnd), normalizedEnd),
-          warmAudioRange(Math.max(audioReadyUntil, initialReadyEnd), normalizedEnd),
-        ]);
-      }
-
-      if (!isCancelled()) {
-        publishReadyUntil(
-          videoReachedSelectionEnd && audioReachedSelectionEnd
-            ? normalizedEnd
-            : computeReadyUntil(),
-          videoReachedSelectionEnd && audioReachedSelectionEnd ? "ready" : "idle",
-          true,
-        );
-      }
-    })();
-
-    selectionWarmupPromiseRef.current = selectionWarmupPromise;
-    try {
-      await selectionWarmupPromise;
-    } finally {
-      if (selectionWarmupPromiseRef.current === selectionWarmupPromise) {
-        selectionWarmupPromiseRef.current = null;
-      }
-    }
-  }, [
-    activeSourceLabelRef,
-    audioSinkRef,
+  const {
     cancelSelectionWarmup,
-    clampTime,
+    warmClipSelection,
+    scheduleSelectionWarmupExtension,
+  } = useEditorPlaybackSelectionWarmup({
     loadingPreview,
-    playbackReadyRangeRef,
-    playingRef,
-    selectionWarmupAudioIteratorRef,
+    activeSourceLabel,
+    playing,
+    currentTime,
+    startTime,
+    endTime,
+    sessionId,
+    videoSinkRef,
+    audioSinkRef,
     selectionWarmupGenerationRef,
     selectionWarmupPromiseRef,
     selectionWarmupVideoIteratorRef,
-    setPlaybackReadyRange,
-    skipLiveWaitRef,
-    sourceTimelineOffsetRef,
-    videoSinkRef,
-    warmClipStart,
-  ]);
-
-  const scheduleSelectionWarmupExtension = useCallback((clipStart: number, clipEnd: number) => {
-    cancelScheduledSelectionWarmupExtension();
-
-    if (
-      loadingPreview
-      || playingRef.current
-      || activeSourceLabelRef.current !== "HLS stream"
-    ) {
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(clipStart).toFixed(6));
-    const normalizedEnd = Number(clampTime(clipEnd).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      return;
-    }
-
-    selectionWarmupExtensionTimeoutRef.current = window.setTimeout(() => {
-      selectionWarmupExtensionTimeoutRef.current = null;
-
-      if (
-        loadingPreview
-        || playingRef.current
-        || activeSourceLabelRef.current !== "HLS stream"
-      ) {
-        return;
-      }
-
-      void warmClipSelection(normalizedStart, normalizedEnd);
-    }, SEEK_SELECTION_EXTENSION_DELAY_MS);
-  }, [
-    activeSourceLabelRef,
-    cancelScheduledSelectionWarmupExtension,
-    clampTime,
-    loadingPreview,
-    playingRef,
+    selectionWarmupAudioIteratorRef,
     selectionWarmupExtensionTimeoutRef,
-    warmClipSelection,
-  ]);
-
-  useEffect(() => {
-    if (loadingPreview || activeSourceLabel !== "HLS stream") {
-      autoWarmupSessionKeyRef.current = null;
-      setPlaybackReadyRange(null);
-      return;
-    }
-
-    const normalizedStart = Number(clampTime(startTime).toFixed(6));
-    const normalizedEnd = Number(clampTime(endTime).toFixed(6));
-    if (!Number.isFinite(normalizedStart) || !Number.isFinite(normalizedEnd) || normalizedEnd <= normalizedStart) {
-      setPlaybackReadyRange(null);
-      return;
-    }
-
-    const nextRange: PlaybackReadyRange = {
-      startTime: normalizedStart,
-      endTime: normalizedEnd,
-      readyUntilTime: normalizedStart,
-      status: "idle",
-    };
-
-    setPlaybackReadyRange((current) => (
-      samePlaybackRange(current, nextRange) ? current : nextRange
-    ));
-
-    const warmupSessionKey = `${sessionId}:hls:${normalizedStart}:${normalizedEnd}`;
-    if (autoWarmupSessionKeyRef.current === warmupSessionKey) {
-      return;
-    }
-
-    autoWarmupSessionKeyRef.current = warmupSessionKey;
-    void warmClipSelection(startTimeRef.current, endTimeRef.current, {
-      extendToSelectionEnd: false,
-    });
-    scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
-  }, [
-    activeSourceLabel,
     autoWarmupSessionKeyRef,
-    clampTime,
-    endTime,
-    endTimeRef,
-    loadingPreview,
-    scheduleSelectionWarmupExtension,
-    sessionId,
-    setPlaybackReadyRange,
-    startTime,
-    startTimeRef,
-    warmClipSelection,
-  ]);
-
-  useEffect(() => {
-    if (
-      wasPlayingRef.current
-      && !playing
-      && !loadingPreview
-      && activeSourceLabel === "HLS stream"
-    ) {
-      const currentReadyRange = playbackReadyRangeRef.current;
-      if (currentReadyRange && currentReadyRange.status !== "ready") {
-        const selectionStart = clampTime(startTimeRef.current);
-        if (selectionStart < endTimeRef.current) {
-          void warmClipSelection(selectionStart, endTimeRef.current, {
-            extendToSelectionEnd: false,
-          });
-          scheduleSelectionWarmupExtension(selectionStart, endTimeRef.current);
-        }
-      }
-    }
-
-    wasPlayingRef.current = playing;
-  }, [
-    activeSourceLabel,
-    clampTime,
-    currentTime,
-    endTimeRef,
-    loadingPreview,
-    playbackReadyRangeRef,
-    playing,
-    scheduleSelectionWarmupExtension,
-    startTimeRef,
-    warmClipSelection,
     wasPlayingRef,
-  ]);
-
-  useEffect(() => {
-    if (!playing || activeSourceLabel !== "HLS stream") {
-      return;
-    }
-
-    const normalizedCurrent = Number(clampTime(currentTime).toFixed(6));
-    setPlaybackReadyRange((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const readyUntilTime = Math.max(
-        current.readyUntilTime,
-        Math.min(current.endTime, normalizedCurrent),
-      );
-      const status = readyUntilTime >= current.endTime ? "ready" : "warming";
-
-      if (
-        current.status === status
-        && Math.abs(current.readyUntilTime - readyUntilTime) < 1e-6
-      ) {
-        return current;
-      }
-
-      return {
-        ...current,
-        readyUntilTime,
-        status,
-      };
-    });
-  }, [activeSourceLabel, clampTime, currentTime, playing, setPlaybackReadyRange]);
+    playingRef,
+    activeSourceLabelRef,
+    playbackReadyRangeRef,
+    sourceTimelineOffsetRef,
+    skipLiveWaitRef,
+    startTimeRef,
+    endTimeRef,
+    clampTime,
+    setPlaybackReadyRange,
+    warmClipStart,
+  });
 
   return {
     cancelSelectionWarmup,
@@ -647,16 +184,4 @@ export function useEditorPlaybackWarmup({
     warmClipSelection,
     scheduleSelectionWarmupExtension,
   };
-}
-
-function samePlaybackRange(
-  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
-  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
-) {
-  return (
-    left !== null
-    && left !== undefined
-    && Math.abs(left.startTime - right.startTime) < 1e-6
-    && Math.abs(left.endTime - right.endTime) < 1e-6
-  );
 }

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -8,15 +8,14 @@ import {
   getTimelineZoomLevel, 
   roundTimelineTime, 
   MIN_CLIP_SECONDS, 
-  TIMELINE_START_LEFT, 
-  normalizeWheelDelta, 
-  getTimelineMaxScrollLeft, 
-  TIMELINE_ZOOM_WHEEL_STEP, 
-  timelinePixelToTime, 
-  timelineTimeToPixel,
   type ClipTimelineData,
   type ClipTimelineEffects
 } from "./EditorUtils";
+import {
+  accumulateTimelineWheelZoomDelta,
+  resolveTimelineScrollWheelUpdate,
+  resolveTimelineZoomUpdate,
+} from "./timelineZoom";
 
 interface UseEditorTimelineProps {
   duration: number;
@@ -212,56 +211,25 @@ export function useEditorTimeline({
     if (!timelineWheelRegion) return;
 
     const currentZoomIndex = timelineZoomIndexRef.current;
-    const currentTimelineScale = getTimelineZoomLevel(
+    const currentScrollLeft = pendingTimelineScrollLeftRef.current ?? timelineScrollLeftRef.current;
+    const regionRect = timelineWheelRegion.getBoundingClientRect();
+    const zoomUpdate = resolveTimelineZoomUpdate({
       availableTimelineZoomLevels,
       currentZoomIndex,
-      activeTimelineScale,
-    );
-    const currentScrollLeft = pendingTimelineScrollLeftRef.current ?? timelineScrollLeftRef.current;
-    const nextZoomIndex = Math.min(
-      availableTimelineZoomLevels.length - 1,
-      Math.max(0, currentZoomIndex + Math.sign(zoomDelta)),
-    );
-    if (nextZoomIndex === currentZoomIndex) {
+      fallbackTimelineScale: activeTimelineScale,
+      zoomDelta,
+      currentScrollLeft,
+      duration,
+      regionLeft: regionRect.left,
+      regionWidth: regionRect.width,
+      anchorClientX,
+    });
+    if (!zoomUpdate) {
       timelineWheelDeltaRef.current = 0;
       return;
     }
 
-    const nextTimelineScale = getTimelineZoomLevel(
-      availableTimelineZoomLevels,
-      nextZoomIndex,
-      currentTimelineScale,
-    );
-    const regionRect = timelineWheelRegion.getBoundingClientRect();
-    const pointerX = typeof anchorClientX === "number"
-      ? Math.min(Math.max(anchorClientX - regionRect.left, 0), regionRect.width)
-      : regionRect.width / 2;
-    const anchorPixel = Math.max(TIMELINE_START_LEFT, currentScrollLeft + pointerX);
-    const anchorTime = Math.min(
-      duration,
-      Math.max(
-        0,
-        timelinePixelToTime(
-          anchorPixel,
-          currentTimelineScale.scale,
-          currentTimelineScale.scaleWidth,
-          TIMELINE_START_LEFT,
-        ),
-      ),
-    );
-    const nextAnchorPixel = timelineTimeToPixel(
-      anchorTime,
-      nextTimelineScale.scale,
-      nextTimelineScale.scaleWidth,
-      TIMELINE_START_LEFT,
-    );
-    const nextMaxScrollLeft = getTimelineMaxScrollLeft(
-      duration,
-      nextTimelineScale.scale,
-      nextTimelineScale.scaleWidth,
-      regionRect.width,
-    );
-    const nextScrollLeft = Math.min(nextMaxScrollLeft, Math.max(0, nextAnchorPixel - pointerX));
+    const { nextZoomIndex, nextScrollLeft } = zoomUpdate;
     pendingTimelineScrollLeftRef.current = nextScrollLeft;
     timelineScrollLeftRef.current = nextScrollLeft;
     setTimelineScrollLeft(nextScrollLeft);
@@ -292,24 +260,21 @@ export function useEditorTimeline({
 
     if (!event.metaKey && !event.ctrlKey) {
       timelineWheelDeltaRef.current = 0;
-      const horizontalWheelDelta = normalizeWheelDelta(event.deltaX, event.deltaMode, containerWidth);
-      const verticalWheelDelta = normalizeWheelDelta(event.deltaY, event.deltaMode, containerHeight);
-      const nextScrollDelta = horizontalWheelDelta + verticalWheelDelta;
-      const maxScrollLeft = getTimelineMaxScrollLeft(
-        duration,
-        activeTimelineScale.scale,
-        activeTimelineScale.scaleWidth,
+      const nextScrollLeft = resolveTimelineScrollWheelUpdate({
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
         containerWidth,
-      );
-      if (nextScrollDelta === 0 || maxScrollLeft <= 0) return;
+        containerHeight,
+        currentScrollLeft: timelineScrollLeftRef.current,
+        duration,
+        timelineScale: activeTimelineScale,
+      });
+      if (nextScrollLeft === null) return;
 
       event.preventDefault();
       event.stopPropagation();
 
-      const nextScrollLeft = Math.min(
-        maxScrollLeft,
-        Math.max(0, timelineScrollLeftRef.current + nextScrollDelta),
-      );
       timelineRef.current?.setScrollLeft(nextScrollLeft);
       timelineScrollLeftRef.current = nextScrollLeft;
       setTimelineScrollLeft(nextScrollLeft);
@@ -319,22 +284,16 @@ export function useEditorTimeline({
     event.preventDefault();
     event.stopPropagation();
 
-    const normalizedDeltaY = normalizeWheelDelta(event.deltaY, event.deltaMode, containerHeight);
-    if (normalizedDeltaY === 0 || availableTimelineZoomLevels.length < 2) return;
+    if (availableTimelineZoomLevels.length < 2) return;
 
-    if (
-      timelineWheelDeltaRef.current !== 0 &&
-      Math.sign(timelineWheelDeltaRef.current) !== Math.sign(normalizedDeltaY)
-    ) {
-      timelineWheelDeltaRef.current = 0;
-    }
-
-    timelineWheelDeltaRef.current += normalizedDeltaY;
-    const accumulatedZoomDelta = Math.trunc(timelineWheelDeltaRef.current / TIMELINE_ZOOM_WHEEL_STEP);
-    if (accumulatedZoomDelta === 0) return;
-
-    const zoomDelta = Math.sign(accumulatedZoomDelta);
-    timelineWheelDeltaRef.current = 0;
+    const { accumulatedWheelDelta, zoomDelta } = accumulateTimelineWheelZoomDelta({
+      currentWheelDelta: timelineWheelDeltaRef.current,
+      deltaY: event.deltaY,
+      deltaMode: event.deltaMode,
+      containerHeight,
+    });
+    timelineWheelDeltaRef.current = accumulatedWheelDelta;
+    if (zoomDelta === 0) return;
     updateTimelineZoom(zoomDelta, event.clientX);
   }, [hasDuration, duration, activeTimelineScale, availableTimelineZoomLevels, updateTimelineZoom]);
 

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from "react";
+import type { PlaybackSubtitleTrack } from "../../providers/types";
+import {
+  subtitleTrackSupportsBurnIn,
+  subtitleTrackUnavailableMessage,
+} from "../../lib/selectPreferredSubtitleTrack";
+import { parseSubtitleText } from "../../lib/subtitles/parseSubtitleText";
+import type { SubtitleCue } from "../../lib/subtitles/types";
+
+interface UseSubtitleCuesOptions {
+  selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  subtitleEnabled: boolean;
+  providerId: string;
+}
+
+const subtitleRequestTimeoutMs = 15_000;
+
+function responseErrorMessage(payload: unknown) {
+  if (!payload || typeof payload !== "object" || !("error" in payload)) {
+    return "";
+  }
+
+  const error = payload.error;
+  if (!error || typeof error !== "object" || !("message" in error) || typeof error.message !== "string") {
+    return "";
+  }
+
+  return error.message.trim();
+}
+
+async function subtitleDownloadErrorDetail(response: Response) {
+  try {
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.toLowerCase().includes("application/json")) {
+      return responseErrorMessage(await response.json());
+    }
+
+    return (await response.text()).replace(/\s+/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
+async function downloadSubtitleCues(
+  track: PlaybackSubtitleTrack,
+  contentUrl: string,
+  signal: AbortSignal
+) {
+  const response = await fetch(contentUrl, { signal });
+  if (!response.ok) {
+    const detail = await subtitleDownloadErrorDetail(response);
+    throw new Error(
+      detail
+        ? `Subtitle download failed (${response.status}): ${detail}`
+        : `Subtitle download failed (${response.status})`
+    );
+  }
+
+  return parseSubtitleText(await response.text(), track.contentFormat);
+}
+
+export function useSubtitleCues({
+  selectedSubtitleTrack,
+  subtitleEnabled,
+  providerId,
+}: UseSubtitleCuesOptions) {
+  const [subtitleCues, setSubtitleCues] = useState<SubtitleCue[]>([]);
+  const [subtitleLoading, setSubtitleLoading] = useState(false);
+  const [subtitleError, setSubtitleError] = useState<string | null>(null);
+
+  const resetSubtitleCues = useCallback(() => {
+    setSubtitleCues([]);
+    setSubtitleLoading(false);
+    setSubtitleError(null);
+  }, []);
+
+  const clearSubtitleError = useCallback(() => {
+    setSubtitleError(null);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+    const timeout = window.setTimeout(() => {
+      abortController.abort();
+    }, subtitleRequestTimeoutMs);
+
+    async function loadSubtitleCues() {
+      if (!subtitleEnabled || !selectedSubtitleTrack) {
+        resetSubtitleCues();
+        return;
+      }
+
+      const contentUrl = selectedSubtitleTrack.contentUrl;
+      if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack) || !contentUrl) {
+        setSubtitleLoading(false);
+        setSubtitleCues([]);
+        setSubtitleError(
+          subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId)
+            ?? "This subtitle track is not yet supported for styled burn-in."
+        );
+        return;
+      }
+
+      setSubtitleCues([]);
+      setSubtitleLoading(true);
+      setSubtitleError(null);
+
+      try {
+        const parsedSubtitleCues = await downloadSubtitleCues(
+          selectedSubtitleTrack,
+          contentUrl,
+          abortController.signal
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        setSubtitleCues(parsedSubtitleCues);
+        setSubtitleError(parsedSubtitleCues.length === 0 ? "No subtitle cues were found in this track." : null);
+      } catch (err) {
+        if (cancelled || abortController.signal.aborted) {
+          if (!cancelled) {
+            setSubtitleCues([]);
+            setSubtitleError("Subtitle request timed out. Please try again.");
+            setSubtitleLoading(false);
+          }
+          return;
+        }
+
+        console.error("Could not load subtitle cues", err);
+        setSubtitleCues([]);
+        setSubtitleError(err instanceof Error ? err.message : "Could not load subtitle cues.");
+      } finally {
+        if (!cancelled) {
+          setSubtitleLoading(false);
+        }
+      }
+    }
+
+    void loadSubtitleCues();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+      abortController.abort();
+    };
+  }, [providerId, resetSubtitleCues, selectedSubtitleTrack, subtitleEnabled]);
+
+  return {
+    subtitleCues,
+    subtitleLoading,
+    subtitleError,
+    resetSubtitleCues,
+    clearSubtitleError,
+  };
+}

--- a/apps/frontend/src/components/useModalFocusTrap.ts
+++ b/apps/frontend/src/components/useModalFocusTrap.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+interface UseModalFocusTrapOptions {
+  isOpen: boolean;
+  dialogRef: RefObject<HTMLElement | null>;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  onEscape?: () => void;
+}
+
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex=\"-1\"])",
+].join(", ");
+
+export function useModalFocusTrap({
+  isOpen,
+  dialogRef,
+  initialFocusRef,
+  onEscape,
+}: UseModalFocusTrapOptions) {
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const frameId = window.requestAnimationFrame(() => {
+      (initialFocusRef?.current ?? dialogRef.current)?.focus();
+    });
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onEscape?.();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+
+      const focusable = [...dialog.querySelectorAll<HTMLElement>(focusableSelector)]
+        .filter((element) => element.getAttribute("aria-hidden") !== "true");
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const firstFocusable = focusable[0];
+      const lastFocusable = focusable[focusable.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey) {
+        if (activeElement === firstFocusable || !dialog.contains(activeElement)) {
+          event.preventDefault();
+          lastFocusable?.focus();
+        }
+        return;
+      }
+
+      if (activeElement === lastFocusable) {
+        event.preventDefault();
+        firstFocusable?.focus();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+      lastFocusedElementRef.current?.focus();
+    };
+  }, [dialogRef, initialFocusRef, isOpen, onEscape]);
+}

--- a/apps/frontend/src/components/useModalFocusTrap.ts
+++ b/apps/frontend/src/components/useModalFocusTrap.ts
@@ -76,7 +76,7 @@ export function useModalFocusTrap({
         return;
       }
 
-      if (activeElement === lastFocusable) {
+      if (activeElement === lastFocusable || !dialog.contains(activeElement)) {
         event.preventDefault();
         firstFocusable?.focus();
       }

--- a/apps/frontend/src/components/useProviderConnectFlow.ts
+++ b/apps/frontend/src/components/useProviderConnectFlow.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cliparrClient } from "../api/cliparrClient";
+import type { ProviderDefinition, ProviderSession } from "../providers/types";
+
+interface UseProviderConnectFlowOptions {
+  onConnected: (session: ProviderSession) => Promise<void> | void;
+}
+
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+export function useProviderConnectFlow({
+  onConnected,
+}: UseProviderConnectFlowOptions) {
+  const [providers, setProviders] = useState<ProviderDefinition[]>([]);
+  const [selectedProviderId, setSelectedProviderId] = useState("");
+  const [authId, setAuthId] = useState("");
+  const [providerId, setProviderId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [authenticating, setAuthenticating] = useState(false);
+  const [error, setError] = useState("");
+  const [serverUrl, setServerUrl] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProviders() {
+      try {
+        const data = await cliparrClient.listProviders();
+        if (!cancelled) {
+          setProviders(data);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(errorMessage(err, "Failed to load providers"));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadProviders();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedProviderId && providers[0]) {
+      setSelectedProviderId(providers[0].id);
+    }
+  }, [providers, selectedProviderId]);
+
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === selectedProviderId) ?? providers[0],
+    [providers, selectedProviderId]
+  );
+
+  const providerLabel = useCallback((id: string) => {
+    return providers.find((provider) => provider.id === id)?.name ?? "provider";
+  }, [providers]);
+
+  const resetProviderState = useCallback(() => {
+    setAuthenticating(false);
+    setAuthId("");
+    setProviderId("");
+    setPassword("");
+  }, []);
+
+  useEffect(() => {
+    if (!authId || !providerId) {
+      return;
+    }
+
+    const pollAuthStatus = async () => {
+      try {
+        const status = await cliparrClient.pollAuth(providerId, authId);
+        if (status.status === "complete") {
+          window.clearInterval(intervalId);
+          const session = await cliparrClient.getSession();
+          await onConnected(session);
+          resetProviderState();
+          return;
+        }
+
+        if (status.status === "expired") {
+          window.clearInterval(intervalId);
+          resetProviderState();
+          setError(`That ${providerLabel(providerId)} sign-in expired. Start again when you're ready.`);
+        }
+      } catch (err: unknown) {
+        window.clearInterval(intervalId);
+        resetProviderState();
+        setError(errorMessage(err, `Failed to finish ${providerLabel(providerId)} sign-in`));
+      }
+    };
+    const intervalId = window.setInterval(() => {
+      void pollAuthStatus();
+    }, 1500);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [authId, onConnected, providerId, providerLabel, resetProviderState]);
+
+  const startAuth = useCallback(async (provider: ProviderDefinition) => {
+    setError("");
+    setAuthId("");
+    setProviderId(provider.id);
+    setAuthenticating(true);
+
+    try {
+      const auth = await cliparrClient.startAuth(provider.id);
+      setAuthId(auth.authId);
+      window.open(auth.authUrl, "_blank", "noopener,noreferrer");
+    } catch (err: unknown) {
+      resetProviderState();
+      setError(errorMessage(err, `Failed to start ${provider.name} sign-in`));
+    }
+  }, [resetProviderState]);
+
+  const loginWithCredentials = useCallback(async (provider: ProviderDefinition) => {
+    setError("");
+    setAuthId("");
+    setProviderId(provider.id);
+    setAuthenticating(true);
+
+    try {
+      const session = await cliparrClient.loginWithCredentials(provider.id, {
+        serverUrl,
+        username,
+        password,
+      });
+      await onConnected(session);
+      resetProviderState();
+      setServerUrl("");
+      setUsername("");
+    } catch (err: unknown) {
+      resetProviderState();
+      setError(errorMessage(err, `Failed to connect ${provider.name}`));
+    }
+  }, [onConnected, password, resetProviderState, serverUrl, username]);
+
+  return {
+    providers,
+    selectedProvider,
+    selectedProviderId,
+    setSelectedProviderId,
+    authId,
+    providerId,
+    loading,
+    authenticating,
+    error,
+    setError,
+    serverUrl,
+    setServerUrl,
+    username,
+    setUsername,
+    password,
+    setPassword,
+    providerLabel,
+    startAuth,
+    loginWithCredentials,
+  };
+}

--- a/apps/frontend/src/components/useSourcesModalState.ts
+++ b/apps/frontend/src/components/useSourcesModalState.ts
@@ -1,0 +1,471 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cliparrClient } from "../api/cliparrClient";
+import { useAuth } from "../auth";
+import type { MediaSource, ProviderSession } from "../providers/types";
+import type { Feedback, SourceFilter } from "./SourcesModalSections";
+import {
+  compareStrings,
+  sortSources,
+  stringValue,
+} from "./SourcesModalSections";
+
+interface UseSourcesModalStateOptions {
+  isOpen: boolean;
+  onSourcesChanged?: () => Promise<void> | void;
+}
+
+interface SourceActionResult {
+  feedback: Feedback;
+  source?: MediaSource;
+  removeSourceId?: string;
+}
+
+function draftBaseUrlsFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.baseUrl]));
+}
+
+function draftNamesFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.name]));
+}
+
+export function useSourcesModalState({
+  isOpen,
+  onSourcesChanged,
+}: UseSourcesModalStateOptions) {
+  const auth = useAuth();
+  const [sources, setSources] = useState<MediaSource[]>([]);
+  const [draftBaseUrls, setDraftBaseUrls] = useState<Record<string, string>>({});
+  const [draftNames, setDraftNames] = useState<Record<string, string>>({});
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<SourceFilter>("all");
+  const [providerFilter, setProviderFilter] = useState("all");
+  const [loading, setLoading] = useState(false);
+  const [reloading, setReloading] = useState(false);
+  const [refreshingAll, setRefreshingAll] = useState(false);
+  const [busyActions, setBusyActions] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [showAddSource, setShowAddSource] = useState(false);
+  const latestLoadRequestIdRef = useRef(0);
+  const isOpenRef = useRef(isOpen);
+
+  const replaceSources = useCallback((nextSources: MediaSource[]) => {
+    setSources(nextSources);
+    setDraftBaseUrls(draftBaseUrlsFor(nextSources));
+    setDraftNames(draftNamesFor(nextSources));
+  }, []);
+
+  const applyLoadedSources = useCallback(async (requestId: number) => {
+    const nextSources = sortSources(await cliparrClient.listSources());
+    if (requestId !== latestLoadRequestIdRef.current || !isOpenRef.current) {
+      return false;
+    }
+
+    replaceSources(nextSources);
+    return true;
+  }, [replaceSources]);
+
+  const loadSources = useCallback(async (mode: "initial" | "reload" = "initial") => {
+    const requestId = latestLoadRequestIdRef.current + 1;
+    latestLoadRequestIdRef.current = requestId;
+    const isCurrentRequest = () => requestId === latestLoadRequestIdRef.current && isOpenRef.current;
+
+    if (mode === "initial") {
+      setLoading(true);
+    } else {
+      setReloading(true);
+    }
+
+    setError("");
+
+    try {
+      await applyLoadedSources(requestId);
+    } catch (err) {
+      if (!isCurrentRequest()) {
+        return;
+      }
+
+      const message = err instanceof Error ? err.message : "Failed to load sources";
+      setSources([]);
+      setDraftBaseUrls({});
+      setDraftNames({});
+      setError(message);
+    } finally {
+      if (isCurrentRequest()) {
+        if (mode === "initial") {
+          setLoading(false);
+        } else {
+          setReloading(false);
+        }
+      }
+    }
+  }, [applyLoadedSources]);
+
+  function updateBusyAction(sourceId: string, action?: string) {
+    setBusyActions((current) => {
+      const next = { ...current };
+      if (action) {
+        next[sourceId] = action;
+      } else {
+        delete next[sourceId];
+      }
+      return next;
+    });
+  }
+
+  function upsertSource(source: MediaSource) {
+    setSources((current) => {
+      const exists = current.some((item) => item.id === source.id);
+      return sortSources(exists ? current.map((item) => (item.id === source.id ? source : item)) : [...current, source]);
+    });
+    setDraftBaseUrls((current) => ({
+      ...current,
+      [source.id]: source.baseUrl,
+    }));
+    setDraftNames((current) => ({
+      ...current,
+      [source.id]: source.name,
+    }));
+  }
+
+  function removeSource(sourceId: string) {
+    setSources((current) => current.filter((source) => source.id !== sourceId));
+    setDraftBaseUrls((current) => {
+      const next = { ...current };
+      delete next[sourceId];
+      return next;
+    });
+    setDraftNames((current) => {
+      const next = { ...current };
+      delete next[sourceId];
+      return next;
+    });
+  }
+
+  async function refreshPlaybackView() {
+    await onSourcesChanged?.();
+  }
+
+  async function runSourceAction(
+    source: MediaSource,
+    busyAction: string,
+    fallbackError: string,
+    action: () => Promise<SourceActionResult>
+  ) {
+    setFeedback(null);
+    setError("");
+    updateBusyAction(source.id, busyAction);
+
+    try {
+      const result = await action();
+      if (result.source) {
+        upsertSource(result.source);
+      }
+      if (result.removeSourceId) {
+        removeSource(result.removeSourceId);
+      }
+      setFeedback(result.feedback);
+      await refreshPlaybackView();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : fallbackError;
+      setError(message);
+    } finally {
+      updateBusyAction(source.id);
+    }
+  }
+
+  async function handleSourceConnected(session: ProviderSession) {
+    auth.setProviderSession(session);
+    setFeedback({
+      tone: "success",
+      message: "Source connected. Refreshing your library list now.",
+    });
+    setShowAddSource(false);
+    await loadSources("reload");
+    await refreshPlaybackView();
+  }
+
+  async function saveSourceEdits(source: MediaSource) {
+    const nextName = (draftNames[source.id] ?? source.name).trim();
+    const nextBaseUrl = (draftBaseUrls[source.id] ?? source.baseUrl).trim();
+    const hasNameChange = Boolean(nextName) && nextName !== source.name;
+    const hasBaseUrlChange = Boolean(nextBaseUrl) && nextBaseUrl !== source.baseUrl;
+
+    if (!hasNameChange && !hasBaseUrlChange) {
+      return;
+    }
+
+    await runSourceAction(source, "Saving...", "Failed to update source", async () => {
+      const updatedSource = await cliparrClient.updateSource(source.id, {
+        ...(hasNameChange ? { name: nextName } : {}),
+        ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
+      });
+
+      return {
+        source: updatedSource,
+        feedback: {
+          tone: "success",
+          message: `Updated ${updatedSource.name}.`,
+        },
+      };
+    });
+  }
+
+  async function toggleSourceEnabled(source: MediaSource) {
+    await runSourceAction(
+      source,
+      source.enabled ? "Disabling..." : "Enabling...",
+      "Failed to update source",
+      async () => {
+        const updatedSource = await cliparrClient.updateSource(source.id, { enabled: !source.enabled });
+
+        return {
+          source: updatedSource,
+          feedback: {
+            tone: "success",
+            message: `${updatedSource.name} is now ${updatedSource.enabled ? "enabled" : "disabled"}.`,
+          },
+        };
+      },
+    );
+  }
+
+  async function checkSource(source: MediaSource) {
+    await runSourceAction(source, "Refreshing...", "Failed to refresh source", async () => {
+      const result = await cliparrClient.checkSource(source.id);
+
+      return {
+        source: result.source,
+        feedback: {
+          tone: result.ok ? "success" : "warning",
+          message: result.ok
+            ? `${result.source.name} passed its health check.`
+            : `${result.source.name} still needs attention.`,
+        },
+      };
+    });
+  }
+
+  async function deleteSource(source: MediaSource) {
+    const confirmed = window.confirm(
+      `Remove ${source.name}? Cliparr will stop querying it until it is reconnected.`
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    await runSourceAction(source, "Removing...", "Failed to remove source", async () => {
+      await cliparrClient.deleteSource(source.id);
+
+      return {
+        removeSourceId: source.id,
+        feedback: {
+          tone: "success",
+          message: `Removed ${source.name}.`,
+        },
+      };
+    });
+  }
+
+  async function refreshAllSources() {
+    if (sources.length === 0) {
+      return;
+    }
+
+    setFeedback(null);
+    setError("");
+    setRefreshingAll(true);
+    setBusyActions(Object.fromEntries(sources.map((source) => [source.id, "Refreshing..."])));
+
+    try {
+      const results = await Promise.allSettled(
+        sources.map(async (source) => {
+          const result = await cliparrClient.checkSource(source.id);
+          return { source, result };
+        })
+      );
+
+      const nextSources = new Map(sources.map((source) => [source.id, source]));
+      let healthyCount = 0;
+      let attentionCount = 0;
+      let failedCount = 0;
+
+      results.forEach((entry, index) => {
+        const currentSource = sources[index];
+        if (!currentSource) {
+          return;
+        }
+
+        if (entry.status === "fulfilled") {
+          nextSources.set(entry.value.result.source.id, entry.value.result.source);
+          if (entry.value.result.ok) {
+            healthyCount += 1;
+          } else {
+            attentionCount += 1;
+          }
+          return;
+        }
+
+        failedCount += 1;
+      });
+
+      const mergedSources = sortSources([...nextSources.values()]);
+      replaceSources(mergedSources);
+
+      const summaryParts = [
+        `${healthyCount} healthy`,
+        `${attentionCount} need attention`,
+      ];
+      if (failedCount > 0) {
+        summaryParts.push(`${failedCount} failed to refresh`);
+      }
+
+      setFeedback({
+        tone: attentionCount > 0 || failedCount > 0 ? "warning" : "success",
+        message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}: ${summaryParts.join(", ")}.`,
+      });
+      await refreshPlaybackView();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to refresh sources";
+      setError(message);
+    } finally {
+      setRefreshingAll(false);
+      setBusyActions({});
+    }
+  }
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+    if (!isOpen) {
+      latestLoadRequestIdRef.current += 1;
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShowAddSource(false);
+      return;
+    }
+
+    setFeedback(null);
+    void loadSources();
+  }, [isOpen, loadSources]);
+
+  useEffect(() => {
+    if (!isOpen || loading) {
+      return;
+    }
+
+    if (sources.length === 0) {
+      setShowAddSource(true);
+    }
+  }, [isOpen, loading, sources.length]);
+
+  const providerOptions = useMemo(() => {
+    const providers = [...new Set(sources.map((source) => source.providerId))];
+    return providers.sort(compareStrings);
+  }, [sources]);
+
+  useEffect(() => {
+    if (providerFilter === "all" || providerOptions.includes(providerFilter)) {
+      return;
+    }
+
+    setProviderFilter("all");
+  }, [providerFilter, providerOptions]);
+
+  const counts = useMemo(() => ({
+    all: sources.length,
+    enabled: sources.filter((source) => source.enabled).length,
+    disabled: sources.filter((source) => !source.enabled).length,
+    attention: sources.filter((source) => Boolean(source.lastError)).length,
+  }), [sources]);
+
+  const filteredSources = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return sources.filter((source) => {
+      if (providerFilter !== "all" && source.providerId !== providerFilter) {
+        return false;
+      }
+
+      if (statusFilter === "enabled" && !source.enabled) {
+        return false;
+      }
+
+      if (statusFilter === "disabled" && source.enabled) {
+        return false;
+      }
+
+      if (statusFilter === "attention" && !source.lastError) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      const haystack = [
+        source.name,
+        source.baseUrl,
+        source.providerId,
+        stringValue(source.metadata.product),
+        stringValue(source.metadata.platform),
+      ].filter(Boolean).join(" ").toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [providerFilter, query, sources, statusFilter]);
+
+  const updateDraftName = useCallback((sourceId: string, value: string) => {
+    setDraftNames((current) => ({
+      ...current,
+      [sourceId]: value,
+    }));
+  }, []);
+
+  const updateDraftBaseUrl = useCallback((sourceId: string, value: string) => {
+    setDraftBaseUrls((current) => ({
+      ...current,
+      [sourceId]: value,
+    }));
+  }, []);
+
+  const hasBusyActions = Object.keys(busyActions).length > 0;
+  const forceAddSourceOpen = !loading && sources.length === 0;
+  const showConnectPanel = showAddSource || forceAddSourceOpen;
+
+  return {
+    sources,
+    filteredSources,
+    draftBaseUrls,
+    draftNames,
+    query,
+    setQuery,
+    statusFilter,
+    setStatusFilter,
+    providerFilter,
+    setProviderFilter,
+    providerOptions,
+    loading,
+    reloading,
+    refreshingAll,
+    busyActions,
+    error,
+    feedback,
+    showConnectPanel,
+    forceAddSourceOpen,
+    hasBusyActions,
+    counts,
+    setShowAddSource,
+    loadSources,
+    refreshAllSources,
+    handleSourceConnected,
+    saveSourceEdits,
+    toggleSourceEnabled,
+    checkSource,
+    deleteSource,
+    updateDraftName,
+    updateDraftBaseUrl,
+  };
+}

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -7,25 +7,29 @@ import {
   Output,
   WebMOutputFormat,
 } from "mediabunny";
-import type { ConversionOptions, DiscardedTrack, MetadataTags, VideoSample } from "mediabunny";
+import type { ConversionOptions, DiscardedTrack, VideoSample } from "mediabunny";
 import { createCliparrInputFromUrl } from "./mediabunnyInput";
 import { ensureMediabunnyCodecs } from "./mediabunnyCodecs";
 import {
-  describeInputTrack,
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
   toSourceTimelineTime,
 } from "./mediabunnyTrackAccess";
 import { selectPreferredPairableAudioTrack } from "./selectPreferredAudioTrack";
 import type { MediaExportMetadata, PlaybackAudioSelection } from "../providers/types";
+import {
+  buildMetadataTags,
+  describeDiscardedTracks,
+  isIsobmffExportFormat,
+  patchMp4MetadataBoxes,
+} from "./exportMetadata";
+import type { ExportFormat, ExportResolution } from "./exportTypes";
 import { getActiveSubtitleCue } from "./subtitles/getActiveSubtitleCue";
 import { renderSubtitleCue } from "./subtitles/renderSubtitleCue";
 import { trimSubtitleCues } from "./subtitles/trimSubtitleCues";
 import type { SubtitleCue, SubtitleStyleSettings } from "./subtitles/types";
 
-export type ExportFormat = "mp4" | "webm" | "mov" | "mkv";
-
-export type ExportResolution = "original" | "1080" | "720";
+export type { ExportFormat, ExportResolution } from "./exportTypes";
 
 interface ExportClipOptions {
   mediaUrl: string;
@@ -43,298 +47,11 @@ interface ExportClipOptions {
   onProgress: (progress: number) => void;
 }
 
-const discardReasonLabels: Record<DiscardedTrack["reason"], string> = {
-  discarded_by_user: "discarded by configuration",
-  max_track_count_reached: "the output track limit was reached",
-  max_track_count_of_type_reached: "the output cannot contain another track of this type",
-  unknown_source_codec: "the source codec is unknown",
-  undecodable_source_codec: "the source codec could not be decoded",
-  no_encodable_target_codec: "no compatible output codec could be encoded",
-};
-
-async function describeDiscardedTracks(discardedTracks: readonly DiscardedTrack[]) {
-  if (discardedTracks.length === 0) {
-    return "";
-  }
-
-  const details = await Promise.all(
-    discardedTracks.map(async ({ track, reason }) =>
-      `${await describeInputTrack(track)}: ${discardReasonLabels[reason]}`
-    )
-  );
-
-  return details.join("; ");
-}
-
 async function buildAudioDroppedError(discardedTracks: readonly DiscardedTrack[]) {
   const discardedDetails = await describeDiscardedTracks(discardedTracks);
   const suffix = discardedDetails ? ` ${discardedDetails}` : " Mediabunny did not report a discarded-track reason.";
 
   return new Error(`Export would drop the source audio track.${suffix}`);
-}
-
-function firstText(...values: Array<string | undefined>) {
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed) {
-      return trimmed;
-    }
-  }
-
-  return undefined;
-}
-
-function nonNegativeInteger(value: number | undefined) {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
-}
-
-function parseMetadataDate(date: string | undefined, year: number | undefined) {
-  const dateText = firstText(date, year ? `${year}-01-01` : undefined);
-  if (!dateText) {
-    return undefined;
-  }
-
-  const parsed = new Date(dateText);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-}
-
-function formatMetadataTime(seconds: number) {
-  if (!Number.isFinite(seconds)) {
-    return "0:00";
-  }
-
-  const wholeSeconds = Math.max(0, Math.round(seconds));
-  const hours = Math.floor(wholeSeconds / 3600);
-  const minutes = Math.floor((wholeSeconds % 3600) / 60);
-  const remainingSeconds = wholeSeconds % 60;
-
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, "0")}:${remainingSeconds.toString().padStart(2, "0")}`;
-  }
-
-  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
-}
-
-function formatMetadataTimecode(seconds: number) {
-  if (!Number.isFinite(seconds)) {
-    return "00:00:00.000";
-  }
-
-  const wholeMilliseconds = Math.max(0, Math.round(seconds * 1000));
-  const milliseconds = wholeMilliseconds % 1000;
-  const wholeSeconds = Math.floor(wholeMilliseconds / 1000);
-  const hours = Math.floor(wholeSeconds / 3600);
-  const minutes = Math.floor((wholeSeconds % 3600) / 60);
-  const remainingSeconds = wholeSeconds % 60;
-
-  return [
-    hours.toString().padStart(2, "0"),
-    minutes.toString().padStart(2, "0"),
-    remainingSeconds.toString().padStart(2, "0"),
-  ].join(":") + `.${milliseconds.toString().padStart(3, "0")}`;
-}
-
-function formatMetadataSeconds(seconds: number) {
-  if (!Number.isFinite(seconds)) {
-    return "0.000";
-  }
-
-  return Math.max(0, seconds).toFixed(3);
-}
-
-function uint8Atom(value: number) {
-  return new Uint8Array([Math.max(0, Math.min(255, value))]);
-}
-
-function uint32Atom(value: number) {
-  const safeValue = Math.max(0, Math.trunc(value));
-  return new Uint8Array([
-    (safeValue >>> 24) & 0xff,
-    (safeValue >>> 16) & 0xff,
-    (safeValue >>> 8) & 0xff,
-    safeValue & 0xff,
-  ]);
-}
-
-const mp4IntegerMetadataDataTypes: Record<string, number> = {
-  hdvd: 0x15,
-  stik: 0x15,
-  tves: 0x15,
-  tvsn: 0x16,
-};
-
-function readUint32(bytes: Uint8Array, offset: number) {
-  return (
-    bytes[offset] * 2 ** 24
-    + bytes[offset + 1] * 2 ** 16
-    + bytes[offset + 2] * 2 ** 8
-    + bytes[offset + 3]
-  );
-}
-
-function writeUint32(bytes: Uint8Array, offset: number, value: number) {
-  bytes[offset] = (value >>> 24) & 0xff;
-  bytes[offset + 1] = (value >>> 16) & 0xff;
-  bytes[offset + 2] = (value >>> 8) & 0xff;
-  bytes[offset + 3] = value & 0xff;
-}
-
-function readBoxType(bytes: Uint8Array, offset: number) {
-  return String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]);
-}
-
-function boxBounds(bytes: Uint8Array, offset: number, end: number) {
-  const size32 = readUint32(bytes, offset);
-  const headerSize = size32 === 1 ? 16 : 8;
-  let size = size32;
-
-  if (size32 === 0) {
-    size = end - offset;
-  } else if (size32 === 1) {
-    if (offset + 16 > end) {
-      return undefined;
-    }
-
-    const high = readUint32(bytes, offset + 8);
-    const low = readUint32(bytes, offset + 12);
-    size = high * 2 ** 32 + low;
-  }
-
-  const boxEnd = offset + size;
-  if (size < headerSize || boxEnd > end || !Number.isSafeInteger(boxEnd)) {
-    return undefined;
-  }
-
-  return { headerSize, end: boxEnd };
-}
-
-function patchIlstItemDataType(bytes: Uint8Array, start: number, end: number, dataType: number) {
-  let offset = start;
-
-  while (offset + 8 <= end) {
-    const bounds = boxBounds(bytes, offset, end);
-    if (!bounds) {
-      return;
-    }
-
-    if (readBoxType(bytes, offset + 4) === "data") {
-      if (offset + bounds.headerSize + 4 > bounds.end) {
-        return;
-      }
-
-      writeUint32(bytes, offset + bounds.headerSize, dataType);
-      return;
-    }
-
-    offset = bounds.end;
-  }
-}
-
-function patchMp4MetadataBoxes(bytes: Uint8Array, start = 0, end = bytes.length, parentType?: string) {
-  let offset = start;
-
-  while (offset + 8 <= end) {
-    const bounds = boxBounds(bytes, offset, end);
-    if (!bounds) {
-      return;
-    }
-
-    const type = readBoxType(bytes, offset + 4);
-    let contentStart = offset + bounds.headerSize;
-
-    if (parentType === "ilst") {
-      const dataType = mp4IntegerMetadataDataTypes[type];
-      if (dataType !== undefined) {
-        patchIlstItemDataType(bytes, contentStart, bounds.end, dataType);
-      }
-    }
-
-    if (type === "meta") {
-      contentStart += 4;
-    }
-
-    if (type === "moov" || type === "udta" || type === "meta" || type === "ilst") {
-      patchMp4MetadataBoxes(bytes, contentStart, bounds.end, type);
-    }
-
-    offset = bounds.end;
-  }
-}
-
-function inferHdVideoFlag(height: number | undefined) {
-  if (typeof height !== "number" || !Number.isFinite(height)) {
-    return undefined;
-  }
-
-  if (height >= 720) return 1;
-  return 0;
-}
-
-function buildMp4RawTags(
-  metadata: MediaExportMetadata,
-  outputHeight: number | undefined,
-  startTime: number,
-  endTime: number
-): MetadataTags["raw"] | undefined {
-  const raw: MetadataTags["raw"] = {};
-  const itemType = metadata.itemType.toLowerCase();
-  const showTitle = firstText(metadata.showTitle);
-  const seasonNumber = nonNegativeInteger(metadata.seasonNumber);
-  const episodeNumber = nonNegativeInteger(metadata.episodeNumber);
-  const network = firstText(metadata.network, metadata.studio);
-  const director = firstText(metadata.directors?.join(", "));
-  const longDescription = firstText(metadata.description, metadata.tagline);
-
-  if (longDescription) {
-    raw.ldes = longDescription;
-  }
-
-  if (director) {
-    raw["©dir"] = director;
-  }
-
-  const hdVideoFlag = inferHdVideoFlag(outputHeight);
-  if (hdVideoFlag !== undefined) {
-    raw.hdvd = uint8Atom(hdVideoFlag);
-  }
-
-  raw["©TIM"] = formatMetadataTimecode(startTime);
-  raw.csta = formatMetadataSeconds(startTime);
-  raw.cend = formatMetadataSeconds(endTime);
-  raw.cdur = formatMetadataSeconds(endTime - startTime);
-  raw.clpr = JSON.stringify({
-    sourceStartSeconds: Number(formatMetadataSeconds(startTime)),
-    sourceEndSeconds: Number(formatMetadataSeconds(endTime)),
-    sourceDurationSeconds: Number(formatMetadataSeconds(endTime - startTime)),
-  });
-
-  if (itemType === "episode") {
-    raw.stik = uint8Atom(10);
-
-    if (showTitle) {
-      raw.tvsh = showTitle;
-    }
-    if (seasonNumber !== undefined) {
-      raw.tvsn = uint32Atom(seasonNumber);
-    }
-    if (episodeNumber !== undefined) {
-      raw.tves = uint32Atom(episodeNumber);
-    }
-    if (seasonNumber !== undefined && episodeNumber !== undefined) {
-      raw.tven = `S${String(seasonNumber).padStart(2, "0")}E${String(episodeNumber).padStart(2, "0")}`;
-    }
-    if (network) {
-      raw.tvnn = network;
-    }
-  } else if (itemType === "movie") {
-    raw.stik = uint8Atom(9);
-  }
-
-  return Object.keys(raw).length > 0 ? raw : undefined;
-}
-
-function isIsobmffExportFormat(format: ExportFormat) {
-  return format === "mp4" || format === "mov";
 }
 
 function createOutputFormat(format: ExportFormat) {
@@ -348,88 +65,6 @@ function createOutputFormat(format: ExportFormat) {
     case "mkv":
       return new MkvOutputFormat();
   }
-}
-
-function inferImageMimeType(url: string) {
-  const pathname = new URL(url, window.location.href).pathname.toLowerCase();
-  if (pathname.endsWith(".png")) return "image/png";
-  if (pathname.endsWith(".webp")) return "image/webp";
-  if (pathname.endsWith(".gif")) return "image/gif";
-  if (pathname.endsWith(".bmp")) return "image/bmp";
-  return "image/jpeg";
-}
-
-async function fetchAttachedImage(url: string | undefined): Promise<NonNullable<MetadataTags["images"]>[number] | undefined> {
-  if (!url) {
-    return undefined;
-  }
-
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      return undefined;
-    }
-
-    const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
-    const mimeType = contentType?.startsWith("image/") ? contentType : inferImageMimeType(url);
-    const data = new Uint8Array(await response.arrayBuffer());
-
-    if (data.length === 0) {
-      return undefined;
-    }
-
-    return {
-      data,
-      mimeType,
-      kind: "coverFront",
-    };
-  } catch (err) {
-    console.warn("Could not embed clip artwork:", err);
-    return undefined;
-  }
-}
-
-async function buildMetadataTags(
-  metadata: MediaExportMetadata | undefined,
-  startTime: number,
-  endTime: number,
-  outputHeight: number | undefined,
-  format: ExportFormat
-): Promise<MetadataTags | undefined> {
-  if (!metadata) {
-    return undefined;
-  }
-
-  const title = firstText(metadata.title, metadata.sourceTitle);
-  const description = firstText(metadata.description, metadata.tagline);
-  const sourceTitle = firstText(metadata.showTitle);
-  const clipRange = `${formatMetadataTime(startTime)} to ${formatMetadataTime(endTime)}`;
-  const tags: MetadataTags = {};
-
-  if (title) tags.title = title;
-  if (description) tags.description = description;
-  if (metadata.genres?.length) tags.genre = metadata.genres.join(", ");
-
-  const date = parseMetadataDate(metadata.date, metadata.year);
-  if (date) tags.date = date;
-
-  const source = firstText(metadata.sourceTitle, metadata.title, sourceTitle, "source media");
-  const contentRating = firstText(metadata.contentRating);
-  tags.comment = `Clip from ${source}, ${clipRange}.${contentRating ? ` Content rating: ${contentRating}.` : ""}`;
-
-  const image = await fetchAttachedImage(metadata.imageUrl);
-  if (image) {
-    tags.images = [image];
-  }
-
-  const raw = isIsobmffExportFormat(format)
-    ? buildMp4RawTags(metadata, outputHeight, startTime, endTime)
-    : undefined;
-  if (raw) {
-    tags.raw = raw;
-  }
-
-  return Object.keys(tags).length > 0 ? tags : undefined;
 }
 
 function buildSubtitleBurnInProcessor(

--- a/apps/frontend/src/lib/exportMetadata.ts
+++ b/apps/frontend/src/lib/exportMetadata.ts
@@ -1,0 +1,373 @@
+import type { DiscardedTrack, MetadataTags } from "mediabunny";
+import type { MediaExportMetadata } from "../providers/types";
+import { describeInputTrack } from "./mediabunnyTrackAccess";
+import type { ExportFormat } from "./exportTypes";
+
+const discardReasonLabels: Record<DiscardedTrack["reason"], string> = {
+  discarded_by_user: "discarded by configuration",
+  max_track_count_reached: "the output track limit was reached",
+  max_track_count_of_type_reached: "the output cannot contain another track of this type",
+  unknown_source_codec: "the source codec is unknown",
+  undecodable_source_codec: "the source codec could not be decoded",
+  no_encodable_target_codec: "no compatible output codec could be encoded",
+};
+
+export async function describeDiscardedTracks(discardedTracks: readonly DiscardedTrack[]) {
+  if (discardedTracks.length === 0) {
+    return "";
+  }
+
+  const details = await Promise.all(
+    discardedTracks.map(async ({ track, reason }) =>
+      `${await describeInputTrack(track)}: ${discardReasonLabels[reason]}`
+    )
+  );
+
+  return details.join("; ");
+}
+
+function firstText(...values: Array<string | undefined>) {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
+}
+
+function nonNegativeInteger(value: number | undefined) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function parseMetadataDate(date: string | undefined, year: number | undefined) {
+  const dateText = firstText(date, year ? `${year}-01-01` : undefined);
+  if (!dateText) {
+    return undefined;
+  }
+
+  const parsed = new Date(dateText);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function formatMetadataTime(seconds: number) {
+  if (!Number.isFinite(seconds)) {
+    return "0:00";
+  }
+
+  const wholeSeconds = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(wholeSeconds / 3600);
+  const minutes = Math.floor((wholeSeconds % 3600) / 60);
+  const remainingSeconds = wholeSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${remainingSeconds.toString().padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+function formatMetadataTimecode(seconds: number) {
+  if (!Number.isFinite(seconds)) {
+    return "00:00:00.000";
+  }
+
+  const wholeMilliseconds = Math.max(0, Math.round(seconds * 1000));
+  const milliseconds = wholeMilliseconds % 1000;
+  const wholeSeconds = Math.floor(wholeMilliseconds / 1000);
+  const hours = Math.floor(wholeSeconds / 3600);
+  const minutes = Math.floor((wholeSeconds % 3600) / 60);
+  const remainingSeconds = wholeSeconds % 60;
+
+  return [
+    hours.toString().padStart(2, "0"),
+    minutes.toString().padStart(2, "0"),
+    remainingSeconds.toString().padStart(2, "0"),
+  ].join(":") + `.${milliseconds.toString().padStart(3, "0")}`;
+}
+
+function formatMetadataSeconds(seconds: number) {
+  if (!Number.isFinite(seconds)) {
+    return "0.000";
+  }
+
+  return Math.max(0, seconds).toFixed(3);
+}
+
+function uint8Atom(value: number) {
+  return new Uint8Array([Math.max(0, Math.min(255, value))]);
+}
+
+function uint32Atom(value: number) {
+  const safeValue = Math.max(0, Math.trunc(value));
+  return new Uint8Array([
+    (safeValue >>> 24) & 0xff,
+    (safeValue >>> 16) & 0xff,
+    (safeValue >>> 8) & 0xff,
+    safeValue & 0xff,
+  ]);
+}
+
+const mp4IntegerMetadataDataTypes: Record<string, number> = {
+  hdvd: 0x15,
+  stik: 0x15,
+  tves: 0x15,
+  tvsn: 0x16,
+};
+
+function readUint32(bytes: Uint8Array, offset: number) {
+  return (
+    bytes[offset] * 2 ** 24
+    + bytes[offset + 1] * 2 ** 16
+    + bytes[offset + 2] * 2 ** 8
+    + bytes[offset + 3]
+  );
+}
+
+function writeUint32(bytes: Uint8Array, offset: number, value: number) {
+  bytes[offset] = (value >>> 24) & 0xff;
+  bytes[offset + 1] = (value >>> 16) & 0xff;
+  bytes[offset + 2] = (value >>> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
+}
+
+function readBoxType(bytes: Uint8Array, offset: number) {
+  return String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]);
+}
+
+function boxBounds(bytes: Uint8Array, offset: number, end: number) {
+  const size32 = readUint32(bytes, offset);
+  const headerSize = size32 === 1 ? 16 : 8;
+  let size = size32;
+
+  if (size32 === 0) {
+    size = end - offset;
+  } else if (size32 === 1) {
+    if (offset + 16 > end) {
+      return undefined;
+    }
+
+    const high = readUint32(bytes, offset + 8);
+    const low = readUint32(bytes, offset + 12);
+    size = high * 2 ** 32 + low;
+  }
+
+  const boxEnd = offset + size;
+  if (size < headerSize || boxEnd > end || !Number.isSafeInteger(boxEnd)) {
+    return undefined;
+  }
+
+  return { headerSize, end: boxEnd };
+}
+
+function patchIlstItemDataType(bytes: Uint8Array, start: number, end: number, dataType: number) {
+  let offset = start;
+
+  while (offset + 8 <= end) {
+    const bounds = boxBounds(bytes, offset, end);
+    if (!bounds) {
+      return;
+    }
+
+    if (readBoxType(bytes, offset + 4) === "data") {
+      if (offset + bounds.headerSize + 4 > bounds.end) {
+        return;
+      }
+
+      writeUint32(bytes, offset + bounds.headerSize, dataType);
+      return;
+    }
+
+    offset = bounds.end;
+  }
+}
+
+export function patchMp4MetadataBoxes(bytes: Uint8Array, start = 0, end = bytes.length, parentType?: string) {
+  let offset = start;
+
+  while (offset + 8 <= end) {
+    const bounds = boxBounds(bytes, offset, end);
+    if (!bounds) {
+      return;
+    }
+
+    const type = readBoxType(bytes, offset + 4);
+    let contentStart = offset + bounds.headerSize;
+
+    if (parentType === "ilst") {
+      const dataType = mp4IntegerMetadataDataTypes[type];
+      if (dataType !== undefined) {
+        patchIlstItemDataType(bytes, contentStart, bounds.end, dataType);
+      }
+    }
+
+    if (type === "meta") {
+      contentStart += 4;
+    }
+
+    if (type === "moov" || type === "udta" || type === "meta" || type === "ilst") {
+      patchMp4MetadataBoxes(bytes, contentStart, bounds.end, type);
+    }
+
+    offset = bounds.end;
+  }
+}
+
+function inferHdVideoFlag(height: number | undefined) {
+  if (typeof height !== "number" || !Number.isFinite(height)) {
+    return undefined;
+  }
+
+  if (height >= 720) return 1;
+  return 0;
+}
+
+function buildMp4RawTags(
+  metadata: MediaExportMetadata,
+  outputHeight: number | undefined,
+  startTime: number,
+  endTime: number
+): MetadataTags["raw"] | undefined {
+  const raw: MetadataTags["raw"] = {};
+  const itemType = metadata.itemType.toLowerCase();
+  const showTitle = firstText(metadata.showTitle);
+  const seasonNumber = nonNegativeInteger(metadata.seasonNumber);
+  const episodeNumber = nonNegativeInteger(metadata.episodeNumber);
+  const network = firstText(metadata.network, metadata.studio);
+  const director = firstText(metadata.directors?.join(", "));
+  const longDescription = firstText(metadata.description, metadata.tagline);
+
+  if (longDescription) {
+    raw.ldes = longDescription;
+  }
+
+  if (director) {
+    raw["©dir"] = director;
+  }
+
+  const hdVideoFlag = inferHdVideoFlag(outputHeight);
+  if (hdVideoFlag !== undefined) {
+    raw.hdvd = uint8Atom(hdVideoFlag);
+  }
+
+  raw["©TIM"] = formatMetadataTimecode(startTime);
+  raw.csta = formatMetadataSeconds(startTime);
+  raw.cend = formatMetadataSeconds(endTime);
+  raw.cdur = formatMetadataSeconds(endTime - startTime);
+  raw.clpr = JSON.stringify({
+    sourceStartSeconds: Number(formatMetadataSeconds(startTime)),
+    sourceEndSeconds: Number(formatMetadataSeconds(endTime)),
+    sourceDurationSeconds: Number(formatMetadataSeconds(endTime - startTime)),
+  });
+
+  if (itemType === "episode") {
+    raw.stik = uint8Atom(10);
+
+    if (showTitle) {
+      raw.tvsh = showTitle;
+    }
+    if (seasonNumber !== undefined) {
+      raw.tvsn = uint32Atom(seasonNumber);
+    }
+    if (episodeNumber !== undefined) {
+      raw.tves = uint32Atom(episodeNumber);
+    }
+    if (seasonNumber !== undefined && episodeNumber !== undefined) {
+      raw.tven = `S${String(seasonNumber).padStart(2, "0")}E${String(episodeNumber).padStart(2, "0")}`;
+    }
+    if (network) {
+      raw.tvnn = network;
+    }
+  } else if (itemType === "movie") {
+    raw.stik = uint8Atom(9);
+  }
+
+  return Object.keys(raw).length > 0 ? raw : undefined;
+}
+
+export function isIsobmffExportFormat(format: ExportFormat) {
+  return format === "mp4" || format === "mov";
+}
+
+function inferImageMimeType(url: string) {
+  const pathname = new URL(url, window.location.href).pathname.toLowerCase();
+  if (pathname.endsWith(".png")) return "image/png";
+  if (pathname.endsWith(".webp")) return "image/webp";
+  if (pathname.endsWith(".gif")) return "image/gif";
+  if (pathname.endsWith(".bmp")) return "image/bmp";
+  return "image/jpeg";
+}
+
+async function fetchAttachedImage(url: string | undefined): Promise<NonNullable<MetadataTags["images"]>[number] | undefined> {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+    const mimeType = contentType?.startsWith("image/") ? contentType : inferImageMimeType(url);
+    const data = new Uint8Array(await response.arrayBuffer());
+
+    if (data.length === 0) {
+      return undefined;
+    }
+
+    return {
+      data,
+      mimeType,
+      kind: "coverFront",
+    };
+  } catch (err) {
+    console.warn("Could not embed clip artwork:", err);
+    return undefined;
+  }
+}
+
+export async function buildMetadataTags(
+  metadata: MediaExportMetadata | undefined,
+  startTime: number,
+  endTime: number,
+  outputHeight: number | undefined,
+  format: ExportFormat
+): Promise<MetadataTags | undefined> {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const title = firstText(metadata.title, metadata.sourceTitle);
+  const description = firstText(metadata.description, metadata.tagline);
+  const sourceTitle = firstText(metadata.showTitle);
+  const clipRange = `${formatMetadataTime(startTime)} to ${formatMetadataTime(endTime)}`;
+  const tags: MetadataTags = {};
+
+  if (title) tags.title = title;
+  if (description) tags.description = description;
+  if (metadata.genres?.length) tags.genre = metadata.genres.join(", ");
+
+  const date = parseMetadataDate(metadata.date, metadata.year);
+  if (date) tags.date = date;
+
+  const source = firstText(metadata.sourceTitle, metadata.title, sourceTitle, "source media");
+  const contentRating = firstText(metadata.contentRating);
+  tags.comment = `Clip from ${source}, ${clipRange}.${contentRating ? ` Content rating: ${contentRating}.` : ""}`;
+
+  const image = await fetchAttachedImage(metadata.imageUrl);
+  if (image) {
+    tags.images = [image];
+  }
+
+  const raw = isIsobmffExportFormat(format)
+    ? buildMp4RawTags(metadata, outputHeight, startTime, endTime)
+    : undefined;
+  if (raw) {
+    tags.raw = raw;
+  }
+
+  return Object.keys(tags).length > 0 ? tags : undefined;
+}

--- a/apps/frontend/src/lib/exportTypes.ts
+++ b/apps/frontend/src/lib/exportTypes.ts
@@ -1,0 +1,3 @@
+export type ExportFormat = "mp4" | "webm" | "mov" | "mkv";
+
+export type ExportResolution = "original" | "1080" | "720";

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
-import { and, asc, eq, sql, type SQL } from "drizzle-orm";
+import { and, asc, eq, type SQL } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { mediaSources, type MediaSourceRow } from "./schema.js";
+import { currentTimestampSql } from "./timestamps.js";
 import { decryptJsonSecrets, encryptJsonSecrets } from "../security/secrets.js";
 
 export interface MediaSource {
@@ -118,7 +119,7 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       ...(input.lastCheckedAt !== undefined ? { lastCheckedAt: input.lastCheckedAt } : {}),
       ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
-      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      updatedAt: currentTimestampSql(),
     })
     .where(eq(mediaSources.id, id))
     .run();
@@ -194,7 +195,7 @@ export function upsertMediaSource(input: CreateMediaSourceInput) {
         ...(input.connection !== undefined ? { connection: encryptJsonSecrets(input.connection) } : {}),
         ...(input.credentials !== undefined ? { credentials: encryptJsonSecrets(input.credentials) } : {}),
         ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-        updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+        updatedAt: currentTimestampSql(),
       },
     })
     .run();
@@ -243,7 +244,7 @@ export function updateMediaSourceForAccount(id: string, providerAccountId: strin
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       ...(input.lastCheckedAt !== undefined ? { lastCheckedAt: input.lastCheckedAt } : {}),
       ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
-      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      updatedAt: currentTimestampSql(),
     })
     .where(and(
       eq(mediaSources.id, id),
@@ -264,7 +265,7 @@ export function updateMediaSourceHealthForAccount(
     .set({
       lastCheckedAt: input.lastCheckedAt,
       lastError: input.lastError ?? null,
-      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      updatedAt: currentTimestampSql(),
     })
     .where(and(
       eq(mediaSources.id, id),

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { providerAccounts, type ProviderAccountRow } from "./schema.js";
+import { currentTimestampSql } from "./timestamps.js";
 import { decryptSecret, encryptSecret, hashSecret } from "../security/secrets.js";
 
 export interface ProviderAccount {
@@ -74,7 +75,7 @@ function updateProviderAccount(id: string, input: UpdateProviderAccountInput) {
         }
         : {}),
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      updatedAt: currentTimestampSql(),
     })
     .where(eq(providerAccounts.id, id))
     .run();
@@ -152,7 +153,7 @@ export function upsertProviderAccountByAccessToken(input: CreateProviderAccountI
         accessToken: encryptSecret(input.accessToken),
         accessTokenHash: hashSecret(input.accessToken),
         ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-        updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+        updatedAt: currentTimestampSql(),
       },
     })
     .run();

--- a/apps/server/src/db/rememberedProviderSessionsRepository.ts
+++ b/apps/server/src/db/rememberedProviderSessionsRepository.ts
@@ -1,7 +1,8 @@
 import { randomBytes, randomUUID } from "crypto";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { getDatabase } from "./database.js";
 import { rememberedProviderSessions, type RememberedProviderSessionRow } from "./schema.js";
+import { currentTimestampSql } from "./timestamps.js";
 import { hashSecret } from "../security/secrets.js";
 
 export const REMEMBERED_PROVIDER_SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 365;
@@ -87,7 +88,7 @@ export function revokeRememberedProviderSession(token?: string) {
     .update(rememberedProviderSessions)
     .set({
       revokedAt: now,
-      updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      updatedAt: currentTimestampSql(),
     })
     .where(eq(rememberedProviderSessions.tokenHash, hashSecret(token)))
     .run();

--- a/apps/server/src/db/timestamps.ts
+++ b/apps/server/src/db/timestamps.ts
@@ -1,0 +1,5 @@
+import { sql } from "drizzle-orm";
+
+export function currentTimestampSql() {
+  return sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`;
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm -r --if-present lint:eslint",
     "lint:types": "pnpm -r --if-present lint:types",
-    "test": "pnpm --filter @cliparr/server test",
+    "test": "pnpm --filter @cliparr/server test && pnpm --filter @cliparr/frontend test",
     "knip": "knip",
     "preview": "pnpm --filter @cliparr/server preview",
     "start": "pnpm --filter @cliparr/server start",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ~6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- Split editor export, keyboard shortcut, timeline zoom, playback source, render loop, audio, sink lifecycle, and HLS warmup responsibilities into focused helpers/hooks.
- Split provider connection presentation and source modal state to reduce large component complexity.
- Extract export metadata/tagging helpers and shared export types from the conversion pipeline.
- Add focused frontend tests for subtitle export summaries, timeline zoom math, and playback source fallback behavior.

## Validation
- pnpm lint
- pnpm test

## Notes
- Functionality should be maintained; this PR is intentionally organized as separate refactor commits for easier review.