### PR TITLE
[codex] Add local video support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Before opening a pull request, run:
 
 ```sh
 pnpm lint
+pnpm test
+pnpm knip
 pnpm build
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-**Cliparr** is a streamlined media clipper that allows you to quickly create and download clips from the media currently playing on your Plex or Jellyfin server.
+**Cliparr** is a streamlined media clipper that allows you to quickly create and download clips from the media currently playing on your Plex or Jellyfin server, or from a local video file opened directly in your browser.
 
 <video src="https://github.com/user-attachments/assets/4f9d5f6b-8016-4068-b375-f050d57de534" width="100%" alt="Cliparr Demo">
 </video>
@@ -21,6 +21,7 @@
 ## Features
 
 - **Instant Session Discovery**: Automatically loads your media player's currently playing file.
+- **Local Video Opening**: Open a local file or direct media URL before or after connecting a provider.
 - **Intuitive Timeline Editor**: Familiar UI based on common video editing interfaces.
 - **Local Transcoding**: Powered by [Mediabunny](https://mediabunny.dev/), video is transcoded in your browser.
 - **Rich Metadata Tagging**: Clips are exported with full EXIF data, including Season, Episode numbers, and timing metadata.
@@ -46,6 +47,12 @@ docker run -d \
 
 > [!IMPORTANT]
 > **Use HTTPS for editing**: Cliparr's editor uses browser WebCodecs. Supporting browsers require a secure context. Use an HTTPS reverse proxy like Caddy, or local `localhost` / `127.0.0.1`.
+
+### Local Videos
+
+Use **Open Video** on the connect screen or dashboard to open a file from your device or a direct media URL. Files are read by the browser with Mediabunny and are not uploaded to the Cliparr server. Browsers that support persistent file handles can reopen the selected file after refresh once you grant permission again; other file input and drag-and-drop sessions stay available only while the tab is open.
+
+URL media is also read by the browser, so the remote server must allow CORS and byte-range requests. HLS `.m3u8` URLs can be opened when their playlist and segment URLs are browser-readable.
 
 ### Using Docker Compose
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,7 +8,7 @@
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm exec eslint \"src/**/*.{ts,tsx}\" vite.config.js",
     "lint:types": "tsc --noEmit",
-    "test": "node --import tsx --test src/**/*.test.ts",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, LogOut, Play, RefreshCw, Settings2, Video } from "lucide-react";
+import { AlertTriangle, FolderOpen, LogOut, Play, RefreshCw, Settings2, Video } from "lucide-react";
 import { cliparrClient } from "../api/cliparrClient";
 import { formatProviderName, ProviderGlyph } from "./ProviderGlyph";
 import type { CurrentlyPlayingItem, SourcePlaybackError, ViewerPlaybackGroup } from "../providers/types";
 
 interface Props {
   onSelectSession: (session: CurrentlyPlayingItem) => void;
+  onOpenLocalVideo: () => void;
   onOpenSources: () => void;
   onLogout: () => Promise<void> | void;
 }
@@ -100,7 +101,7 @@ function WarningBanner({ sourceErrors }: { sourceErrors: SourcePlaybackError[] }
   );
 }
 
-export default function DashboardScreen({ onSelectSession, onOpenSources, onLogout }: Props) {
+export default function DashboardScreen({ onSelectSession, onOpenLocalVideo, onOpenSources, onLogout }: Props) {
   const [viewers, setViewers] = useState<ViewerPlaybackGroup[]>([]);
   const [sourceErrors, setSourceErrors] = useState<SourcePlaybackError[]>([]);
   const [appVersion, setAppVersion] = useState("");
@@ -183,6 +184,14 @@ export default function DashboardScreen({ onSelectSession, onOpenSources, onLogo
               <GithubIcon className="h-4 w-4" />
               <span className="hidden sm:inline">GitHub</span>
             </a>
+            <button
+              type="button"
+              onClick={onOpenLocalVideo}
+              className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <FolderOpen className="w-4 h-4" />
+              Open Video
+            </button>
             <button
               type="button"
               onClick={onOpenSources}

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -15,7 +15,8 @@ import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
 import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
 import { useSubtitleCues } from "./editor/useSubtitleCues";
-import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../providers/types";
+import type { PlaybackSubtitleTrack } from "../providers/types";
+import { sourceDisplayLabel, type EditorSession } from "../lib/editorMedia";
 import {
   selectPreferredSubtitleTrack,
   subtitleTrackKey,
@@ -28,7 +29,7 @@ import {
 import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
 
 interface Props {
-  session: CurrentlyPlayingItem;
+  session: EditorSession;
   onBack: () => void;
 }
 
@@ -41,8 +42,10 @@ export default function EditorScreen({ session, onBack }: Props) {
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState("none");
 
   const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
-    () => (session.subtitleTracks ?? []).filter((track) => subtitleTrackSupportsBurnIn(track)),
-    [session.subtitleTracks]
+    () => session.local
+      ? []
+      : (session.subtitleTracks ?? []).filter((track) => subtitleTrackSupportsBurnIn(track)),
+    [session.local, session.subtitleTracks]
   );
   const selectedSubtitleTrack = useMemo(() => {
     if (selectedSubtitleTrackKey === "none") {
@@ -96,7 +99,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     previewStatus,
     error,
     activeSourceLabel,
-    exportFallbackSourceUrl,
+    exportFallbackSource,
     hlsFallbackInfo,
     sourceVideoDimensions,
     playbackReadyRange,
@@ -111,8 +114,8 @@ export default function EditorScreen({ session, onBack }: Props) {
     setCurrentTime,
     playbackTimeAtStartRef,
   } = useEditorPlayback({
-    hlsUrl: session.hlsUrl,
-    mediaUrl: session.mediaUrl,
+    hlsSource: session.hlsSource,
+    directSource: session.directSource,
     initialDuration: session.duration,
     startTime,
     endTime,
@@ -154,7 +157,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     startTime,
     endTime,
     sourceVideoDimensions,
-    exportFallbackSourceUrl,
+    exportFallbackSource,
     hlsFallbackInfo,
     subtitleEnabled,
     selectedSubtitleTrack,
@@ -165,10 +168,11 @@ export default function EditorScreen({ session, onBack }: Props) {
   });
   const playbackFallbackReason = buildPlaybackFallbackReason({
     activeSourceLabel,
-    hlsUrl: session.hlsUrl,
+    hasHlsSource: Boolean(session.hlsSource),
     hlsFallbackInfo,
   });
   const previewSourceLabel = activeSourceLabel || (loadingPreview ? "Resolving stream" : "Unavailable");
+  const isHlsPreviewSource = previewSourceLabel === "HLS stream" || previewSourceLabel === "HLS URL";
 
   const updateClipRange = useCallback((nextStart: number, nextEnd: number) => {
     if (!duration || duration <= 0) return;
@@ -269,7 +273,7 @@ export default function EditorScreen({ session, onBack }: Props) {
 
   useEditorKeyboardShortcuts({ togglePlay });
 
-  if (!exportSource.url) {
+  if (!exportSource.source) {
     return (
       <div className="flex h-dvh items-center justify-center overflow-hidden bg-background p-8 text-foreground">
         <div className="text-center">
@@ -303,7 +307,7 @@ export default function EditorScreen({ session, onBack }: Props) {
               <EditorPlaybackSourcePanel
                 previewSourceLabel={previewSourceLabel}
                 fallbackMessage={playbackFallbackReason}
-                hasHlsSource={Boolean(session.hlsUrl)}
+                hasHlsSource={Boolean(session.hlsSource)}
               />
             </div>
 
@@ -353,7 +357,7 @@ export default function EditorScreen({ session, onBack }: Props) {
                     timelineScaleCount={timelineScaleCount}
                     timelineScrollLeft={timelineScrollLeft}
                     timelineViewportWidth={timelineViewportWidth}
-                    playbackReadyRange={previewSourceLabel === "HLS stream" ? playbackReadyRange : null}
+                    playbackReadyRange={isHlsPreviewSource ? playbackReadyRange : null}
                     loadingPreview={loadingPreview}
                     playing={playing}
                     handleTimelineScroll={handleTimelineScroll}
@@ -376,21 +380,23 @@ export default function EditorScreen({ session, onBack }: Props) {
               )}
             </section>
 
-            <div className="min-h-[28rem] lg:hidden">
-              <EditorSubtitlePanel
-                providerId={session.source.providerId}
-                subtitleTracks={subtitleTracks}
-                selectedSubtitleTrackKey={selectedSubtitleTrackKey}
-                onSelectedSubtitleTrackKeyChange={handleSelectedSubtitleTrackChange}
-                subtitlesEnabled={subtitleEnabled}
-                onSubtitlesEnabledChange={setSubtitleEnabled}
-                subtitleStyleSettings={subtitleStyleSettings}
-                onSubtitleStyleSettingsChange={setSubtitleStyleSettings}
-                subtitleLoading={subtitleLoading}
-                subtitleError={subtitleError}
-                selectedSubtitleTrack={selectedSubtitleTrack}
-              />
-            </div>
+            {!session.local && (
+              <div className="min-h-[28rem] lg:hidden">
+                <EditorSubtitlePanel
+                  providerId={session.source.providerId}
+                  subtitleTracks={subtitleTracks}
+                  selectedSubtitleTrackKey={selectedSubtitleTrackKey}
+                  onSelectedSubtitleTrackKeyChange={handleSelectedSubtitleTrackChange}
+                  subtitlesEnabled={subtitleEnabled}
+                  onSubtitlesEnabledChange={setSubtitleEnabled}
+                  subtitleStyleSettings={subtitleStyleSettings}
+                  onSubtitleStyleSettingsChange={setSubtitleStyleSettings}
+                  subtitleLoading={subtitleLoading}
+                  subtitleError={subtitleError}
+                  selectedSubtitleTrack={selectedSubtitleTrack}
+                />
+              </div>
+            )}
           </div>
 
           <div className="hidden min-h-0 lg:block">
@@ -405,24 +411,26 @@ export default function EditorScreen({ session, onBack }: Props) {
                 <EditorPlaybackSourcePanel
                   previewSourceLabel={previewSourceLabel}
                   fallbackMessage={playbackFallbackReason}
-                  hasHlsSource={Boolean(session.hlsUrl)}
+                  hasHlsSource={Boolean(session.hlsSource)}
                   className="shrink-0 p-0"
                 />
-                <div className="min-h-[28rem] flex-1">
-                  <EditorSubtitlePanel
-                    providerId={session.source.providerId}
-                    subtitleTracks={subtitleTracks}
-                    selectedSubtitleTrackKey={selectedSubtitleTrackKey}
-                    onSelectedSubtitleTrackKeyChange={handleSelectedSubtitleTrackChange}
-                    subtitlesEnabled={subtitleEnabled}
-                    onSubtitlesEnabledChange={setSubtitleEnabled}
-                    subtitleStyleSettings={subtitleStyleSettings}
-                    onSubtitleStyleSettingsChange={setSubtitleStyleSettings}
-                    subtitleLoading={subtitleLoading}
-                    subtitleError={subtitleError}
-                    selectedSubtitleTrack={selectedSubtitleTrack}
-                  />
-                </div>
+                {!session.local && (
+                  <div className="min-h-[28rem] flex-1">
+                    <EditorSubtitlePanel
+                      providerId={session.source.providerId}
+                      subtitleTracks={subtitleTracks}
+                      selectedSubtitleTrackKey={selectedSubtitleTrackKey}
+                      onSelectedSubtitleTrackKeyChange={handleSelectedSubtitleTrackChange}
+                      subtitlesEnabled={subtitleEnabled}
+                      onSubtitlesEnabledChange={setSubtitleEnabled}
+                      subtitleStyleSettings={subtitleStyleSettings}
+                      onSubtitleStyleSettingsChange={setSubtitleStyleSettings}
+                      subtitleLoading={subtitleLoading}
+                      subtitleError={subtitleError}
+                      selectedSubtitleTrack={selectedSubtitleTrack}
+                    />
+                  </div>
+                )}
               </div>
             </EditorSidebar>
           </div>
@@ -447,8 +455,10 @@ export default function EditorScreen({ session, onBack }: Props) {
         error={exportError}
         fileNamePreview={fileName.fullName}
         outputDimensions={outputDimensions}
-        hasHlsSource={Boolean(session.hlsUrl)}
-        hasDirectSource={Boolean(session.mediaUrl)}
+        hasHlsSource={Boolean(session.hlsSource)}
+        hasDirectSource={Boolean(session.directSource)}
+        directSourceLabel={session.directSource ? sourceDisplayLabel(session.directSource) : "Direct/original"}
+        hlsSourceLabel={session.hlsSource ? sourceDisplayLabel(session.hlsSource) : "HLS playback"}
         exportSourceLabel={exportSourceLabel}
         exportSourceMessage={exportSourceMessage}
         exportSourceSummaryMessage={exportSourceSummaryMessage}
@@ -471,14 +481,18 @@ export default function EditorScreen({ session, onBack }: Props) {
 
 function buildPlaybackFallbackReason({
   activeSourceLabel,
-  hlsUrl,
+  hasHlsSource,
   hlsFallbackInfo,
 }: {
   activeSourceLabel: string;
-  hlsUrl?: string;
+  hasHlsSource: boolean;
   hlsFallbackInfo: PlaybackFallbackInfo | null;
 }) {
-  if (activeSourceLabel !== "Direct source" || !hlsUrl || !hlsFallbackInfo) {
+  if (
+    (activeSourceLabel !== "Direct source" && activeSourceLabel !== "Local file" && activeSourceLabel !== "URL")
+    || !hasHlsSource
+    || !hlsFallbackInfo
+  ) {
     return null;
   }
 

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -273,6 +273,11 @@ export default function EditorScreen({ session, onBack }: Props) {
 
   useEditorKeyboardShortcuts({ togglePlay });
 
+  const durationExportDisabledReason = !hasDuration
+    ? "Waiting for media duration before export is available."
+    : null;
+  const exportDisabledReason = durationExportDisabledReason ?? subtitleExportSummary.disabledReason;
+
   if (!exportSource.source) {
     return (
       <div className="flex h-dvh items-center justify-center overflow-hidden bg-background p-8 text-foreground">
@@ -291,6 +296,7 @@ export default function EditorScreen({ session, onBack }: Props) {
         onBack={onBack}
         exporting={exporting}
         progress={progress}
+        exportDisabledReason={exportDisabledReason}
         onExportClick={handleOpenExportDialog}
       />
 
@@ -465,7 +471,7 @@ export default function EditorScreen({ session, onBack }: Props) {
         subtitleSummaryLabel={subtitleExportSummary.label}
         subtitleSummaryDetail={subtitleExportSummary.detail}
         subtitleSummaryTone={subtitleExportSummary.tone}
-        exportDisabledReason={subtitleExportSummary.disabledReason}
+        exportDisabledReason={exportDisabledReason}
         activeTemplateKind={fileName.templateKind}
         editingTemplateKind={templateEditorKind}
         onEditingTemplateKindChange={setTemplateEditorKind}

--- a/apps/frontend/src/components/LocalVideoOpenModal.tsx
+++ b/apps/frontend/src/components/LocalVideoOpenModal.tsx
@@ -1,0 +1,283 @@
+import { FileVideo, FolderOpen, Link, Upload, X } from "lucide-react";
+import { useCallback, useRef, useState, type DragEvent, type FormEvent } from "react";
+import {
+  createLocalSessionFromFile,
+  createLocalSessionFromPicker,
+  createLocalSessionFromUrl,
+  LOCAL_VIDEO_FILE_ACCEPT,
+  localMediaPickerSupported,
+} from "../lib/localMediaRegistry";
+import { useModalFocusTrap } from "./useModalFocusTrap";
+
+interface LocalVideoOpenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onOpened: (sessionId: string) => void;
+}
+
+type LocalOpenTab = "file" | "url";
+
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpenModalProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const initialFocusRef = useRef<HTMLButtonElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [activeTab, setActiveTab] = useState<LocalOpenTab>("file");
+  const [urlValue, setUrlValue] = useState("");
+  const [opening, setOpening] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const [error, setError] = useState("");
+
+  useModalFocusTrap({
+    isOpen,
+    dialogRef,
+    initialFocusRef,
+    onEscape: opening ? undefined : onClose,
+  });
+
+  const completeOpen = useCallback((sessionId: string) => {
+    setError("");
+    setUrlValue("");
+    onClose();
+    onOpened(sessionId);
+  }, [onClose, onOpened]);
+
+  const openFile = useCallback(async (file: File | null | undefined) => {
+    if (!file) {
+      return;
+    }
+
+    setOpening(true);
+    setError("");
+    try {
+      const session = await createLocalSessionFromFile(file);
+      completeOpen(session.id);
+    } catch (err) {
+      setError(errorMessage(err, "Could not open that file."));
+    } finally {
+      setOpening(false);
+    }
+  }, [completeOpen]);
+
+  const handleChooseFile = useCallback(async () => {
+    setError("");
+
+    if (!localMediaPickerSupported()) {
+      fileInputRef.current?.click();
+      return;
+    }
+
+    setOpening(true);
+    try {
+      const result = await createLocalSessionFromPicker();
+      if (result.status === "ready") {
+        completeOpen(result.session.id);
+        return;
+      }
+
+      if (result.status === "unsupported") {
+        fileInputRef.current?.click();
+        return;
+      }
+
+      if (result.status === "error") {
+        setError(result.message);
+      }
+    } catch (err) {
+      setError(errorMessage(err, "Could not open that file."));
+    } finally {
+      setOpening(false);
+    }
+  }, [completeOpen]);
+
+  const handleDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragActive(false);
+    void openFile(event.dataTransfer.files.item(0));
+  }, [openFile]);
+
+  const handleUrlSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setOpening(true);
+    setError("");
+
+    try {
+      const result = await createLocalSessionFromUrl(urlValue);
+      if (result.status === "ready") {
+        completeOpen(result.session.id);
+        return;
+      }
+
+      setError(result.message);
+    } catch (err) {
+      setError(errorMessage(err, "Could not open that URL."));
+    } finally {
+      setOpening(false);
+    }
+  }, [completeOpen, urlValue]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color-mix(in_oklch,var(--foreground)_40%,transparent)] p-4 backdrop-blur-sm"
+      role="presentation"
+      onClick={() => {
+        if (!opening) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cliparr-local-open-title"
+        tabIndex={-1}
+        className="mx-auto flex max-h-full w-full max-w-xl flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="space-y-1">
+            <h2 id="cliparr-local-open-title" className="text-sm font-semibold uppercase tracking-[var(--tracking-caps-md)] text-foreground">
+              Open Video
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              Local files stay in your browser. URL media must allow browser reads.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={opening}
+            aria-label="Close local video dialog"
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="border-b border-border px-4 pt-3">
+          <div className="grid grid-cols-2 rounded-md border border-border bg-background p-1">
+            <button
+              ref={initialFocusRef}
+              type="button"
+              onClick={() => {
+                setActiveTab("file");
+                setError("");
+              }}
+              className={`inline-flex h-8 items-center justify-center gap-2 rounded-[var(--radius-control)] px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] transition-colors ${
+                activeTab === "file"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+              }`}
+            >
+              <FileVideo className="h-4 w-4" />
+              File
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setActiveTab("url");
+                setError("");
+              }}
+              className={`inline-flex h-8 items-center justify-center gap-2 rounded-[var(--radius-control)] px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] transition-colors ${
+                activeTab === "url"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+              }`}
+            >
+              <Link className="h-4 w-4" />
+              URL
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 overflow-y-auto p-4">
+          {error && (
+            <div className="mb-4 rounded-md border border-destructive/35 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          {activeTab === "file" ? (
+            <div
+              onDragOver={(event) => {
+                event.preventDefault();
+                setDragActive(true);
+              }}
+              onDragLeave={() => setDragActive(false)}
+              onDrop={handleDrop}
+              className={`flex min-h-52 flex-col items-center justify-center border border-dashed p-6 text-center transition-colors ${
+                dragActive
+                  ? "border-primary bg-primary/8"
+                  : "border-border bg-background"
+              }`}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={LOCAL_VIDEO_FILE_ACCEPT}
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.currentTarget.files?.item(0) ?? null;
+                  event.currentTarget.value = "";
+                  void openFile(file);
+                }}
+              />
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card text-muted-foreground">
+                <Upload className="h-5 w-5" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">Drop a video file here</p>
+                <p className="text-xs text-muted-foreground">MP4, MOV, MKV, WebM, Ogg video, and MPEG-TS are supported when your browser can decode them.</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleChooseFile()}
+                disabled={opening}
+                className="mt-5 inline-flex h-9 items-center justify-center gap-2 rounded-md border border-primary bg-primary px-4 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <FolderOpen className="h-4 w-4" />
+                {opening ? "Opening" : "Choose File"}
+              </button>
+            </div>
+          ) : (
+            <form className="space-y-4" onSubmit={(event) => void handleUrlSubmit(event)}>
+              <label className="block space-y-1.5">
+                <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
+                  Media URL
+                </span>
+                <input
+                  type="url"
+                  value={urlValue}
+                  onChange={(event) => setUrlValue(event.target.value)}
+                  placeholder="https://example.com/video.mp4"
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/40"
+                />
+              </label>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Direct media files and HLS playlists can work when the remote server permits CORS and byte-range requests from this browser.
+              </p>
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={opening}
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-primary bg-primary px-4 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <Link className="h-4 w-4" />
+                  {opening ? "Opening" : "Open URL"}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ProviderConnectScreen.tsx
+++ b/apps/frontend/src/components/ProviderConnectScreen.tsx
@@ -1,11 +1,13 @@
+import { FolderOpen } from "lucide-react";
 import ProviderConnectFlow from "./ProviderConnectFlow";
 import type { ProviderSession } from "../providers/types";
 
 interface Props {
   onConnected: (session: ProviderSession) => Promise<void> | void;
+  onOpenLocalVideo: () => void;
 }
 
-export default function ProviderConnectScreen({ onConnected }: Props) {
+export default function ProviderConnectScreen({ onConnected, onOpenLocalVideo }: Props) {
   return (
     <div className="flex min-h-screen items-start justify-center bg-background p-4 pt-6 text-foreground sm:items-center">
       <div className="relative w-full max-w-5xl overflow-hidden rounded-4xl border border-border bg-card text-card-foreground shadow-2xl">
@@ -23,6 +25,16 @@ export default function ProviderConnectScreen({ onConnected }: Props) {
           <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-6 text-muted-foreground">
             Select a provider. You will be able to add more providers later.
           </p>
+          <div className="mt-5 flex justify-center">
+            <button
+              type="button"
+              onClick={onOpenLocalVideo}
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-foreground transition-colors hover:bg-accent"
+            >
+              <FolderOpen className="h-4 w-4" />
+              Open Video
+            </button>
+          </div>
         </div>
 
         <div className="relative px-6 py-6 sm:px-8">

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -40,6 +40,8 @@ interface EditorExportDialogProps {
   outputDimensions: VideoDimensions | null;
   hasHlsSource: boolean;
   hasDirectSource: boolean;
+  directSourceLabel: string;
+  hlsSourceLabel: string;
   exportSourceLabel: string;
   exportSourceMessage: string | null;
   exportSourceSummaryMessage: string | null;
@@ -77,6 +79,8 @@ export function EditorExportDialog({
   outputDimensions,
   hasHlsSource,
   hasDirectSource,
+  directSourceLabel,
+  hlsSourceLabel,
   exportSourceLabel,
   exportSourceMessage,
   exportSourceSummaryMessage,
@@ -173,6 +177,8 @@ export function EditorExportDialog({
               onIncludeAudioChange={onIncludeAudioChange}
               hasHlsSource={hasHlsSource}
               hasDirectSource={hasDirectSource}
+              directSourceLabel={directSourceLabel}
+              hlsSourceLabel={hlsSourceLabel}
             />
 
             <EditorFilenameTemplateSection

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -80,24 +80,6 @@ const resolutionOptions: ReadonlyArray<ExportOption<ExportResolution>> = [
   },
 ];
 
-const sourceOptions: ReadonlyArray<ExportOption<ExportSourcePreference>> = [
-  {
-    value: "auto",
-    label: "Auto",
-    description: "Lets Cliparr choose the safest export path for this session.",
-  },
-  {
-    value: "direct",
-    label: "Direct/original",
-    description: "Uses the direct media path when available, usually best for preserving source quality.",
-  },
-  {
-    value: "hls",
-    label: "HLS playback",
-    description: "Uses the media server playback stream, which may include server-side transcoding.",
-  },
-];
-
 const templateOptions: ReadonlyArray<{
   kind: ExportFileNameTemplateKind;
   label: string;
@@ -131,7 +113,34 @@ function resolutionOptionFor(resolution: ExportResolution) {
   return resolutionOptions.find((option) => option.value === resolution) ?? resolutionOptions[0];
 }
 
-function sourceOptionFor(preference: ExportSourcePreference) {
+function sourceOptionsFor(labels: {
+  directSourceLabel: string;
+  hlsSourceLabel: string;
+}): ReadonlyArray<ExportOption<ExportSourcePreference>> {
+  return [
+    {
+      value: "auto",
+      label: "Auto",
+      description: "Lets Cliparr choose the safest export path for this session.",
+    },
+    {
+      value: "direct",
+      label: labels.directSourceLabel,
+      description: "Uses the direct media path when available, usually best for preserving source quality.",
+    },
+    {
+      value: "hls",
+      label: labels.hlsSourceLabel,
+      description: "Uses the playback stream or HLS playlist for this export.",
+    },
+  ];
+}
+
+function sourceOptionFor(
+  preference: ExportSourcePreference,
+  labels: { directSourceLabel: string; hlsSourceLabel: string },
+) {
+  const sourceOptions = sourceOptionsFor(labels);
   return sourceOptions.find((option) => option.value === preference) ?? sourceOptions[0];
 }
 
@@ -160,6 +169,8 @@ interface EditorExportSettingsSectionProps {
   onIncludeAudioChange: (includeAudio: boolean) => void;
   hasHlsSource: boolean;
   hasDirectSource: boolean;
+  directSourceLabel: string;
+  hlsSourceLabel: string;
 }
 
 export function EditorExportSettingsSection({
@@ -173,7 +184,11 @@ export function EditorExportSettingsSection({
   onIncludeAudioChange,
   hasHlsSource,
   hasDirectSource,
+  directSourceLabel,
+  hlsSourceLabel,
 }: EditorExportSettingsSectionProps) {
+  const sourceOptions = sourceOptionsFor({ directSourceLabel, hlsSourceLabel });
+
   return (
     <section className="rounded-md border border-border bg-card">
       <SectionHeader>Export Settings</SectionHeader>
@@ -269,7 +284,9 @@ export function EditorExportSettingsSection({
               </SelectGroup>
             </SelectContent>
           </Select>
-          <p className="text-xs text-muted-foreground">{sourceOptionFor(selectedSourcePreference).description}</p>
+          <p className="text-xs text-muted-foreground">
+            {sourceOptionFor(selectedSourcePreference, { directSourceLabel, hlsSourceLabel }).description}
+          </p>
         </div>
 
         <label className="space-y-1.5">

--- a/apps/frontend/src/components/editor/EditorHeader.tsx
+++ b/apps/frontend/src/components/editor/EditorHeader.tsx
@@ -5,6 +5,7 @@ interface EditorHeaderProps {
   onBack: () => void;
   exporting: boolean;
   progress: number;
+  exportDisabledReason?: string | null;
   onExportClick: () => void;
 }
 
@@ -13,8 +14,11 @@ export function EditorHeader({
   onBack,
   exporting,
   progress,
+  exportDisabledReason,
   onExportClick,
 }: EditorHeaderProps) {
+  const exportDisabled = exporting || Boolean(exportDisabledReason);
+
   return (
     <header className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border bg-card px-3 py-2">
       <div className="flex items-center gap-2">
@@ -40,7 +44,8 @@ export function EditorHeader({
         <button
           type="button"
           onClick={onExportClick}
-          disabled={exporting}
+          disabled={exportDisabled}
+          title={exportDisabledReason ?? undefined}
           className="flex h-8 min-w-36 items-center justify-center gap-2 rounded-[var(--radius-control)] border border-primary bg-primary px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {exporting ? (

--- a/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
@@ -25,9 +25,10 @@ export function EditorPlaybackSourcePanel({
   hasHlsSource,
   className,
 }: EditorPlaybackSourcePanelProps) {
-  const sourceNote = !hasHlsSource
-    ? "This session did not expose an HLS stream, so Cliparr is using the direct media path."
-    : fallbackMessage;
+  const sourceNote = fallbackMessage
+    ?? (!hasHlsSource && previewSourceLabel === "Direct source"
+      ? "This session did not expose an HLS stream, so Cliparr is using the direct media path."
+      : null);
 
   return (
     <section className={cn("flex min-h-0 flex-col gap-3 p-3", className)}>

--- a/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
@@ -2,6 +2,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createProviderUrlSource, type EditorMediaSource } from "../../lib/editorMedia";
 import {
   buildPlaybackFailure,
   buildPlaybackLoadError,
@@ -12,32 +13,76 @@ import {
   type PlaybackLoadFailure,
 } from "./editorPlaybackSources";
 
+function localFileSource(label = "movie.mp4") {
+  return {
+    kind: "file",
+    role: "local-file",
+    label: "Local file",
+    file: new File(["video"], label, { type: "video/mp4" }),
+    fileName: label,
+    mimeType: "video/mp4",
+    size: 5,
+  } satisfies EditorMediaSource;
+}
+
 void test("builds playback source candidates in fallback order without duplicates", () => {
-  assert.deepEqual(buildPlaybackSourceCandidates("/playback/master.m3u8", "/media/movie.mp4"), [
-    { label: "hls stream", url: "/playback/master.m3u8" },
-    { label: "direct source", url: "/media/movie.mp4" },
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+  const directSource = createProviderUrlSource("/media/movie.mp4", "direct");
+
+  assert.deepEqual(buildPlaybackSourceCandidates(hlsSource, directSource), [
+    { label: "hls stream", source: hlsSource },
+    { label: "direct source", source: directSource },
   ]);
 
-  assert.deepEqual(buildPlaybackSourceCandidates("/media/movie.mp4", "/media/movie.mp4"), [
-    { label: "hls stream", url: "/media/movie.mp4" },
+  const duplicateHlsSource = createProviderUrlSource("/media/movie.mp4", "hls");
+  assert.deepEqual(buildPlaybackSourceCandidates(duplicateHlsSource, directSource), [
+    { label: "hls stream", source: duplicateHlsSource },
+  ]);
+});
+
+void test("builds local file and URL playback candidates", () => {
+  const fileSource = localFileSource();
+  const urlSource = {
+    kind: "url",
+    role: "local-url",
+    label: "URL",
+    url: "https://example.com/movie.mp4",
+    hls: false,
+  } satisfies EditorMediaSource;
+  const hlsUrlSource = {
+    ...urlSource,
+    label: "HLS URL",
+    url: "https://example.com/master.m3u8",
+    hls: true,
+  } satisfies EditorMediaSource;
+
+  assert.deepEqual(buildPlaybackSourceCandidates(undefined, fileSource), [
+    { label: "local file", source: fileSource },
+  ]);
+  assert.deepEqual(buildPlaybackSourceCandidates(hlsUrlSource, urlSource), [
+    { label: "hls url", source: hlsUrlSource },
+    { label: "url", source: urlSource },
   ]);
 });
 
 void test("preserves server duration for HLS and uses computed direct duration when available", () => {
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+  const directSource = createProviderUrlSource("/media/movie.mp4", "direct");
+
   assert.equal(resolvePlaybackDuration(
-    { label: "hls stream", url: "/playback/master.m3u8" },
+    { label: "hls stream", source: hlsSource },
     95,
     100,
   ), 100);
 
   assert.equal(resolvePlaybackDuration(
-    { label: "direct source", url: "/media/movie.mp4" },
+    { label: "direct source", source: directSource },
     95,
     100,
   ), 95);
 
   assert.equal(resolvePlaybackDuration(
-    { label: "direct source", url: "/media/movie.mp4" },
+    { label: "direct source", source: directSource },
     Number.NaN,
     100,
   ), 100);
@@ -45,7 +90,7 @@ void test("preserves server duration for HLS and uses computed direct duration w
 
 void test("classifies source failures and export fallback eligibility", () => {
   const failure = buildPlaybackFailure(
-    { label: "hls stream", url: "/playback/master.m3u8" },
+    { label: "hls stream", source: createProviderUrlSource("/playback/master.m3u8", "hls") },
     new PlaybackSourceError("shared-export-blocking", "Decoder unavailable"),
   );
 

--- a/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
@@ -44,7 +44,7 @@ void test("builds local file and URL playback candidates", () => {
   const fileSource = localFileSource();
   const urlSource = {
     kind: "url",
-    role: "local-url",
+    role: "direct-url",
     label: "URL",
     url: "https://example.com/movie.mp4",
     hls: false,

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -63,7 +63,7 @@ function playbackLabelForSource(source: EditorMediaSource, role: "hls" | "direct
     return "local file" satisfies PlaybackSourceLabel;
   }
 
-  if (source.role === "local-url") {
+  if (source.role === "direct-url") {
     return isHlsEditorMediaSource(source)
       ? "hls url" satisfies PlaybackSourceLabel
       : "url" satisfies PlaybackSourceLabel;

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -1,5 +1,10 @@
 import type { InputAudioTrack, InputVideoTrack } from "mediabunny";
-import { isHlsPlaylistUrl } from "../../lib/mediabunnyInput";
+import {
+  editorMediaSourcesEqual,
+  isHlsEditorMediaSource,
+  sourceDisplayLabel,
+  type EditorMediaSource,
+} from "../../lib/editorMedia";
 import {
   getTrackCodec,
   getTrackLanguageCode,
@@ -8,9 +13,11 @@ import {
 import type { PlaybackAudioSelection } from "../../providers/types";
 import { errorMessage, isAc3FamilyCodec } from "./EditorUtils";
 
+type PlaybackSourceLabel = "hls stream" | "direct source" | "local file" | "url" | "hls url";
+
 export interface PlaybackSourceCandidate {
-  label: "hls stream" | "direct source";
-  url: string;
+  label: PlaybackSourceLabel;
+  source: EditorMediaSource;
 }
 
 export interface PlaybackLoadFailure {
@@ -28,7 +35,7 @@ export interface PlaybackFallbackInfo {
 export interface PlaybackSourceAnalysisContext {
   sessionId: string;
   source: PlaybackSourceCandidate["label"];
-  url: string;
+  mediaSource: EditorMediaSource;
   selectedAudioTrack?: PlaybackAudioSelection;
   videoTracks: readonly InputVideoTrack[];
   allAudioTracks: readonly InputAudioTrack[];
@@ -51,22 +58,45 @@ export class PlaybackSourceError extends Error {
   }
 }
 
-export function buildPlaybackSourceCandidates(hlsUrl: string | undefined, mediaUrl: string | undefined) {
-  const candidates: PlaybackSourceCandidate[] = [];
-
-  if (hlsUrl) {
-    candidates.push({ label: "hls stream", url: hlsUrl });
+function playbackLabelForSource(source: EditorMediaSource, role: "hls" | "direct") {
+  if (source.role === "local-file") {
+    return "local file" satisfies PlaybackSourceLabel;
   }
 
-  if (mediaUrl && !candidates.some((candidate) => candidate.url === mediaUrl)) {
-    candidates.push({ label: "direct source", url: mediaUrl });
+  if (source.role === "local-url") {
+    return isHlsEditorMediaSource(source)
+      ? "hls url" satisfies PlaybackSourceLabel
+      : "url" satisfies PlaybackSourceLabel;
+  }
+
+  return role === "hls"
+    ? "hls stream" satisfies PlaybackSourceLabel
+    : "direct source" satisfies PlaybackSourceLabel;
+}
+
+export function buildPlaybackSourceCandidates(
+  hlsSource: EditorMediaSource | undefined,
+  directSource: EditorMediaSource | undefined,
+) {
+  const candidates: PlaybackSourceCandidate[] = [];
+
+  if (hlsSource) {
+    candidates.push({ label: playbackLabelForSource(hlsSource, "hls"), source: hlsSource });
+  }
+
+  if (directSource && !candidates.some((candidate) => editorMediaSourcesEqual(candidate.source, directSource))) {
+    candidates.push({ label: playbackLabelForSource(directSource, "direct"), source: directSource });
   }
 
   return candidates;
 }
 
-function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "url">): PlaybackLoadFailure["classification"] {
-  return source.label === "hls stream" || isHlsPlaylistUrl(source.url) ? "hls-playlist" : "unknown";
+function classifyPlaybackSource(source: Pick<PlaybackSourceCandidate, "label" | "source">): PlaybackLoadFailure["classification"] {
+  return source.label === "hls stream"
+    || source.label === "hls url"
+    || isHlsEditorMediaSource(source.source)
+    ? "hls-playlist"
+    : "unknown";
 }
 
 export function buildPlaybackFailure(source: PlaybackSourceCandidate, err: unknown): PlaybackLoadFailure {
@@ -83,13 +113,24 @@ export function shouldUseExportFallback(failure: PlaybackLoadFailure) {
 }
 
 export function describePlaybackFailure(failure: PlaybackLoadFailure) {
-  const prefix = failure.label === "hls stream" ? "HLS stream" : "Direct source";
+  const prefix = formatPlaybackSourceLabel(failure.label);
 
   return `${prefix} failed: ${failure.message}`;
 }
 
 export function formatPlaybackSourceLabel(label: PlaybackSourceCandidate["label"]) {
-  return label === "hls stream" ? "HLS stream" : "Direct source";
+  switch (label) {
+    case "hls stream":
+      return "HLS stream";
+    case "direct source":
+      return "Direct source";
+    case "local file":
+      return "Local file";
+    case "hls url":
+      return "HLS URL";
+    case "url":
+      return "URL";
+  }
 }
 
 export function isPresent<T>(value: T | null | undefined): value is T {
@@ -108,7 +149,7 @@ export function resolvePlaybackDuration(
   const fallbackDuration = finiteNonNegativeDuration(initialDuration);
   const normalizedComputedDuration = finiteNonNegativeDuration(computedDuration);
 
-  if (playbackSource.label === "hls stream") {
+  if (playbackSource.label === "hls stream" || playbackSource.label === "hls url") {
     return Math.max(fallbackDuration, normalizedComputedDuration);
   }
 
@@ -301,8 +342,9 @@ export async function buildPlaybackSourceAnalysis(context: PlaybackSourceAnalysi
     source: context.source,
     urlClassification: classifyPlaybackSource({
       label: context.source,
-      url: context.url,
+      source: context.mediaSource,
     }),
+    sourceLabel: sourceDisplayLabel(context.mediaSource),
     selectedAudioTrack: context.selectedAudioTrack ?? null,
     videoTrackCount: context.videoTracks.length,
     audioTrackCount: context.allAudioTracks.length,

--- a/apps/frontend/src/components/editor/useEditorExport.test.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createProviderUrlSource, type EditorMediaSource } from "../../lib/editorMedia";
+import { resolveExportSource } from "./useEditorExport";
+
+const localFileSource = {
+  kind: "file",
+  role: "local-file",
+  label: "Local file",
+  file: new File(["video"], "movie.mp4", { type: "video/mp4" }),
+  fileName: "movie.mp4",
+} satisfies EditorMediaSource;
+
+void test("resolves provider export sources by preference", () => {
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+  const directSource = createProviderUrlSource("/media/movie.mp4", "direct");
+
+  assert.deepEqual(resolveExportSource({
+    preference: "auto",
+    hlsSource,
+    directSource,
+  }), {
+    source: hlsSource,
+    kind: "hls",
+  });
+
+  assert.deepEqual(resolveExportSource({
+    preference: "direct",
+    hlsSource,
+    directSource,
+  }), {
+    source: directSource,
+    kind: "direct",
+  });
+});
+
+void test("resolves local file export sources", () => {
+  assert.deepEqual(resolveExportSource({
+    preference: "auto",
+    directSource: localFileSource,
+  }), {
+    source: localFileSource,
+    kind: "direct",
+  });
+
+  assert.deepEqual(resolveExportSource({
+    preference: "hls",
+    directSource: localFileSource,
+  }), {
+    source: null,
+    kind: "none",
+  });
+});
+
+void test("uses export fallback source when auto-selected", () => {
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+
+  assert.deepEqual(resolveExportSource({
+    preference: "auto",
+    hlsSource,
+    directSource: localFileSource,
+    exportFallbackSource: localFileSource,
+  }), {
+    source: localFileSource,
+    kind: "direct",
+  });
+});

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -8,9 +8,15 @@ import {
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
 } from "../../lib/exportFileName";
+import {
+  isHlsEditorMediaSource,
+  sourceDisplayLabel,
+  type EditorMediaSource,
+  type EditorSession,
+} from "../../lib/editorMedia";
 import { subtitleTrackSupportsBurnIn } from "../../lib/selectPreferredSubtitleTrack";
 import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
-import type { CurrentlyPlayingItem, PlaybackSubtitleTrack } from "../../providers/types";
+import type { PlaybackSubtitleTrack } from "../../providers/types";
 import type { ExportSourcePreference } from "./EditorExportDialog";
 import type { PlaybackFallbackInfo } from "./useEditorPlayback";
 
@@ -22,16 +28,16 @@ interface VideoDimensions {
 type ResolvedExportSourceKind = "hls" | "direct" | "none";
 
 interface ResolvedExportSource {
-  url: string;
+  source: EditorMediaSource | null;
   kind: ResolvedExportSourceKind;
 }
 
 interface UseEditorExportProps {
-  session: CurrentlyPlayingItem;
+  session: EditorSession;
   startTime: number;
   endTime: number;
   sourceVideoDimensions: VideoDimensions | null;
-  exportFallbackSourceUrl?: string;
+  exportFallbackSource?: EditorMediaSource;
   hlsFallbackInfo: PlaybackFallbackInfo | null;
   subtitleEnabled: boolean;
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
@@ -46,7 +52,7 @@ export function useEditorExport({
   startTime,
   endTime,
   sourceVideoDimensions,
-  exportFallbackSourceUrl,
+  exportFallbackSource,
   hlsFallbackInfo,
   subtitleEnabled,
   selectedSubtitleTrack,
@@ -67,56 +73,62 @@ export function useEditorExport({
   const [exportError, setExportError] = useState<string | null>(null);
 
   const effectiveExportSourcePreference =
-    exportSourcePreference === "direct" && !session.mediaUrl
+    exportSourcePreference === "direct" && !session.directSource
       ? "auto"
-      : exportSourcePreference === "hls" && !session.hlsUrl
+      : exportSourcePreference === "hls" && !session.hlsSource
         ? "auto"
         : exportSourcePreference;
 
   const exportSource = useMemo(() => resolveExportSource({
     preference: effectiveExportSourcePreference,
-    hlsUrl: session.hlsUrl,
-    mediaUrl: session.mediaUrl,
-    exportFallbackSourceUrl,
+    hlsSource: session.hlsSource,
+    directSource: session.directSource,
+    exportFallbackSource,
   }), [
     effectiveExportSourcePreference,
-    exportFallbackSourceUrl,
-    session.hlsUrl,
-    session.mediaUrl,
+    exportFallbackSource,
+    session.directSource,
+    session.hlsSource,
   ]);
 
   const exportSourceMessage = useMemo(() => buildExportSourceMessage({
     preference: effectiveExportSourcePreference,
     resolvedSourceKind: exportSource.kind,
-    hlsUrl: session.hlsUrl,
-    mediaUrl: session.mediaUrl,
+    resolvedSource: exportSource.source,
+    hlsSource: session.hlsSource,
+    directSource: session.directSource,
     hlsFallbackInfo,
   }), [
     effectiveExportSourcePreference,
     exportSource.kind,
+    exportSource.source,
     hlsFallbackInfo,
-    session.hlsUrl,
-    session.mediaUrl,
+    session.directSource,
+    session.hlsSource,
   ]);
 
   const exportSourceSummaryMessage = useMemo(() => buildExportSourceSummaryMessage({
     preference: effectiveExportSourcePreference,
     resolvedSourceKind: exportSource.kind,
-    hlsUrl: session.hlsUrl,
+    resolvedSource: exportSource.source,
+    hlsSource: session.hlsSource,
   }), [
     effectiveExportSourcePreference,
     exportSource.kind,
-    session.hlsUrl,
+    exportSource.source,
+    session.hlsSource,
   ]);
 
   const exportSourceLabel = useMemo(() => buildExportSourceLabel({
     preference: effectiveExportSourcePreference,
     resolvedSourceKind: exportSource.kind,
-    exportFallbackSourceUrl,
+    resolvedSource: exportSource.source,
+    exportFallbackSource,
   }), [
     effectiveExportSourcePreference,
-    exportFallbackSourceUrl,
+    exportFallbackSource,
     exportSource.kind,
+    exportSource.source,
   ]);
 
   const fileName = useMemo(() => buildExportFileName({
@@ -202,7 +214,7 @@ export function useEditorExport({
   }, []);
 
   const handleExport = useCallback(async () => {
-    if (!exportSource.url) return;
+    if (!exportSource.source) return;
     if (exporting) return;
 
     const shouldBurnSubtitles = subtitleEnabled
@@ -226,7 +238,7 @@ export function useEditorExport({
     try {
       const { exportClip } = await import("../../lib/exportClip");
       const blob = await exportClip({
-        mediaUrl: exportSource.url,
+        mediaSource: exportSource.source,
         hls: exportSource.kind === "hls",
         startTime,
         endTime,
@@ -261,7 +273,7 @@ export function useEditorExport({
     endTime,
     exportFormat,
     exportSource.kind,
-    exportSource.url,
+    exportSource.source,
     exporting,
     fileName.fullName,
     includeAudio,
@@ -328,90 +340,102 @@ function getOutputDimensions(
   return { width, height };
 }
 
-function resolveExportSource({
+export function resolveExportSource({
   preference,
-  hlsUrl,
-  mediaUrl,
-  exportFallbackSourceUrl,
+  hlsSource,
+  directSource,
+  exportFallbackSource,
 }: {
   preference: ExportSourcePreference;
-  hlsUrl?: string;
-  mediaUrl?: string;
-  exportFallbackSourceUrl?: string;
+  hlsSource?: EditorMediaSource;
+  directSource?: EditorMediaSource;
+  exportFallbackSource?: EditorMediaSource;
 }): ResolvedExportSource {
   if (preference === "direct") {
-    return mediaUrl
-      ? { url: mediaUrl, kind: "direct" }
-      : { url: "", kind: "none" };
+    return directSource
+      ? { source: directSource, kind: "direct" }
+      : { source: null, kind: "none" };
   }
 
   if (preference === "hls") {
-    return hlsUrl
-      ? { url: hlsUrl, kind: "hls" }
-      : { url: "", kind: "none" };
+    return hlsSource
+      ? { source: hlsSource, kind: "hls" }
+      : { source: null, kind: "none" };
   }
 
-  if (exportFallbackSourceUrl) {
-    return { url: exportFallbackSourceUrl, kind: "direct" };
+  if (exportFallbackSource) {
+    return { source: exportFallbackSource, kind: isHlsEditorMediaSource(exportFallbackSource) ? "hls" : "direct" };
   }
 
-  if (hlsUrl) {
-    return { url: hlsUrl, kind: "hls" };
+  if (hlsSource) {
+    return { source: hlsSource, kind: "hls" };
   }
 
-  if (mediaUrl) {
-    return { url: mediaUrl, kind: "direct" };
+  if (directSource) {
+    return { source: directSource, kind: "direct" };
   }
 
-  return { url: "", kind: "none" };
+  return { source: null, kind: "none" };
 }
 
 function buildExportSourceLabel({
   preference,
   resolvedSourceKind,
-  exportFallbackSourceUrl,
+  resolvedSource,
+  exportFallbackSource,
 }: {
   preference: ExportSourcePreference;
   resolvedSourceKind: ResolvedExportSourceKind;
-  exportFallbackSourceUrl?: string;
+  resolvedSource: EditorMediaSource | null;
+  exportFallbackSource?: EditorMediaSource;
 }) {
-  if (resolvedSourceKind === "hls") {
-    return preference === "auto" ? "Auto: HLS playback" : "HLS playback";
+  if (!resolvedSource || resolvedSourceKind === "none") {
+    return "Unavailable";
   }
 
-  if (resolvedSourceKind === "direct") {
-    if (preference === "auto" && exportFallbackSourceUrl) {
-      return "Auto: direct fallback";
-    }
+  const label = sourceDisplayLabel(resolvedSource);
 
-    return preference === "auto" ? "Auto: direct/original" : "Direct/original";
+  if (preference === "auto" && exportFallbackSource) {
+    return `Auto: ${label} fallback`;
   }
 
-  return "Unavailable";
+  return preference === "auto" ? `Auto: ${label}` : label;
 }
 
 function buildExportSourceMessage({
   preference,
   resolvedSourceKind,
-  hlsUrl,
-  mediaUrl,
+  resolvedSource,
+  hlsSource,
+  directSource,
   hlsFallbackInfo,
 }: {
   preference: ExportSourcePreference;
   resolvedSourceKind: ResolvedExportSourceKind;
-  hlsUrl?: string;
-  mediaUrl?: string;
+  resolvedSource: EditorMediaSource | null;
+  hlsSource?: EditorMediaSource;
+  directSource?: EditorMediaSource;
   hlsFallbackInfo: PlaybackFallbackInfo | null;
 }) {
-  if (resolvedSourceKind === "none") {
+  if (resolvedSourceKind === "none" || !resolvedSource) {
     return null;
+  }
+
+  if (resolvedSource.role === "local-file") {
+    return "Export will read the selected local file directly in this browser. The file is not uploaded to the Cliparr server.";
+  }
+
+  if (resolvedSource.role === "local-url") {
+    return isHlsEditorMediaSource(resolvedSource)
+      ? "Export will read the HLS URL directly in this browser. The Cliparr server is not used as a proxy."
+      : "Export will read the media URL directly in this browser. The Cliparr server is not used as a proxy.";
   }
 
   if (preference === "hls" && resolvedSourceKind === "hls" && !hlsFallbackInfo) {
     return "Export will use the HLS playback stream. This follows the media server playback path and can include server-side transcoding.";
   }
 
-  if (resolvedSourceKind === "direct" && !hlsUrl && mediaUrl) {
+  if (resolvedSourceKind === "direct" && !hlsSource && directSource) {
     return "This session only exposed a direct/original media path, so export will use that source.";
   }
 
@@ -442,13 +466,20 @@ function buildExportSourceMessage({
 function buildExportSourceSummaryMessage({
   preference,
   resolvedSourceKind,
-  hlsUrl,
+  resolvedSource,
+  hlsSource,
 }: {
   preference: ExportSourcePreference;
   resolvedSourceKind: ResolvedExportSourceKind;
-  hlsUrl?: string;
+  resolvedSource: EditorMediaSource | null;
+  hlsSource?: EditorMediaSource;
 }) {
-  if (preference === "direct" && resolvedSourceKind === "direct" && hlsUrl) {
+  if (
+    preference === "direct"
+    && resolvedSourceKind === "direct"
+    && resolvedSource?.role === "direct"
+    && hlsSource
+  ) {
     return "Export will use the direct/original media path. Cliparr still uses playback metadata for track and timing hints when it is available.";
   }
 

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -429,7 +429,7 @@ function buildExportSourceMessage({
     return "Export will read the selected local file directly in this browser. The file is not uploaded to the Cliparr server.";
   }
 
-  if (resolvedSource.role === "local-url") {
+  if (resolvedSource.role === "direct-url") {
     return isHlsEditorMediaSource(resolvedSource)
       ? "Export will read the HLS URL directly in this browser. The Cliparr server is not used as a proxy."
       : "Export will read the media URL directly in this browser. The Cliparr server is not used as a proxy.";

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -216,6 +216,10 @@ export function useEditorExport({
   const handleExport = useCallback(async () => {
     if (!exportSource.source) return;
     if (exporting) return;
+    if (endTime <= startTime) {
+      setExportError("Waiting for media duration before export is available.");
+      return;
+    }
 
     const shouldBurnSubtitles = subtitleEnabled
       && selectedSubtitleTrack !== null

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -8,8 +8,9 @@ import type {
   WrappedCanvas,
 } from "mediabunny";
 import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
+import type { EditorMediaSource } from "../../lib/editorMedia";
 import { ensureMediabunnyCodecs } from "../../lib/mediabunnyCodecs";
-import { createCliparrInputFromUrl } from "../../lib/mediabunnyInput";
+import { createCliparrInputFromSource } from "../../lib/mediabunnyInput";
 import {
   fromSourceTimelineTime,
   getAudioTrackSampleRate,
@@ -58,8 +59,8 @@ export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
 export type { PlaybackReadyRange } from "./useEditorPlaybackWarmup";
 
 interface UseEditorPlaybackProps {
-  hlsUrl?: string;
-  mediaUrl?: string;
+  hlsSource?: EditorMediaSource;
+  directSource?: EditorMediaSource;
   initialDuration: number;
   startTime: number;
   endTime: number;
@@ -76,8 +77,8 @@ interface VideoDimensions {
 }
 
 export function useEditorPlayback({
-  hlsUrl,
-  mediaUrl,
+  hlsSource,
+  directSource,
   initialDuration,
   startTime,
   endTime,
@@ -96,7 +97,7 @@ export function useEditorPlayback({
   const [muted, setMuted] = useState(false);
   const [error, setError] = useState("");
   const [activeSourceLabel, setActiveSourceLabel] = useState("");
-  const [exportFallbackSourceUrl, setExportFallbackSourceUrl] = useState<string | undefined>(undefined);
+  const [exportFallbackSource, setExportFallbackSource] = useState<EditorMediaSource | undefined>(undefined);
   const [hlsFallbackInfo, setHlsFallbackInfo] = useState<PlaybackFallbackInfo | null>(null);
   const [sourceVideoDimensions, setSourceVideoDimensions] = useState<VideoDimensions | null>(null);
   const [playbackReadyRange, setPlaybackReadyRange] = useState<PlaybackReadyRange | null>(null);
@@ -444,7 +445,7 @@ export function useEditorPlayback({
 
     if (
       !wasPlaying
-      && activeSourceLabelRef.current === "HLS stream"
+      && (activeSourceLabelRef.current === "HLS stream" || activeSourceLabelRef.current === "HLS URL")
       && (
         !currentReadyRange
         || nextTime < currentReadyRange.startTime
@@ -473,8 +474,12 @@ export function useEditorPlayback({
   ]);
 
   useEffect(() => {
-    const playbackSources = buildPlaybackSourceCandidates(hlsUrl, mediaUrl);
-    const directSourceUrl = playbackSources.find((source) => source.label === "direct source")?.url;
+    const playbackSources = buildPlaybackSourceCandidates(hlsSource, directSource);
+    const fallbackDirectSource = playbackSources.find((source) =>
+      source.label === "direct source"
+      || source.label === "local file"
+      || source.label === "url"
+    )?.source;
     if (playbackSources.length === 0) {
       return;
     }
@@ -489,7 +494,7 @@ export function useEditorPlayback({
       setPreviewStatus("Loading stream...");
       setError("");
       setActiveSourceLabel("");
-      setExportFallbackSourceUrl(undefined);
+      setExportFallbackSource(undefined);
       setHlsFallbackInfo(null);
       setDuration(resetDuration);
       durationRef.current = resetDuration;
@@ -501,7 +506,7 @@ export function useEditorPlayback({
 
       try {
         const failures: PlaybackLoadFailure[] = [];
-        let nextExportFallbackSourceUrl: string | undefined;
+        let nextExportFallbackSource: EditorMediaSource | undefined;
         let nextHlsFallbackInfo: PlaybackFallbackInfo | null = null;
 
         for (const playbackSource of playbackSources) {
@@ -520,8 +525,8 @@ export function useEditorPlayback({
               return;
             }
 
-            const input = await createCliparrInputFromUrl(playbackSource.url, {
-              hls: playbackSource.label === "hls stream",
+            const input = await createCliparrInputFromSource(playbackSource.source, {
+              hls: playbackSource.label === "hls stream" || playbackSource.label === "hls url",
             });
             inputRef.current = input;
 
@@ -562,7 +567,7 @@ export function useEditorPlayback({
             playbackSourceAnalysisContext = {
               sessionId,
               source: playbackSource.label,
-              url: playbackSource.url,
+              mediaSource: playbackSource.source,
               selectedAudioTrack,
               videoTracks,
               allAudioTracks,
@@ -674,11 +679,19 @@ export function useEditorPlayback({
 
             startRenderLoop();
             setActiveSourceLabel(formatPlaybackSourceLabel(playbackSource.label));
-            setExportFallbackSourceUrl(
-              playbackSource.label === "direct source" ? nextExportFallbackSourceUrl : undefined
+            setExportFallbackSource(
+              playbackSource.label === "direct source"
+              || playbackSource.label === "local file"
+              || playbackSource.label === "url"
+                ? nextExportFallbackSource
+                : undefined
             );
             setHlsFallbackInfo(
-              playbackSource.label === "direct source" ? nextHlsFallbackInfo : null
+              playbackSource.label === "direct source"
+              || playbackSource.label === "local file"
+              || playbackSource.label === "url"
+                ? nextHlsFallbackInfo
+                : null
             );
             return;
           } catch (err) {
@@ -689,14 +702,17 @@ export function useEditorPlayback({
               : undefined;
 
             if (
-              failure.label === "hls stream"
+              (failure.label === "hls stream" || failure.label === "hls url")
               && shouldUseExportFallback(failure)
-              && directSourceUrl
+              && fallbackDirectSource
             ) {
-              nextExportFallbackSourceUrl = directSourceUrl;
+              nextExportFallbackSource = fallbackDirectSource;
             }
 
-            if (failure.label === "hls stream") {
+            if (
+              failure.label === "hls stream"
+              || failure.label === "hls url"
+            ) {
               nextHlsFallbackInfo = {
                 category: failure.category,
                 message: failure.message,
@@ -739,8 +755,8 @@ export function useEditorPlayback({
       disposePreview();
     };
   }, [
-    mediaUrl,
-    hlsUrl,
+    directSource,
+    hlsSource,
     initialDuration,
     selectedAudioTrack,
     sessionId,
@@ -759,7 +775,7 @@ export function useEditorPlayback({
     previewStatus,
     error,
     activeSourceLabel,
-    exportFallbackSourceUrl,
+    exportFallbackSource,
     hlsFallbackInfo,
     sourceVideoDimensions,
     playbackReadyRange,

--- a/apps/frontend/src/lib/editorMedia.test.ts
+++ b/apps/frontend/src/lib/editorMedia.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { titleFromUrl } from "./editorMedia";
+
+void test("uses the URL host as the title when no path segment is present", () => {
+  assert.equal(titleFromUrl("https://example.com/"), "example.com");
+  assert.equal(titleFromUrl("https://example.com"), "example.com");
+});
+
+void test("uses the final URL path segment as the title when present", () => {
+  assert.equal(titleFromUrl("https://example.com/media/example%20clip.mp4"), "example clip");
+});

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -84,7 +84,7 @@ export function titleFromUrl(url: string) {
   try {
     const parsed = new URL(url);
     const finalSegment = decodeURIComponent(parsed.pathname.split("/").filter(Boolean).pop() ?? "");
-    return titleFromFileName(finalSegment) || parsed.hostname || "URL video";
+    return finalSegment ? titleFromFileName(finalSegment) : parsed.hostname || "URL video";
   } catch {
     return "URL video";
   }

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -20,7 +20,7 @@ export interface BrowserFileHandle {
   requestPermission?: (descriptor?: { mode?: "read" }) => Promise<BrowserFilePermissionState>;
 }
 
-export type EditorMediaSourceRole = "hls" | "direct" | "local-file" | "local-url";
+export type EditorMediaSourceRole = "hls" | "direct" | "local-file" | "direct-url";
 
 interface BaseEditorMediaSource {
   role: EditorMediaSourceRole;
@@ -165,7 +165,7 @@ export function sourceDisplayLabel(source: EditorMediaSource) {
     return "Local file";
   }
 
-  if (source.role === "local-url") {
+  if (source.role === "direct-url") {
     return isHlsEditorMediaSource(source) ? "HLS URL" : "URL";
   }
 

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -1,0 +1,193 @@
+import type {
+  CurrentlyPlayingItem,
+  MediaExportMetadata,
+  PlaybackAudioSelection,
+  PlaybackSource,
+  PlaybackSubtitleSelection,
+  PlaybackSubtitleTrack,
+} from "../providers/types";
+import { isHlsPlaylistUrl } from "./mediabunnyInput";
+
+const LOCAL_PROVIDER_ID = "local";
+
+export type BrowserFilePermissionState = "granted" | "denied" | "prompt";
+
+export interface BrowserFileHandle {
+  kind?: "file";
+  name: string;
+  getFile: () => Promise<File>;
+  queryPermission?: (descriptor?: { mode?: "read" }) => Promise<BrowserFilePermissionState>;
+  requestPermission?: (descriptor?: { mode?: "read" }) => Promise<BrowserFilePermissionState>;
+}
+
+export type EditorMediaSourceRole = "hls" | "direct" | "local-file" | "local-url";
+
+interface BaseEditorMediaSource {
+  role: EditorMediaSourceRole;
+  label: string;
+}
+
+export interface EditorUrlMediaSource extends BaseEditorMediaSource {
+  kind: "url";
+  url: string;
+  hls?: boolean;
+}
+
+export interface EditorFileMediaSource extends BaseEditorMediaSource {
+  kind: "file";
+  file: File;
+  fileName: string;
+  mimeType?: string;
+  size?: number;
+  lastModified?: number;
+}
+
+export interface EditorFileHandleMediaSource extends BaseEditorMediaSource {
+  kind: "file-handle";
+  handle: BrowserFileHandle;
+  fileName: string;
+  mimeType?: string;
+  size?: number;
+  lastModified?: number;
+}
+
+export type EditorMediaSource =
+  | EditorUrlMediaSource
+  | EditorFileMediaSource
+  | EditorFileHandleMediaSource;
+
+export interface EditorSession {
+  id: string;
+  source: PlaybackSource;
+  title: string;
+  type: string;
+  duration: number;
+  playerTitle: string;
+  playerState: string;
+  thumbUrl?: string;
+  directSource?: EditorMediaSource;
+  hlsSource?: EditorMediaSource;
+  selectedAudioTrack?: PlaybackAudioSelection;
+  selectedSubtitleTrack?: PlaybackSubtitleSelection;
+  subtitleTracks?: PlaybackSubtitleTrack[];
+  exportMetadata?: MediaExportMetadata;
+  local: boolean;
+}
+
+export function titleFromFileName(fileName: string) {
+  const trimmed = fileName.trim();
+  const withoutExtension = trimmed.replace(/\.[^.]+$/, "");
+  return withoutExtension || trimmed || "Local video";
+}
+
+export function titleFromUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    const finalSegment = decodeURIComponent(parsed.pathname.split("/").filter(Boolean).pop() ?? "");
+    return titleFromFileName(finalSegment) || parsed.hostname || "URL video";
+  } catch {
+    return "URL video";
+  }
+}
+
+export function createProviderUrlSource(
+  url: string,
+  role: Extract<EditorMediaSourceRole, "hls" | "direct">,
+): EditorUrlMediaSource {
+  return {
+    kind: "url",
+    role,
+    url,
+    hls: role === "hls" || isHlsPlaylistUrl(url),
+    label: role === "hls" ? "HLS playback" : "Direct/original",
+  };
+}
+
+export function editorSessionFromCurrentlyPlaying(item: CurrentlyPlayingItem): EditorSession {
+  return {
+    id: item.id,
+    source: item.source,
+    title: item.title,
+    type: item.type,
+    duration: item.duration,
+    playerTitle: item.playerTitle,
+    playerState: item.playerState,
+    thumbUrl: item.thumbUrl,
+    directSource: item.mediaUrl ? createProviderUrlSource(item.mediaUrl, "direct") : undefined,
+    hlsSource: item.hlsUrl ? createProviderUrlSource(item.hlsUrl, "hls") : undefined,
+    selectedAudioTrack: item.selectedAudioTrack,
+    selectedSubtitleTrack: item.selectedSubtitleTrack,
+    subtitleTracks: item.subtitleTracks,
+    exportMetadata: item.exportMetadata,
+    local: false,
+  };
+}
+
+export function buildLocalEditorSession(input: {
+  id: string;
+  title: string;
+  source: EditorMediaSource;
+  duration?: number;
+}): EditorSession {
+  const isHls = isHlsEditorMediaSource(input.source);
+  const title = input.title.trim() || "Local video";
+
+  return {
+    id: input.id,
+    source: {
+      id: LOCAL_PROVIDER_ID,
+      name: "Local video",
+      providerId: LOCAL_PROVIDER_ID,
+    },
+    title,
+    type: "video",
+    duration: input.duration ?? 0,
+    playerTitle: sourceDisplayLabel(input.source),
+    playerState: "ready",
+    directSource: isHls ? undefined : input.source,
+    hlsSource: isHls ? input.source : undefined,
+    exportMetadata: {
+      providerId: LOCAL_PROVIDER_ID,
+      itemType: "video",
+      title,
+      sourceTitle: title,
+    },
+    local: true,
+  };
+}
+
+export function isHlsEditorMediaSource(source: EditorMediaSource) {
+  return source.kind === "url" && (source.hls === true || isHlsPlaylistUrl(source.url));
+}
+
+export function sourceDisplayLabel(source: EditorMediaSource) {
+  if (source.role === "local-file") {
+    return "Local file";
+  }
+
+  if (source.role === "local-url") {
+    return isHlsEditorMediaSource(source) ? "HLS URL" : "URL";
+  }
+
+  return source.label;
+}
+
+export function editorMediaSourcesEqual(left: EditorMediaSource, right: EditorMediaSource) {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+
+  if (left.kind === "url" && right.kind === "url") {
+    return left.url === right.url;
+  }
+
+  if (left.kind === "file" && right.kind === "file") {
+    return left.file === right.file;
+  }
+
+  if (left.kind === "file-handle" && right.kind === "file-handle") {
+    return left.handle === right.handle;
+  }
+
+  return false;
+}

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -8,7 +8,8 @@ import {
   WebMOutputFormat,
 } from "mediabunny";
 import type { ConversionOptions, DiscardedTrack, VideoSample } from "mediabunny";
-import { createCliparrInputFromUrl } from "./mediabunnyInput";
+import type { EditorMediaSource } from "./editorMedia";
+import { createCliparrInputFromSource } from "./mediabunnyInput";
 import { ensureMediabunnyCodecs } from "./mediabunnyCodecs";
 import {
   getTrackTimelineOffsetSeconds,
@@ -32,7 +33,7 @@ import type { SubtitleCue, SubtitleStyleSettings } from "./subtitles/types";
 export type { ExportFormat, ExportResolution } from "./exportTypes";
 
 interface ExportClipOptions {
-  mediaUrl: string;
+  mediaSource: EditorMediaSource;
   hls?: boolean;
   startTime: number;
   endTime: number;
@@ -99,7 +100,7 @@ function buildSubtitleBurnInProcessor(
 }
 
 export async function exportClip({
-  mediaUrl,
+  mediaSource,
   hls,
   startTime,
   endTime,
@@ -115,7 +116,7 @@ export async function exportClip({
 }: ExportClipOptions) {
   await ensureMediabunnyCodecs();
 
-  const input = await createCliparrInputFromUrl(mediaUrl, { hls });
+  const input = await createCliparrInputFromSource(mediaSource, { hls });
 
   try {
     const sourceVideoTrack = await input.getPrimaryVideoTrack({

--- a/apps/frontend/src/lib/localMediaRegistry.test.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrowserFileHandle } from "./editorMedia";
+import {
+  createLocalSessionFromFile,
+  createLocalSessionFromUrl,
+  resolveFileHandleReadPermission,
+  resolveLocalMediaSession,
+  validateLocalMediaUrl,
+} from "./localMediaRegistry";
+
+void test("validates local media URLs", () => {
+  assert.deepEqual(validateLocalMediaUrl(""), {
+    ok: false,
+    message: "Enter a media URL.",
+  });
+  assert.deepEqual(validateLocalMediaUrl("file:///tmp/movie.mp4"), {
+    ok: false,
+    message: "Media URLs must use HTTP or HTTPS.",
+  });
+  assert.deepEqual(validateLocalMediaUrl("https://example.com/master.m3u8").ok, true);
+  const result = validateLocalMediaUrl("https://example.com/master.m3u8");
+  assert.equal(result.ok ? result.hls : false, true);
+});
+
+void test("creates and resolves memory-backed local file sessions", async () => {
+  const file = new File(["video"], "example clip.mp4", { type: "video/mp4" });
+  const session = await createLocalSessionFromFile(file);
+
+  assert.equal(session.title, "example clip");
+  assert.equal(session.local, true);
+  assert.equal(session.directSource?.kind, "file");
+
+  const resolved = await resolveLocalMediaSession(session.id);
+  assert.equal(resolved.status, "ready");
+  assert.equal(resolved.status === "ready" ? resolved.session.directSource?.kind : null, "file");
+});
+
+void test("creates and resolves memory-backed URL sessions when IndexedDB is unavailable", async () => {
+  const result = await createLocalSessionFromUrl("https://example.com/video.mp4");
+
+  assert.equal(result.status, "ready");
+  assert.equal(result.status === "ready" ? result.session.directSource?.kind : null, "url");
+
+  const resolved = result.status === "ready"
+    ? await resolveLocalMediaSession(result.session.id)
+    : null;
+  assert.equal(resolved?.status, "ready");
+  assert.equal(resolved?.status === "ready" ? resolved.session.directSource?.kind : null, "url");
+});
+
+void test("resolves file handle permission states", async () => {
+  const deniedHandle = {
+    name: "denied.mp4",
+    getFile: async () => new File(["video"], "denied.mp4"),
+    queryPermission: async () => "denied" as const,
+    requestPermission: async () => "granted" as const,
+  } satisfies BrowserFileHandle;
+
+  assert.equal(await resolveFileHandleReadPermission(deniedHandle), "denied");
+  assert.equal(await resolveFileHandleReadPermission(deniedHandle, { requestPermission: true }), "granted");
+
+  const legacyHandle = {
+    name: "legacy.mp4",
+    getFile: async () => new File(["video"], "legacy.mp4"),
+  } satisfies BrowserFileHandle;
+
+  assert.equal(await resolveFileHandleReadPermission(legacyHandle), "granted");
+});

--- a/apps/frontend/src/lib/localMediaRegistry.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.ts
@@ -189,7 +189,7 @@ function createFileHandleSource(record: StoredFileHandleRecord): EditorFileHandl
 function createUrlSource(record: StoredUrlRecord): EditorUrlMediaSource {
   return {
     kind: "url",
-    role: "local-url",
+    role: "direct-url",
     label: record.hls ? "HLS URL" : "URL",
     url: record.url,
     hls: record.hls,

--- a/apps/frontend/src/lib/localMediaRegistry.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.ts
@@ -1,0 +1,457 @@
+import {
+  buildLocalEditorSession,
+  type BrowserFileHandle,
+  type BrowserFilePermissionState,
+  type EditorFileHandleMediaSource,
+  type EditorFileMediaSource,
+  type EditorSession,
+  type EditorUrlMediaSource,
+  titleFromFileName,
+  titleFromUrl,
+} from "./editorMedia";
+import { isHlsPlaylistUrl } from "./mediabunnyInput";
+
+const DATABASE_NAME = "cliparr-local-media";
+const DATABASE_VERSION = 1;
+const STORE_NAME = "media";
+
+const VIDEO_PICKER_TYPES = [{
+  description: "Video files",
+  accept: {
+    "video/*": [".mp4", ".m4v", ".mov", ".mkv", ".webm", ".ogv", ".ts", ".m2ts", ".mts"],
+    "application/x-matroska": [".mkv"],
+    "video/mp2t": [".ts", ".m2ts", ".mts"],
+  },
+}] as const;
+
+export const LOCAL_VIDEO_FILE_ACCEPT = [
+  "video/*",
+  "video/x-matroska",
+  "application/x-matroska",
+  "video/mp2t",
+  ".mp4",
+  ".m4v",
+  ".mov",
+  ".mkv",
+  ".webm",
+  ".ogv",
+  ".ts",
+  ".m2ts",
+  ".mts",
+].join(",");
+
+type StoredLocalMediaRecord = StoredUrlRecord | StoredFileHandleRecord;
+
+interface StoredRecordBase {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StoredUrlRecord extends StoredRecordBase {
+  kind: "url";
+  url: string;
+  hls: boolean;
+}
+
+export interface StoredFileHandleRecord extends StoredRecordBase {
+  kind: "file-handle";
+  name: string;
+  type?: string;
+  size?: number;
+  lastModified?: number;
+  handle: BrowserFileHandle;
+}
+
+export interface MemoryFileRecord extends StoredRecordBase {
+  kind: "memory-file";
+  name: string;
+  type?: string;
+  size?: number;
+  lastModified?: number;
+  file: File;
+}
+
+export type LocalMediaRecord = StoredLocalMediaRecord | MemoryFileRecord;
+
+export type LocalMediaResolution =
+  | { status: "ready"; session: EditorSession }
+  | { status: "missing"; title?: string; message: string }
+  | { status: "permission-needed"; id: string; title: string; message: string }
+  | { status: "unavailable"; title?: string; message: string };
+
+interface BrowserWithFilePicker extends Window {
+  showOpenFilePicker?: (options?: {
+    excludeAcceptAllOption?: boolean;
+    multiple?: boolean;
+    types?: typeof VIDEO_PICKER_TYPES;
+  }) => Promise<BrowserFileHandle[]>;
+}
+
+const memoryRecords = new Map<string, LocalMediaRecord>();
+
+function createId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `local-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function nowIsoString() {
+  return new Date().toISOString();
+}
+
+function canUseIndexedDb() {
+  return typeof indexedDB !== "undefined";
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (!canUseIndexedDb()) {
+    return Promise.reject(new Error("IndexedDB is unavailable in this browser."));
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Could not open local media storage."));
+  });
+}
+
+function withStore<T>(
+  mode: IDBTransactionMode,
+  callback: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDatabase().then((database) => new Promise<T>((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = callback(store);
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Local media storage request failed."));
+    transaction.oncomplete = () => database.close();
+    transaction.onerror = () => {
+      database.close();
+      reject(transaction.error ?? new Error("Local media storage transaction failed."));
+    };
+    transaction.onabort = () => {
+      database.close();
+      reject(transaction.error ?? new Error("Local media storage transaction was aborted."));
+    };
+  }));
+}
+
+async function putStoredRecord(record: StoredLocalMediaRecord) {
+  await withStore("readwrite", (store) => store.put(record));
+}
+
+async function getStoredRecord(id: string) {
+  return withStore<StoredLocalMediaRecord | undefined>("readonly", (store) =>
+    store.get(id) as IDBRequest<StoredLocalMediaRecord | undefined>
+  );
+}
+
+function createMemoryFileSource(record: MemoryFileRecord): EditorFileMediaSource {
+  return {
+    kind: "file",
+    role: "local-file",
+    label: "Local file",
+    file: record.file,
+    fileName: record.name,
+    mimeType: record.type,
+    size: record.size,
+    lastModified: record.lastModified,
+  };
+}
+
+function createFileHandleSource(record: StoredFileHandleRecord): EditorFileHandleMediaSource {
+  return {
+    kind: "file-handle",
+    role: "local-file",
+    label: "Local file",
+    handle: record.handle,
+    fileName: record.name,
+    mimeType: record.type,
+    size: record.size,
+    lastModified: record.lastModified,
+  };
+}
+
+function createUrlSource(record: StoredUrlRecord): EditorUrlMediaSource {
+  return {
+    kind: "url",
+    role: "local-url",
+    label: record.hls ? "HLS URL" : "URL",
+    url: record.url,
+    hls: record.hls,
+  };
+}
+
+function sessionFromRecord(record: LocalMediaRecord) {
+  if (record.kind === "memory-file") {
+    return buildLocalEditorSession({
+      id: record.id,
+      title: record.title,
+      source: createMemoryFileSource(record),
+    });
+  }
+
+  if (record.kind === "file-handle") {
+    return buildLocalEditorSession({
+      id: record.id,
+      title: record.title,
+      source: createFileHandleSource(record),
+    });
+  }
+
+  return buildLocalEditorSession({
+    id: record.id,
+    title: record.title,
+    source: createUrlSource(record),
+  });
+}
+
+async function readPermission(handle: BrowserFileHandle) {
+  if (!handle.queryPermission) {
+    return "granted" satisfies BrowserFilePermissionState;
+  }
+
+  return handle.queryPermission({ mode: "read" });
+}
+
+async function requestReadPermission(handle: BrowserFileHandle) {
+  if (!handle.requestPermission) {
+    return readPermission(handle);
+  }
+
+  return handle.requestPermission({ mode: "read" });
+}
+
+export async function resolveFileHandleReadPermission(
+  handle: BrowserFileHandle,
+  options: { requestPermission?: boolean } = {},
+) {
+  return options.requestPermission
+    ? requestReadPermission(handle)
+    : readPermission(handle);
+}
+
+function fileMetadata(file: File) {
+  return {
+    name: file.name,
+    type: file.type || undefined,
+    size: file.size,
+    lastModified: file.lastModified,
+  };
+}
+
+export function validateLocalMediaUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { ok: false as const, message: "Enter a media URL." };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false as const, message: "Enter a valid absolute URL." };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false as const, message: "Media URLs must use HTTP or HTTPS." };
+  }
+
+  return {
+    ok: true as const,
+    url: parsed.toString(),
+    hls: isHlsPlaylistUrl(parsed.toString()),
+  };
+}
+
+export function localMediaPickerSupported() {
+  return typeof window !== "undefined"
+    && typeof (window as BrowserWithFilePicker).showOpenFilePicker === "function";
+}
+
+export async function createLocalSessionFromFile(file: File) {
+  const timestamps = nowIsoString();
+  const metadata = fileMetadata(file);
+  const record: MemoryFileRecord = {
+    id: createId(),
+    kind: "memory-file",
+    title: titleFromFileName(metadata.name),
+    createdAt: timestamps,
+    updatedAt: timestamps,
+    file,
+    ...metadata,
+  };
+
+  memoryRecords.set(record.id, record);
+
+  return sessionFromRecord(record);
+}
+
+export async function createLocalSessionFromPicker() {
+  const picker = typeof window !== "undefined"
+    ? (window as BrowserWithFilePicker).showOpenFilePicker
+    : undefined;
+
+  if (!picker) {
+    return { status: "unsupported" as const };
+  }
+
+  try {
+    const handles = await picker({
+      excludeAcceptAllOption: false,
+      multiple: false,
+      types: VIDEO_PICKER_TYPES,
+    });
+    const handle = handles[0];
+    if (!handle) {
+      return { status: "cancelled" as const };
+    }
+
+    const file = await handle.getFile();
+    const metadata = fileMetadata(file);
+    const timestamps = nowIsoString();
+    const record: StoredFileHandleRecord = {
+      id: createId(),
+      kind: "file-handle",
+      title: titleFromFileName(metadata.name || handle.name),
+      createdAt: timestamps,
+      updatedAt: timestamps,
+      handle,
+      ...metadata,
+      name: metadata.name || handle.name,
+    };
+
+    memoryRecords.set(record.id, record);
+    await putStoredRecord(record).catch(() => undefined);
+
+    return {
+      status: "ready" as const,
+      session: sessionFromRecord(record),
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return { status: "cancelled" as const };
+    }
+
+    return {
+      status: "error" as const,
+      message: err instanceof Error ? err.message : "Could not open that file.",
+    };
+  }
+}
+
+export async function createLocalSessionFromUrl(value: string) {
+  const validation = validateLocalMediaUrl(value);
+  if (!validation.ok) {
+    return {
+      status: "invalid" as const,
+      message: validation.message,
+    };
+  }
+
+  const timestamps = nowIsoString();
+  const record: StoredUrlRecord = {
+    id: createId(),
+    kind: "url",
+    title: titleFromUrl(validation.url),
+    url: validation.url,
+    hls: validation.hls,
+    createdAt: timestamps,
+    updatedAt: timestamps,
+  };
+
+  memoryRecords.set(record.id, record);
+  await putStoredRecord(record).catch(() => undefined);
+
+  return {
+    status: "ready" as const,
+    session: sessionFromRecord(record),
+  };
+}
+
+export async function resolveLocalMediaSession(
+  id: string,
+  options: { requestPermission?: boolean } = {},
+): Promise<LocalMediaResolution> {
+  const memoryRecord = memoryRecords.get(id);
+  if (memoryRecord) {
+    return { status: "ready", session: sessionFromRecord(memoryRecord) };
+  }
+
+  let storedRecord: StoredLocalMediaRecord | undefined;
+  try {
+    storedRecord = await getStoredRecord(id);
+  } catch {
+    return {
+      status: "unavailable",
+      message: "Local media storage is unavailable. Reopen the file or URL to continue.",
+    };
+  }
+
+  if (!storedRecord) {
+    return {
+      status: "missing",
+      message: "This local video is no longer available in this tab. Reopen it to continue.",
+    };
+  }
+
+  if (storedRecord.kind === "url") {
+    return { status: "ready", session: sessionFromRecord(storedRecord) };
+  }
+
+  try {
+    const permission = await resolveFileHandleReadPermission(storedRecord.handle, options);
+
+    if (permission !== "granted") {
+      return {
+        status: "permission-needed",
+        id: storedRecord.id,
+        title: storedRecord.title,
+        message: "Cliparr needs permission to reopen this local file.",
+      };
+    }
+
+    const file = await storedRecord.handle.getFile();
+    const metadata = fileMetadata(file);
+    const nextRecord: StoredFileHandleRecord = {
+      ...storedRecord,
+      ...metadata,
+      name: metadata.name || storedRecord.name,
+      title: titleFromFileName(metadata.name || storedRecord.name),
+      updatedAt: nowIsoString(),
+    };
+
+    await putStoredRecord(nextRecord).catch(() => undefined);
+
+    return { status: "ready", session: sessionFromRecord(nextRecord) };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "NotAllowedError") {
+      return {
+        status: "permission-needed",
+        id: storedRecord.id,
+        title: storedRecord.title,
+        message: "Cliparr needs permission to reopen this local file.",
+      };
+    }
+
+    return {
+      status: "unavailable",
+      title: storedRecord.title,
+      message: "This local file could not be reopened. It may have moved or changed permissions.",
+    };
+  }
+}

--- a/apps/frontend/src/lib/mediabunnyInput.ts
+++ b/apps/frontend/src/lib/mediabunnyInput.ts
@@ -1,4 +1,5 @@
 import type { Input } from "mediabunny";
+import type { EditorMediaSource } from "./editorMedia";
 
 const HLS_PLAYLIST_PATTERN = /\.m3u8(?:$|[?#])/i;
 const HLS_URL_SOURCE_OPTIONS = {
@@ -10,15 +11,22 @@ export function isHlsPlaylistUrl(url: string) {
   return HLS_PLAYLIST_PATTERN.test(url);
 }
 
-export async function createCliparrInputFromUrl(
-  url: string,
+function isHlsMediaSource(source: EditorMediaSource) {
+  return source.kind === "url" && (source.hls === true || isHlsPlaylistUrl(source.url));
+}
+
+export async function createCliparrInputFromSource(
+  source: EditorMediaSource,
   options: { hls?: boolean } = {},
 ): Promise<Input> {
-  const { ALL_FORMATS, HLS_FORMATS, Input, UrlSource } = await import("mediabunny");
-  const isHlsSource = options.hls ?? isHlsPlaylistUrl(url);
+  const { ALL_FORMATS, BlobSource, HLS_FORMATS, Input, UrlSource } = await import("mediabunny");
+  const isHlsSource = options.hls ?? isHlsMediaSource(source);
+  const inputSource = source.kind === "url"
+    ? new UrlSource(source.url, isHlsSource ? HLS_URL_SOURCE_OPTIONS : undefined)
+    : new BlobSource(source.kind === "file" ? source.file : await source.handle.getFile());
 
   return new Input({
-    source: new UrlSource(url, isHlsSource ? HLS_URL_SOURCE_OPTIONS : undefined),
+    source: inputSource,
     formats: isHlsSource ? HLS_FORMATS : ALL_FORMATS,
   });
 }

--- a/apps/frontend/src/providers/types.ts
+++ b/apps/frontend/src/providers/types.ts
@@ -4,6 +4,7 @@ export type {
   CurrentlyPlayingItem,
   MediaExportMetadata,
   PlaybackAudioSelection,
+  PlaybackSource,
   PlaybackSubtitleSelection,
   PlaybackSubtitleTrack,
   SourcePlaybackError,

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProvidersConnectRouteImport } from './routes/providers.connect'
 import { Route as AppSourcesRouteImport } from './routes/_app.sources'
 import { Route as AppDashboardRouteImport } from './routes/_app.dashboard'
+import { Route as LocalEditSessionIdRouteImport } from './routes/local.edit.$sessionId'
 import { Route as AuthPlexCompleteRouteImport } from './routes/auth.plex.complete'
 import { Route as AppEditSessionIdRouteImport } from './routes/_app.edit.$sessionId'
 
@@ -41,6 +42,11 @@ const AppDashboardRoute = AppDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AppRoute,
 } as any)
+const LocalEditSessionIdRoute = LocalEditSessionIdRouteImport.update({
+  id: '/local/edit/$sessionId',
+  path: '/local/edit/$sessionId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthPlexCompleteRoute = AuthPlexCompleteRouteImport.update({
   id: '/auth/plex/complete',
   path: '/auth/plex/complete',
@@ -59,6 +65,7 @@ export interface FileRoutesByFullPath {
   '/providers/connect': typeof ProvidersConnectRoute
   '/edit/$sessionId': typeof AppEditSessionIdRoute
   '/auth/plex/complete': typeof AuthPlexCompleteRoute
+  '/local/edit/$sessionId': typeof LocalEditSessionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -67,6 +74,7 @@ export interface FileRoutesByTo {
   '/providers/connect': typeof ProvidersConnectRoute
   '/edit/$sessionId': typeof AppEditSessionIdRoute
   '/auth/plex/complete': typeof AuthPlexCompleteRoute
+  '/local/edit/$sessionId': typeof LocalEditSessionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -77,6 +85,7 @@ export interface FileRoutesById {
   '/providers/connect': typeof ProvidersConnectRoute
   '/_app/edit/$sessionId': typeof AppEditSessionIdRoute
   '/auth/plex/complete': typeof AuthPlexCompleteRoute
+  '/local/edit/$sessionId': typeof LocalEditSessionIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -87,6 +96,7 @@ export interface FileRouteTypes {
     | '/providers/connect'
     | '/edit/$sessionId'
     | '/auth/plex/complete'
+    | '/local/edit/$sessionId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -95,6 +105,7 @@ export interface FileRouteTypes {
     | '/providers/connect'
     | '/edit/$sessionId'
     | '/auth/plex/complete'
+    | '/local/edit/$sessionId'
   id:
     | '__root__'
     | '/'
@@ -104,6 +115,7 @@ export interface FileRouteTypes {
     | '/providers/connect'
     | '/_app/edit/$sessionId'
     | '/auth/plex/complete'
+    | '/local/edit/$sessionId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -111,6 +123,7 @@ export interface RootRouteChildren {
   AppRoute: typeof AppRouteWithChildren
   ProvidersConnectRoute: typeof ProvidersConnectRoute
   AuthPlexCompleteRoute: typeof AuthPlexCompleteRoute
+  LocalEditSessionIdRoute: typeof LocalEditSessionIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -150,6 +163,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppDashboardRouteImport
       parentRoute: typeof AppRoute
     }
+    '/local/edit/$sessionId': {
+      id: '/local/edit/$sessionId'
+      path: '/local/edit/$sessionId'
+      fullPath: '/local/edit/$sessionId'
+      preLoaderRoute: typeof LocalEditSessionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/auth/plex/complete': {
       id: '/auth/plex/complete'
       path: '/auth/plex/complete'
@@ -186,6 +206,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppRoute: AppRouteWithChildren,
   ProvidersConnectRoute: ProvidersConnectRoute,
   AuthPlexCompleteRoute: AuthPlexCompleteRoute,
+  LocalEditSessionIdRoute: LocalEditSessionIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/frontend/src/routes/_app.dashboard.tsx
+++ b/apps/frontend/src/routes/_app.dashboard.tsx
@@ -1,26 +1,42 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
 import { useAuth } from "../auth";
 import DashboardScreen from "../components/DashboardScreen";
+import { LocalVideoOpenModal } from "../components/LocalVideoOpenModal";
 import { router } from "../router";
 
 function DashboardRouteComponent() {
   const auth = useAuth();
+  const [localVideoOpen, setLocalVideoOpen] = useState(false);
 
   return (
-    <DashboardScreen
-      onSelectSession={(session) => {
-        void router.navigate({
-          to: "/edit/$sessionId",
-          params: {
-            sessionId: session.id,
-          },
-        });
-      }}
-      onOpenSources={() => {
-        void router.navigate({ to: "/sources" });
-      }}
-      onLogout={auth.logout}
-    />
+    <>
+      <DashboardScreen
+        onSelectSession={(session) => {
+          void router.navigate({
+            to: "/edit/$sessionId",
+            params: {
+              sessionId: session.id,
+            },
+          });
+        }}
+        onOpenLocalVideo={() => setLocalVideoOpen(true)}
+        onOpenSources={() => {
+          void router.navigate({ to: "/sources" });
+        }}
+        onLogout={auth.logout}
+      />
+      <LocalVideoOpenModal
+        isOpen={localVideoOpen}
+        onClose={() => setLocalVideoOpen(false)}
+        onOpened={(sessionId) => {
+          void router.navigate({
+            to: "/local/edit/$sessionId",
+            params: { sessionId },
+          });
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/frontend/src/routes/_app.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/_app.edit.$sessionId.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { cliparrClient } from "../api/cliparrClient";
 import EditorScreen from "../components/EditorScreen";
-import type { CurrentlyPlayingItem } from "../providers/types";
+import { editorSessionFromCurrentlyPlaying, type EditorSession } from "../lib/editorMedia";
 import { router } from "../router";
 
 function errorMessage(err: unknown, fallback: string) {
@@ -12,7 +12,7 @@ function errorMessage(err: unknown, fallback: string) {
 function EditorRouteComponent() {
   const { sessionId } = Route.useParams();
   const canGoBack = useCanGoBack();
-  const [session, setSession] = useState<CurrentlyPlayingItem | null>(null);
+  const [session, setSession] = useState<EditorSession | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [attempt, setAttempt] = useState(0);
@@ -41,7 +41,7 @@ function EditorRouteComponent() {
         }
 
         if (!cancelled) {
-          setSession(activeSession);
+          setSession(editorSessionFromCurrentlyPlaying(activeSession));
         }
       } catch (err: unknown) {
         if (!cancelled) {

--- a/apps/frontend/src/routes/local.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/local.edit.$sessionId.tsx
@@ -1,0 +1,117 @@
+import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
+import { FolderOpen, ShieldCheck, TriangleAlert } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import EditorScreen from "../components/EditorScreen";
+import { LocalVideoOpenModal } from "../components/LocalVideoOpenModal";
+import {
+  resolveLocalMediaSession,
+  type LocalMediaResolution,
+} from "../lib/localMediaRegistry";
+import { router } from "../router";
+
+function LocalEditorRouteComponent() {
+  const { sessionId } = Route.useParams();
+  const canGoBack = useCanGoBack();
+  const [resolution, setResolution] = useState<LocalMediaResolution | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [openDialog, setOpenDialog] = useState(false);
+
+  const navigateHome = useCallback(() => {
+    if (canGoBack) {
+      window.history.back();
+      return;
+    }
+
+    void router.navigate({ to: "/", replace: true });
+  }, [canGoBack]);
+
+  const loadSession = useCallback(async (requestPermission = false) => {
+    setLoading(true);
+    try {
+      setResolution(await resolveLocalMediaSession(sessionId, { requestPermission }));
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void loadSession();
+  }, [loadSession]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+        Loading local video...
+      </div>
+    );
+  }
+
+  if (resolution?.status === "ready") {
+    return <EditorScreen session={resolution.session} onBack={navigateHome} />;
+  }
+
+  const title = resolution?.title ?? "Local video";
+  const message = resolution?.message ?? "This local video could not be opened.";
+  const needsPermission = resolution?.status === "permission-needed";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-5 text-card-foreground shadow-lg">
+        <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full border border-border bg-background text-muted-foreground">
+          {needsPermission ? (
+            <ShieldCheck className="h-5 w-5" />
+          ) : (
+            <TriangleAlert className="h-5 w-5" />
+          )}
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+          <p className="text-sm leading-6 text-muted-foreground">{message}</p>
+        </div>
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          {needsPermission && (
+            <button
+              type="button"
+              onClick={() => void loadSession(true)}
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-primary bg-primary px-4 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              <ShieldCheck className="h-4 w-4" />
+              Grant Access
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setOpenDialog(true)}
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-foreground transition-colors hover:bg-accent"
+          >
+            <FolderOpen className="h-4 w-4" />
+            Open Video
+          </button>
+          <button
+            type="button"
+            onClick={navigateHome}
+            className="inline-flex h-9 items-center justify-center rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            Back
+          </button>
+        </div>
+      </div>
+
+      <LocalVideoOpenModal
+        isOpen={openDialog}
+        onClose={() => setOpenDialog(false)}
+        onOpened={(nextSessionId) => {
+          void router.navigate({
+            to: "/local/edit/$sessionId",
+            params: { sessionId: nextSessionId },
+            replace: true,
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/local/edit/$sessionId")({
+  component: LocalEditorRouteComponent,
+});

--- a/apps/frontend/src/routes/providers.connect.tsx
+++ b/apps/frontend/src/routes/providers.connect.tsx
@@ -1,11 +1,32 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useState } from "react";
 import { useAuth } from "../auth";
+import { LocalVideoOpenModal } from "../components/LocalVideoOpenModal";
 import ProviderConnectScreen from "../components/ProviderConnectScreen";
+import { router } from "../router";
 
 function ProviderConnectRouteComponent() {
   const auth = useAuth();
+  const [localVideoOpen, setLocalVideoOpen] = useState(false);
 
-  return <ProviderConnectScreen onConnected={auth.setProviderSession} />;
+  return (
+    <>
+      <ProviderConnectScreen
+        onConnected={auth.setProviderSession}
+        onOpenLocalVideo={() => setLocalVideoOpen(true)}
+      />
+      <LocalVideoOpenModal
+        isOpen={localVideoOpen}
+        onClose={() => setLocalVideoOpen(false)}
+        onOpened={(sessionId) => {
+          void router.navigate({
+            to: "/local/edit/$sessionId",
+            params: { sessionId },
+          });
+        }}
+      />
+    </>
+  );
 }
 
 export const Route = createFileRoute("/providers/connect")({


### PR DESCRIPTION
## Summary

- add a first-class local video flow before login and from the dashboard
- introduce a frontend local media registry for file handles, in-memory file fallback, and URL records
- refactor editor preview/export to consume editor-owned media sources backed by Mediabunny BlobSource or UrlSource
- add local route handling for restored sessions, permission prompts, and missing local media
- document local video behavior and required PR checks

## Validation

- pnpm lint
- pnpm test
- pnpm knip
- pnpm build

## Notes

- Local files are not uploaded or sent to the server.
- URL media is read directly by the browser, so remote CORS and byte-range support still matter.
- Provider API contracts and database schema are unchanged.