### PR TITLE
[codex] Clean up app version fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG CLIPARR_VERSION=0.0.0
+ARG CLIPARR_VERSION
 
 FROM node:24-slim AS base
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cliparr/frontend",
   "private": true,
-  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -16,7 +16,7 @@ interface ResponseErrorDetails {
 interface HealthResponse {
   status: string;
   database: string;
-  version: string;
+  version?: string;
 }
 
 class CliparrRequestError extends Error {

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -133,7 +133,7 @@ export default function DashboardScreen({ onSelectSession, onOpenSources, onLogo
     void cliparrClient.getHealth()
       .then((health) => {
         if (!cancelled) {
-          setAppVersion(health.version);
+          setAppVersion(health.version ?? "");
         }
       })
       .catch(() => {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cliparr/server",
   "private": true,
-  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "node --watch-path=./src --import tsx ./src/server.ts",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,7 +38,11 @@ export async function createApp() {
 
   app.get("/api/health", (_req, res) => {
     checkDatabaseHealth();
-    res.json({ status: "ok", database: "ok", version: CLIPARR_VERSION });
+    res.json({
+      status: "ok",
+      database: "ok",
+      ...(CLIPARR_VERSION ? { version: CLIPARR_VERSION } : {}),
+    });
   });
 
   app.use("/api/providers", providersRouter);

--- a/apps/server/src/config/version.test.ts
+++ b/apps/server/src/config/version.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveCliparrVersion } from "./version.js";
+import { resolveCliparrClientVersion, resolveCliparrVersion } from "./version.js";
 
 void test("uses CI build identity exactly as provided", () => {
   assert.equal(
@@ -14,18 +14,28 @@ void test("uses CI build identity exactly as provided", () => {
 void test("preserves release tags as display-ready values", () => {
   assert.equal(
     resolveCliparrVersion({
-      CLIPARR_VERSION: "v0.4.0",
+      CLIPARR_VERSION: "v1.2.3",
     }),
-    "v0.4.0"
+    "v1.2.3"
   );
 });
 
-void test("falls back to the package version when environment values are empty", () => {
+void test("omits the display version when CI has not injected one", () => {
   assert.equal(
     resolveCliparrVersion({
       CLIPARR_VERSION: " ",
-      npm_package_version: "",
+      npm_package_version: "9.9.9",
     }),
-    "0.4.0"
+    undefined
+  );
+});
+
+void test("uses an explicit local client version when CI has not injected one", () => {
+  assert.equal(
+    resolveCliparrClientVersion({
+      CLIPARR_VERSION: "",
+      npm_package_version: "9.9.9",
+    }),
+    "dev"
   );
 });

--- a/apps/server/src/config/version.ts
+++ b/apps/server/src/config/version.ts
@@ -1,9 +1,4 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const packageJsonPath = path.resolve(__dirname, "../../package.json");
+const LOCAL_CLIENT_VERSION = "dev";
 
 function normalizeVersion(value: string | undefined) {
   const normalized = value?.trim();
@@ -14,25 +9,13 @@ function normalizeVersion(value: string | undefined) {
   return normalized;
 }
 
-function readPackageVersion() {
-  try {
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-      version?: unknown;
-    };
-
-    return typeof packageJson.version === "string" ? normalizeVersion(packageJson.version) : undefined;
-  } catch {
-    return undefined;
-  }
+export function resolveCliparrVersion(env: NodeJS.ProcessEnv = process.env) {
+  return normalizeVersion(env.CLIPARR_VERSION);
 }
 
-export function resolveCliparrVersion(env: NodeJS.ProcessEnv = process.env) {
-  return (
-    normalizeVersion(env.CLIPARR_VERSION) ??
-    normalizeVersion(env.npm_package_version) ??
-    readPackageVersion() ??
-    "0.0.0"
-  );
+export function resolveCliparrClientVersion(env: NodeJS.ProcessEnv = process.env) {
+  return resolveCliparrVersion(env) ?? LOCAL_CLIENT_VERSION;
 }
 
 export const CLIPARR_VERSION = resolveCliparrVersion();
+export const CLIPARR_CLIENT_VERSION = resolveCliparrClientVersion();

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -1,14 +1,14 @@
 import { createHash, randomUUID } from "crypto";
 import { lookup } from "dns/promises";
 import { isIP } from "net";
-import { CLIPARR_VERSION } from "../../config/version.js";
+import { CLIPARR_CLIENT_VERSION } from "../../config/version.js";
 import type { MediaSource } from "../../db/mediaSourcesRepository.js";
 import { ApiError } from "../../http/errors.js";
 import { errorMessage, numberValue, stringValue, uniqueStrings } from "../shared/utils.js";
 
 const JELLYFIN_PRODUCT = "Cliparr";
 const JELLYFIN_DEVICE_NAME = "Cliparr";
-const JELLYFIN_VERSION = CLIPARR_VERSION;
+const JELLYFIN_VERSION = CLIPARR_CLIENT_VERSION;
 
 export const JELLYFIN_REQUEST_TIMEOUT_MS = 5000;
 const CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS = 5000;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "cliparr",
   "private": true,
-  "version": "0.4.0",
   "description": "Plex clipper for exporting MP4 clips from active playback sessions, featuring a React frontend and Express server.",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cliparr/shared",
   "private": true,
-  "version": "0.4.0",
   "type": "module",
   "types": "./src/providers.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- stop deriving the displayed app version from package metadata in local/dev runs
- only include the health-check version when `CLIPARR_VERSION` is injected by CI or Docker build metadata
- keep Jellyfin client versioning explicit with a local `dev` fallback
- remove stale private package manifest version fields and Docker's baked-in default version

## Root cause
The server version resolver fell back to `npm_package_version`, which pnpm populated from `apps/server/package.json` during `pnpm dev`. That made the dashboard display the stale manifest value even though CI injects the real build identity separately.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @cliparr/server test`
- `pnpm --filter @cliparr/server lint:types`
- `pnpm --filter @cliparr/frontend lint:types`
- `pnpm --filter @cliparr/server lint:eslint`
- `pnpm --filter @cliparr/frontend lint:eslint`
- `pnpm build`