### PR TITLE
[codex] Improve timeline controls UX

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -372,14 +372,6 @@ export default function EditorScreen({ session, onBack }: Props) {
                       setCurrentTime(nextTime);
                     }}
                   />
-                  {previewSourceLabel === "HLS stream" && (
-                    <div className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground">Preview Ready</span>
-                      {" "}
-                      shows which parts of the selection are warmed for smoother preview playback.
-                      Export uses a separate read path.
-                    </div>
-                  )}
                 </>
               )}
             </section>

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -290,8 +290,8 @@ export default function EditorScreen({ session, onBack }: Props) {
         onExportClick={handleOpenExportDialog}
       />
 
-      <main className="min-h-0 flex-1 overflow-hidden p-3 sm:p-4">
-        <div className="flex h-full min-h-0 flex-col gap-3 lg:grid lg:grid-cols-[minmax(0,1fr)_auto]">
+      <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-3 sm:p-4 lg:overflow-hidden">
+        <div className="flex min-h-full flex-col gap-3 lg:grid lg:h-full lg:min-h-0 lg:grid-cols-[minmax(0,1fr)_auto]">
           <div className="flex min-h-0 flex-col gap-3">
             {error && (
               <div className="border border-destructive/35 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -307,7 +307,7 @@ export default function EditorScreen({ session, onBack }: Props) {
               />
             </div>
 
-            <section className="flex min-h-0 flex-1 items-center justify-center overflow-hidden border border-border bg-card p-3">
+            <section className="flex min-h-[12rem] flex-none items-center justify-center overflow-hidden border border-border bg-card p-3 sm:min-h-[16rem] lg:min-h-0 lg:flex-1">
               <EditorPreview
                 canvasRef={canvasRef}
                 playing={playing}

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -330,6 +330,10 @@ export default function EditorScreen({ session, onBack }: Props) {
                 setMuted={setMuted}
                 volume={volume}
                 setVolume={setVolume}
+                handleTimelineZoomIn={handleTimelineZoomIn}
+                handleTimelineZoomOut={handleTimelineZoomOut}
+                canZoomIn={canZoomIn}
+                canZoomOut={canZoomOut}
               />
 
               {!hasDuration && (
@@ -357,10 +361,6 @@ export default function EditorScreen({ session, onBack }: Props) {
                     handleTimelineActionMoveEnd={handleTimelineActionMoveEnd}
                     handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
                     handleTimelineWheel={handleTimelineWheel}
-                    handleTimelineZoomIn={handleTimelineZoomIn}
-                    handleTimelineZoomOut={handleTimelineZoomOut}
-                    canZoomIn={canZoomIn}
-                    canZoomOut={canZoomOut}
                     isValidTimelineRange={isValidTimelineRange}
                     seekToTime={seekToTime}
                     onCursorDragStart={() => {

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,4 +1,4 @@
-import { Pause, Play, Volume2, VolumeX } from "lucide-react";
+import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
 import { formatTime } from "./EditorUtils";
 
 interface EditorControlsProps {
@@ -13,6 +13,10 @@ interface EditorControlsProps {
   setMuted: (muted: boolean | ((prev: boolean) => boolean)) => void;
   volume: number;
   setVolume: (volume: number) => void;
+  handleTimelineZoomIn: () => void;
+  handleTimelineZoomOut: () => void;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
 }
 
 export function EditorControls({
@@ -27,6 +31,10 @@ export function EditorControls({
   setMuted,
   volume,
   setVolume,
+  handleTimelineZoomIn,
+  handleTimelineZoomOut,
+  canZoomIn,
+  canZoomOut,
 }: EditorControlsProps) {
   const clipDuration = Math.max(0, endTime - startTime);
   const clipMetrics = [
@@ -75,6 +83,28 @@ export function EditorControls({
             className="w-24 accent-primary sm:w-28"
             aria-label="Preview volume"
           />
+          <div className="ml-1 flex items-center overflow-hidden border border-border bg-background">
+            <button
+              type="button"
+              onClick={handleTimelineZoomOut}
+              disabled={!canZoomOut}
+              className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label="Zoom timeline out"
+              title="Zoom timeline out"
+            >
+              <ZoomOut className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleTimelineZoomIn}
+              disabled={!canZoomIn}
+              className="flex h-8 w-8 items-center justify-center border-l border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label="Zoom timeline in"
+              title="Zoom timeline in"
+            >
+              <ZoomIn className="h-4 w-4" />
+            </button>
+          </div>
         </div>
         <div className="min-w-0 flex-1" />
         <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-right sm:gap-x-6">

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { RefObject, WheelEvent as ReactWheelEvent } from "react";
-import { Scissors, ZoomIn, ZoomOut } from "lucide-react";
+import { Scissors } from "lucide-react";
 import type { PlaybackReadyRange } from "./useEditorPlayback";
 import { 
   formatTime,
@@ -31,10 +31,6 @@ interface EditorTimelineProps {
   handleTimelineActionMoveEnd: (params: { action: { id: string }; start: number; end: number }) => void;
   handleTimelineActionResizeEnd: (params: { action: { id: string }; start: number; end: number }) => void;
   handleTimelineWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
-  handleTimelineZoomIn: () => void;
-  handleTimelineZoomOut: () => void;
-  canZoomIn: boolean;
-  canZoomOut: boolean;
   isValidTimelineRange: (start: number, end: number) => boolean;
   seekToTime: (time: number) => Promise<void> | void;
   onCursorDragStart: () => void;
@@ -58,10 +54,6 @@ export function EditorTimeline({
   handleTimelineActionMoveEnd,
   handleTimelineActionResizeEnd,
   handleTimelineWheel,
-  handleTimelineZoomIn,
-  handleTimelineZoomOut,
-  canZoomIn,
-  canZoomOut,
   isValidTimelineRange,
   seekToTime,
   onCursorDragStart,
@@ -131,28 +123,6 @@ export function EditorTimeline({
       className="cliparr-timeline"
       onWheelCapture={handleTimelineWheel}
     >
-      <div className="cliparr-timeline-zoom-controls" aria-label="Timeline zoom controls">
-        <button
-          type="button"
-          onClick={handleTimelineZoomOut}
-          disabled={!canZoomOut}
-          className="cliparr-timeline-zoom-button"
-          aria-label="Zoom timeline out"
-          title="Zoom timeline out"
-        >
-          <ZoomOut className="h-3.5 w-3.5" />
-        </button>
-        <button
-          type="button"
-          onClick={handleTimelineZoomIn}
-          disabled={!canZoomIn}
-          className="cliparr-timeline-zoom-button"
-          aria-label="Zoom timeline in"
-          title="Zoom timeline in"
-        >
-          <ZoomIn className="h-3.5 w-3.5" />
-        </button>
-      </div>
       <Timeline
         ref={timelineRef}
         editorData={timelineData}

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -178,6 +178,16 @@ export function EditorTimeline({
           void seekToTime(time);
           return false;
         }}
+        onClickRow={(event, { time }) => {
+          if (event.target instanceof HTMLElement && event.target.closest(".timeline-editor-action")) {
+            return;
+          }
+
+          void seekToTime(time);
+        }}
+        onClickActionOnly={(_, { time }) => {
+          void seekToTime(time);
+        }}
         onCursorDragStart={onCursorDragStart}
         onCursorDrag={onCursorDrag}
         onCursorDragEnd={(time) => {

--- a/apps/frontend/src/components/editor/EditorUtils.ts
+++ b/apps/frontend/src/components/editor/EditorUtils.ts
@@ -5,6 +5,8 @@ export const MIN_CLIP_SECONDS = 0.1;
 export const TIMELINE_START_LEFT = 24;
 const MAX_TIMELINE_ZOOM_SCALE_COUNT = 2000;
 export const TIMELINE_ZOOM_WHEEL_STEP = 80;
+const MIN_FOCUSED_TIMELINE_SELECTION_PIXELS = 96;
+const MAX_FOCUSED_TIMELINE_SELECTION_PIXELS = 280;
 const TIMELINE_ZOOM_WIDTH_MULTIPLIERS = [0.64, 0.72, 0.8, 0.88, 0.96, 1.04, 1.12, 1.2] as const;
 
 type TimelineZoomPreset = {
@@ -37,9 +39,23 @@ export function formatTime(seconds: number) {
     return "0:00";
   }
 
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = Math.floor(seconds % 60);
-  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+  const roundedCentiseconds = Math.max(0, Math.round(seconds * 100));
+  const totalSeconds = Math.floor(roundedCentiseconds / 100);
+  const centiseconds = roundedCentiseconds % 100;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const remainingSeconds = totalSeconds % 60;
+  const fraction = centiseconds > 0 ? `.${centiseconds.toString().padStart(2, "0")}` : "";
+
+  if (hours > 0) {
+    return [
+      hours,
+      minutes.toString().padStart(2, "0"),
+      remainingSeconds.toString().padStart(2, "0"),
+    ].join(":") + fraction;
+  }
+
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}${fraction}`;
 }
 
 export function errorMessage(err: unknown) {
@@ -151,6 +167,49 @@ export function getFittingTimelineZoomIndex(
   }
 
   return Math.max(levels.length - 1, 0);
+}
+
+export function getFocusedTimelineZoomIndex(
+  levels: readonly TimelineZoomLevel[],
+  focusDuration: number,
+  viewportWidth: number,
+) {
+  if (levels.length === 0) {
+    return 0;
+  }
+
+  const safeFocusDuration = Math.max(focusDuration, MIN_CLIP_SECONDS);
+  const editableWidth = Math.max(1, viewportWidth - TIMELINE_START_LEFT);
+  const targetSelectionPixels = Math.min(
+    Math.max(MIN_FOCUSED_TIMELINE_SELECTION_PIXELS, editableWidth * 0.32),
+    Math.min(MAX_FOCUSED_TIMELINE_SELECTION_PIXELS, editableWidth * 0.72),
+  );
+  const maximumComfortableSelectionPixels = Math.max(
+    targetSelectionPixels,
+    editableWidth * 0.85,
+  );
+
+  return levels.reduce((bestIndex, level, index) => {
+    const bestLevel = levels[bestIndex];
+    const scoreLevel = (candidate: TimelineZoomLevel) => {
+      const selectionPixels = (safeFocusDuration / candidate.scale) * candidate.scaleWidth;
+      const targetDistance = Math.abs(
+        Math.log2(Math.max(selectionPixels, 1) / targetSelectionPixels),
+      );
+      const undersizedPenalty = Math.max(
+        0,
+        MIN_FOCUSED_TIMELINE_SELECTION_PIXELS - selectionPixels,
+      ) / MIN_FOCUSED_TIMELINE_SELECTION_PIXELS;
+      const oversizedPenalty = Math.max(
+        0,
+        selectionPixels - maximumComfortableSelectionPixels,
+      ) / maximumComfortableSelectionPixels;
+
+      return targetDistance + undersizedPenalty * 3 + oversizedPenalty * 1.5;
+    };
+
+    return scoreLevel(level) < scoreLevel(bestLevel) ? index : bestIndex;
+  }, 0);
 }
 
 export function timelinePixelToTime(pixel: number, scale: number, scaleWidth: number, startLeft: number) {

--- a/apps/frontend/src/components/editor/EditorUtils.ts
+++ b/apps/frontend/src/components/editor/EditorUtils.ts
@@ -153,22 +153,6 @@ export function getClosestTimelineZoomIndex(levels: readonly TimelineZoomLevel[]
   }, 0);
 }
 
-export function getFittingTimelineZoomIndex(
-  levels: readonly TimelineZoomLevel[],
-  duration: number,
-  viewportWidth: number,
-) {
-  const fittingIndex = levels.findIndex((level) => (
-    getTimelineMaxScrollLeft(duration, level.scale, level.scaleWidth, viewportWidth) <= 0
-  ));
-
-  if (fittingIndex !== -1) {
-    return fittingIndex;
-  }
-
-  return Math.max(levels.length - 1, 0);
-}
-
 export function getFocusedTimelineZoomIndex(
   levels: readonly TimelineZoomLevel[],
   focusDuration: number,

--- a/apps/frontend/src/components/editor/timelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.test.ts
@@ -2,7 +2,11 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { TimelineZoomLevel } from "./EditorUtils";
+import {
+  formatTime,
+  getFocusedTimelineZoomIndex,
+  type TimelineZoomLevel,
+} from "./EditorUtils";
 import {
   accumulateTimelineWheelZoomDelta,
   resolveTimelineScrollWheelUpdate,
@@ -33,6 +37,25 @@ void test("keeps the cursor-anchored time stable when changing timeline zoom", (
   });
 });
 
+void test("keeps an explicit zoom anchor time visible when changing timeline zoom", () => {
+  const update = resolveTimelineZoomUpdate({
+    availableTimelineZoomLevels: zoomLevels,
+    currentZoomIndex: 1,
+    fallbackTimelineScale: zoomLevels[1],
+    zoomDelta: -1,
+    currentScrollLeft: 50,
+    duration: 100,
+    regionLeft: 100,
+    regionWidth: 200,
+    anchorTime: 0,
+  });
+
+  assert.deepEqual(update, {
+    nextZoomIndex: 0,
+    nextScrollLeft: 0,
+  });
+});
+
 void test("does not zoom past the available timeline levels", () => {
   assert.equal(resolveTimelineZoomUpdate({
     availableTimelineZoomLevels: zoomLevels,
@@ -44,6 +67,22 @@ void test("does not zoom past the available timeline levels", () => {
     regionLeft: 0,
     regionWidth: 200,
   }), null);
+});
+
+void test("chooses an initial timeline zoom that keeps short selections editable", () => {
+  const focusedLevels = [
+    { scale: 1, scaleSplitCount: 10, scaleWidth: 160 },
+    { scale: 5, scaleSplitCount: 5, scaleWidth: 120 },
+    { scale: 600, scaleSplitCount: 5, scaleWidth: 152 },
+  ] satisfies TimelineZoomLevel[];
+
+  assert.equal(getFocusedTimelineZoomIndex(focusedLevels, 10, 900), 1);
+  assert.equal(getFocusedTimelineZoomIndex(focusedLevels, 1, 900), 0);
+});
+
+void test("formats editor time with hours and sub-second precision when needed", () => {
+  assert.equal(formatTime(7425), "2:03:45");
+  assert.equal(formatTime(0.1), "0:00.10");
 });
 
 void test("combines horizontal and vertical wheel deltas for timeline scrolling", () => {

--- a/apps/frontend/src/components/editor/timelineZoom.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.ts
@@ -19,6 +19,7 @@ interface ResolveTimelineZoomUpdateOptions {
   regionLeft: number;
   regionWidth: number;
   anchorClientX?: number;
+  anchorTime?: number;
 }
 
 interface TimelineZoomUpdate {
@@ -54,6 +55,7 @@ export function resolveTimelineZoomUpdate({
   regionLeft,
   regionWidth,
   anchorClientX,
+  anchorTime,
 }: ResolveTimelineZoomUpdateOptions): TimelineZoomUpdate | null {
   if (availableTimelineZoomLevels.length < 2 || zoomDelta === 0) {
     return null;
@@ -81,20 +83,22 @@ export function resolveTimelineZoomUpdate({
     ? Math.min(Math.max(anchorClientX - regionLeft, 0), regionWidth)
     : regionWidth / 2;
   const anchorPixel = Math.max(TIMELINE_START_LEFT, currentScrollLeft + pointerX);
-  const anchorTime = Math.min(
+  const resolvedAnchorTime = Math.min(
     duration,
     Math.max(
       0,
-      timelinePixelToTime(
-        anchorPixel,
-        currentTimelineScale.scale,
-        currentTimelineScale.scaleWidth,
-        TIMELINE_START_LEFT,
-      ),
+      typeof anchorTime === "number"
+        ? anchorTime
+        : timelinePixelToTime(
+          anchorPixel,
+          currentTimelineScale.scale,
+          currentTimelineScale.scaleWidth,
+          TIMELINE_START_LEFT,
+        ),
     ),
   );
   const nextAnchorPixel = timelineTimeToPixel(
-    anchorTime,
+    resolvedAnchorTime,
     nextTimelineScale.scale,
     nextTimelineScale.scaleWidth,
     TIMELINE_START_LEFT,

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -3,11 +3,14 @@ import type { TimelineState } from "@xzdarcy/react-timeline-editor";
 import { 
   getTimelineZoomLevels, 
   getClosestTimelineZoomIndex, 
-  getFittingTimelineZoomIndex,
+  getFocusedTimelineZoomIndex,
+  getTimelineMaxScrollLeft,
   timelineScaleForDuration, 
   getTimelineZoomLevel, 
   roundTimelineTime, 
   MIN_CLIP_SECONDS, 
+  TIMELINE_START_LEFT,
+  timelineTimeToPixel,
   type ClipTimelineData,
   type ClipTimelineEffects
 } from "./EditorUtils";
@@ -27,6 +30,56 @@ interface UseEditorTimelineProps {
   onClipRangeCommit?: (start: number, end: number) => void;
 }
 
+interface TimelineZoomAnchorOptions {
+  anchorClientX?: number;
+  anchorTime?: number;
+}
+
+function getTimelineRangeScrollLeft({
+  start,
+  end,
+  duration,
+  timelineScale,
+  viewportWidth,
+}: {
+  start: number;
+  end: number;
+  duration: number;
+  timelineScale: { scale: number; scaleWidth: number };
+  viewportWidth: number;
+}) {
+  const safeStart = Math.min(Math.max(start, 0), duration);
+  const safeEnd = Math.min(Math.max(end, safeStart), duration);
+  const startPixel = timelineTimeToPixel(
+    safeStart,
+    timelineScale.scale,
+    timelineScale.scaleWidth,
+    TIMELINE_START_LEFT,
+  );
+  const endPixel = timelineTimeToPixel(
+    safeEnd,
+    timelineScale.scale,
+    timelineScale.scaleWidth,
+    TIMELINE_START_LEFT,
+  );
+  const selectionWidth = Math.max(0, endPixel - startPixel);
+  const viewportGutter = Math.min(
+    Math.max(TIMELINE_START_LEFT, viewportWidth * 0.18),
+    viewportWidth * 0.35,
+  );
+  const desiredScrollLeft = selectionWidth >= viewportWidth - viewportGutter
+    ? startPixel - viewportGutter
+    : startPixel - ((viewportWidth - selectionWidth) / 2);
+  const maxScrollLeft = getTimelineMaxScrollLeft(
+    duration,
+    timelineScale.scale,
+    timelineScale.scaleWidth,
+    viewportWidth,
+  );
+
+  return Math.min(maxScrollLeft, Math.max(0, desiredScrollLeft));
+}
+
 export function useEditorTimeline({
   duration,
   startTime,
@@ -43,6 +96,7 @@ export function useEditorTimeline({
   const pendingTimelineScrollLeftRef = useRef<number | null>(null);
   const timelineWheelDeltaRef = useRef(0);
   const hasUserAdjustedTimelineZoomRef = useRef(false);
+  const hasPositionedTimelineViewRef = useRef(false);
   const [timelineScrollLeft, setTimelineScrollLeft] = useState(0);
   const [timelineViewportWidth, setTimelineViewportWidth] = useState(0);
 
@@ -59,17 +113,23 @@ export function useEditorTimeline({
     () => getClosestTimelineZoomIndex(availableTimelineZoomLevels, defaultTimelineScale),
     [availableTimelineZoomLevels, defaultTimelineScale],
   );
-  const fitTimelineZoomIndex = useMemo(() => {
+  const focusedTimelineZoomIndex = useMemo(() => {
     if (timelineViewportWidth <= 0) {
       return defaultTimelineZoomIndex;
     }
 
-    return getFittingTimelineZoomIndex(
+    return getFocusedTimelineZoomIndex(
       availableTimelineZoomLevels,
-      duration,
+      Math.max(endTime - startTime, MIN_CLIP_SECONDS),
       timelineViewportWidth,
     );
-  }, [availableTimelineZoomLevels, defaultTimelineZoomIndex, duration, timelineViewportWidth]);
+  }, [
+    availableTimelineZoomLevels,
+    defaultTimelineZoomIndex,
+    endTime,
+    startTime,
+    timelineViewportWidth,
+  ]);
 
   const [timelineZoomIndex, setTimelineZoomIndex] = useState(defaultTimelineZoomIndex);
   const timelineZoomIndexRef = useRef(timelineZoomIndex);
@@ -164,24 +224,54 @@ export function useEditorTimeline({
     timelineScrollLeftRef.current = 0;
     timelineWheelDeltaRef.current = 0;
     hasUserAdjustedTimelineZoomRef.current = false;
+    hasPositionedTimelineViewRef.current = false;
     timelineRef.current?.setScrollLeft(0);
     pendingTimelineScrollLeftRef.current = 0;
     setTimelineScrollLeft(0);
   }, [defaultTimelineZoomIndex, sessionId]);
 
   useEffect(() => {
-    if (!hasDuration || timelineViewportWidth <= 0 || hasUserAdjustedTimelineZoomRef.current) {
+    if (
+      !hasDuration
+      || timelineViewportWidth <= 0
+      || hasUserAdjustedTimelineZoomRef.current
+      || hasPositionedTimelineViewRef.current
+    ) {
       return;
     }
 
-    setTimelineZoomIndex(fitTimelineZoomIndex);
-    timelineZoomIndexRef.current = fitTimelineZoomIndex;
-    timelineScrollLeftRef.current = 0;
+    const focusedTimelineScale = getTimelineZoomLevel(
+      availableTimelineZoomLevels,
+      focusedTimelineZoomIndex,
+      getTimelineZoomLevel(availableTimelineZoomLevels, defaultTimelineZoomIndex, defaultTimelineScale),
+    );
+    const nextScrollLeft = getTimelineRangeScrollLeft({
+      start: startTime,
+      end: endTime,
+      duration,
+      timelineScale: focusedTimelineScale,
+      viewportWidth: timelineViewportWidth,
+    });
+
+    setTimelineZoomIndex(focusedTimelineZoomIndex);
+    timelineZoomIndexRef.current = focusedTimelineZoomIndex;
+    timelineScrollLeftRef.current = nextScrollLeft;
     timelineWheelDeltaRef.current = 0;
-    timelineRef.current?.setScrollLeft(0);
-    pendingTimelineScrollLeftRef.current = 0;
-    setTimelineScrollLeft(0);
-  }, [fitTimelineZoomIndex, hasDuration, timelineViewportWidth]);
+    hasPositionedTimelineViewRef.current = true;
+    timelineRef.current?.setScrollLeft(nextScrollLeft);
+    pendingTimelineScrollLeftRef.current = nextScrollLeft;
+    setTimelineScrollLeft(nextScrollLeft);
+  }, [
+    availableTimelineZoomLevels,
+    defaultTimelineScale,
+    defaultTimelineZoomIndex,
+    duration,
+    endTime,
+    focusedTimelineZoomIndex,
+    hasDuration,
+    startTime,
+    timelineViewportWidth,
+  ]);
 
   useEffect(() => {
     const pendingScrollLeft = pendingTimelineScrollLeftRef.current;
@@ -202,7 +292,15 @@ export function useEditorTimeline({
     setTimelineScrollLeft(scrollLeft);
   }, []);
 
-  const updateTimelineZoom = useCallback((zoomDelta: number, anchorClientX?: number) => {
+  const getTimelineZoomAnchorTime = useCallback(() => {
+    if (currentTime >= startTime && currentTime <= endTime) {
+      return currentTime;
+    }
+
+    return startTime + ((endTime - startTime) / 2);
+  }, [currentTime, endTime, startTime]);
+
+  const updateTimelineZoom = useCallback((zoomDelta: number, anchorOptions: TimelineZoomAnchorOptions = {}) => {
     if (!hasDuration || availableTimelineZoomLevels.length < 2 || zoomDelta === 0) {
       return;
     }
@@ -222,7 +320,8 @@ export function useEditorTimeline({
       duration,
       regionLeft: regionRect.left,
       regionWidth: regionRect.width,
-      anchorClientX,
+      anchorClientX: anchorOptions.anchorClientX,
+      anchorTime: anchorOptions.anchorTime,
     });
     if (!zoomUpdate) {
       timelineWheelDeltaRef.current = 0;
@@ -242,12 +341,12 @@ export function useEditorTimeline({
   }, [activeTimelineScale, availableTimelineZoomLevels, duration, hasDuration]);
 
   const handleTimelineZoomIn = useCallback(() => {
-    updateTimelineZoom(-1);
-  }, [updateTimelineZoom]);
+    updateTimelineZoom(-1, { anchorTime: getTimelineZoomAnchorTime() });
+  }, [getTimelineZoomAnchorTime, updateTimelineZoom]);
 
   const handleTimelineZoomOut = useCallback(() => {
-    updateTimelineZoom(1);
-  }, [updateTimelineZoom]);
+    updateTimelineZoom(1, { anchorTime: getTimelineZoomAnchorTime() });
+  }, [getTimelineZoomAnchorTime, updateTimelineZoom]);
 
   const handleTimelineWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
     if (!hasDuration) return;
@@ -294,7 +393,7 @@ export function useEditorTimeline({
     });
     timelineWheelDeltaRef.current = accumulatedWheelDelta;
     if (zoomDelta === 0) return;
-    updateTimelineZoom(zoomDelta, event.clientX);
+    updateTimelineZoom(zoomDelta, { anchorClientX: event.clientX });
   }, [hasDuration, duration, activeTimelineScale, availableTimelineZoomLevels, updateTimelineZoom]);
 
   const handleTimelineChange = useCallback((nextData: ClipTimelineData) => {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -283,6 +283,8 @@
     background: color-mix(in oklch, var(--ring) 44%, var(--background));
     color: var(--foreground);
     box-shadow: none;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .cliparr-timeline .timeline-editor-action-effect-source {
@@ -322,6 +324,8 @@
     overflow: hidden;
     padding: 0 12px;
     white-space: nowrap;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .cliparr-timeline-action-label {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -236,6 +236,37 @@
     background: var(--card);
   }
 
+  .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid {
+    overflow-x: scroll !important;
+    overflow-y: hidden !important;
+    scrollbar-color:
+      color-mix(in oklch, var(--muted-foreground) 44%, transparent)
+      color-mix(in oklch, var(--muted) 70%, var(--card));
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+  }
+
+  .cliparr-timeline .timeline-editor:hover .timeline-editor-edit-area .ReactVirtualized__Grid::-webkit-scrollbar,
+  .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid::-webkit-scrollbar {
+    width: 0;
+    height: 10px;
+  }
+
+  .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid::-webkit-scrollbar-track {
+    background: color-mix(in oklch, var(--muted) 70%, var(--card)) !important;
+  }
+
+  .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid::-webkit-scrollbar-thumb {
+    min-width: 44px;
+    border: 2px solid color-mix(in oklch, var(--muted) 70%, var(--card));
+    border-radius: 999px;
+    background: color-mix(in oklch, var(--muted-foreground) 44%, transparent);
+  }
+
+  .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklch, var(--foreground) 44%, transparent);
+  }
+
   .cliparr-timeline .timeline-editor-edit-row {
     background-image:
       linear-gradient(

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -196,47 +196,7 @@
   .cliparr-timeline {
     position: relative;
     width: 100%;
-    padding-top: 30px;
     background: var(--card);
-  }
-
-  .cliparr-timeline-zoom-controls {
-    position: absolute;
-    top: 3px;
-    right: 6px;
-    z-index: 5;
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-    border: 1px solid var(--border);
-    background: color-mix(in oklch, var(--background) 92%, transparent);
-  }
-
-  .cliparr-timeline-zoom-button {
-    display: flex;
-    width: 26px;
-    height: 24px;
-    align-items: center;
-    justify-content: center;
-    color: var(--muted-foreground);
-    transition:
-      background-color 150ms ease,
-      color 150ms ease,
-      opacity 150ms ease;
-  }
-
-  .cliparr-timeline-zoom-button + .cliparr-timeline-zoom-button {
-    border-left: 1px solid var(--border);
-  }
-
-  .cliparr-timeline-zoom-button:hover:not(:disabled) {
-    background: var(--accent);
-    color: var(--foreground);
-  }
-
-  .cliparr-timeline-zoom-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.45;
   }
 
   .cliparr-timeline .timeline-editor {
@@ -371,7 +331,7 @@
 
   .cliparr-timeline-ready-range {
     position: absolute;
-    top: 94px;
+    top: 64px;
     height: 44px;
     z-index: 2;
     border-radius: 1px;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -196,11 +196,13 @@
   .cliparr-timeline {
     position: relative;
     width: 100%;
+    padding-top: 30px;
+    background: var(--card);
   }
 
   .cliparr-timeline-zoom-controls {
     position: absolute;
-    top: 4px;
+    top: 3px;
     right: 6px;
     z-index: 5;
     display: flex;
@@ -369,7 +371,7 @@
 
   .cliparr-timeline-ready-range {
     position: absolute;
-    top: 64px;
+    top: 94px;
     height: 44px;
     z-index: 2;
     border-radius: 1px;

--- a/apps/server/src/logging.ts
+++ b/apps/server/src/logging.ts
@@ -22,6 +22,7 @@ export function serializeError(error: unknown) {
   }
 
   return {
+    errorMessage: String(error),
     errorValue: String(error),
   };
 }
@@ -47,7 +48,7 @@ export function configureLogging() {
         lowestLevel,
       },
       {
-        category: "logtape",
+        category: ["logtape", "meta"],
         sinks: ["console"],
         lowestLevel: "warning",
       },

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -75,7 +75,7 @@ async function startServer() {
 
 
 startServer().catch((err: unknown) => {
-  logger.fatal("Failed to start server.", serializeError(err));
+  logger.fatal("Failed to start server: {errorMessage}", serializeError(err));
   closeDatabase();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

- keep the initial timeline zoom focused on the editable clip range instead of fitting the whole source
- anchor zoom buttons around the playhead/selection and keep wheel zoom cursor-anchored
- improve editor time formatting with hours and centiseconds
- make the mobile editor scroll naturally so the preview and timeline stay usable
- move zoom controls out of the timeline ruler hit area

## Validation

- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/frontend lint:eslint
- browser check with a mocked 123:45 session at desktop and 390px mobile widths
