### PR TITLE
[codex] Fix home server security issues

### DIFF
--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -37,7 +37,6 @@ import {
   booleanValue,
   fetchItem,
   fetchSessions,
-  jellyfinFetch,
   jellyfinHeaders,
   JELLYFIN_REQUEST_TIMEOUT_MS,
   sourceContext,
@@ -662,34 +661,21 @@ export async function proxyMedia(
     },
     async () => {
       try {
-        if (!useProviderAuth) {
-          const upstream = await fetchMediaHandleRequest(handle, {
-            headers,
-            signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
-          });
+        const upstream = await fetchMediaHandleRequest(handle, {
+          headers,
+          signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
+        });
 
-          if (!upstream.ok && upstream.status !== 206) {
-            const detail = (await upstream.text()).slice(0, 400).replace(/\s+/g, " ").trim();
-            throw new ApiError(
-              upstream.status,
-              "jellyfin_media_failed",
-              detail ? `Jellyfin media request failed: ${detail}` : "Jellyfin media request failed",
-            );
-          }
-
-          return upstream;
+        if (!upstream.ok && upstream.status !== 206) {
+          const detail = (await upstream.text()).slice(0, 400).replace(/\s+/g, " ").trim();
+          throw new ApiError(
+            upstream.status,
+            "jellyfin_media_failed",
+            detail ? `Jellyfin media request failed: ${detail}` : "Jellyfin media request failed",
+          );
         }
 
-        return await jellyfinFetch(upstreamUrl, {
-          headers,
-        }, {
-          token: handle.token,
-          deviceId: handle.deviceId,
-          accept,
-          timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
-          errorCode: "jellyfin_media_failed",
-          failureMessage: "Jellyfin media request failed",
-        });
+        return upstream;
       } catch (err) {
         logger.warn("Jellyfin media request failed for handle {handleId}.", {
           handleId: handle.id,

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.js";
 import {
   createProviderMediaHandle,
+  fetchMediaHandleRequest,
   mediaHandleRequestUrl,
   playlistBasePath,
   proxyProviderMediaResponse,
@@ -662,7 +663,7 @@ export async function proxyMedia(
     async () => {
       try {
         if (!useProviderAuth) {
-          const upstream = await fetch(upstreamUrl, {
+          const upstream = await fetchMediaHandleRequest(handle, {
             headers,
             signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
           });

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -306,7 +306,7 @@ export function jellyfinHeaders(options: {
   return headers;
 }
 
-export async function jellyfinFetch(
+async function jellyfinFetch(
   url: string,
   init: RequestInit = {},
   options: {

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { Request, Response } from "express";
 import type { ProviderSessionRecord } from "../session/store.js";
-import { buildPreviewPath, deriveSelectedSubtitleTrack, deriveSubtitleTracks } from "./jellyfin/playback.js";
+import {
+  buildPreviewPath,
+  deriveSelectedSubtitleTrack,
+  deriveSubtitleTracks,
+  proxyMedia,
+} from "./jellyfin/playback.js";
 import type { JellyfinSourceContext } from "./jellyfin/shared.js";
 
 function createSession(): ProviderSessionRecord {
@@ -31,6 +37,34 @@ function onlyMediaHandle(session: ProviderSessionRecord) {
   const handle = [...session.mediaHandles.values()][0];
   assert(handle);
   return handle;
+}
+
+function createRequest(headers: Record<string, string> = {}) {
+  return {
+    header(name: string) {
+      return headers[name.toLowerCase()];
+    },
+  } as Pick<Request, "header">;
+}
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    ended: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(name: string, value: string | number) {
+      this.headers.set(name.toLowerCase(), String(value));
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
 }
 
 void test("disables Jellyfin subtitle burn-in on HLS previews", () => {
@@ -217,4 +251,53 @@ void test("leaves Jellyfin image subtitle streams visible but unsupported for bu
   assert.equal(tracks[0]?.contentUrl, undefined);
   assert.equal(tracks[0]?.contentFormat, undefined);
   assert.equal(session.mediaHandles.size, 0);
+});
+
+void test("strips Jellyfin auth headers from cross-origin media redirects", async () => {
+  const session = createSession();
+  session.mediaHandles.set("handle-1", {
+    id: "handle-1",
+    providerId: "jellyfin",
+    sourceId: "source-1",
+    baseUrl: "http://jellyfin.local:8096",
+    path: "/Videos/item-1/stream",
+    token: "provider-token",
+    deviceId: "cliparr-device-1",
+    lastAccessedAt: 0,
+  });
+
+  const originalFetch = globalThis.fetch;
+  const requestHeaders: Headers[] = [];
+
+  globalThis.fetch = (async (_input, init) => {
+    requestHeaders.push(new Headers(init?.headers));
+    if (requestHeaders.length === 1) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: "http://1.1.1.1/video.mp4",
+        },
+      });
+    }
+
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const response = createResponseRecorder();
+    await proxyMedia(
+      session,
+      "handle-1",
+      createRequest({ accept: "video/mp4" }) as Request,
+      response as unknown as Response
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.ended, true);
+    assert.match(requestHeaders[0]?.get("authorization") ?? "", /Token="provider-token"/);
+    assert.equal(requestHeaders[1]?.get("authorization"), null);
+    assert.equal(requestHeaders[1]?.get("accept"), "video/mp4");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { Response } from "express";
+import { ApiError } from "../http/errors.js";
 import type { ProviderSessionRecord } from "../session/store.js";
 import type { MediaHandle } from "./types.js";
 import {
+  assertAllowedMediaHandleRequestUrl,
+  fetchMediaHandleRequest,
   proxyProviderMediaResponse,
   proxyUpstreamMediaResponse,
   sanitizeLoggedMediaPath,
@@ -174,6 +177,59 @@ void test("does not attach provider auth to cross-origin absolute media handles"
     path: "https://cdn.example.com/hls/segment0.ts?sig=secret",
     basePath: "https://cdn.example.com/hls/",
   })), false);
+});
+
+void test("allows configured provider origins even when they are private", async () => {
+  await assert.doesNotReject(async () => {
+    await assertAllowedMediaHandleRequestUrl(createMediaHandle({
+      baseUrl: "http://192.168.1.10:32400",
+      path: "/video/master.m3u8",
+    }));
+  });
+});
+
+void test("rejects cross-origin HLS media handles to private addresses", async () => {
+  await assert.rejects(
+    () => assertAllowedMediaHandleRequestUrl(createMediaHandle({
+      path: "http://127.0.0.1:8080/admin",
+      basePath: "http://1.1.1.1/hls/",
+    })),
+    (err: unknown) =>
+      err instanceof ApiError
+      && err.status === 400
+      && err.code === "media_proxy_unsafe_url"
+  );
+});
+
+void test("validates cross-origin media redirects before following them", async () => {
+  const originalFetch = globalThis.fetch;
+  let redirectMode: unknown;
+
+  globalThis.fetch = (async (_input, init) => {
+    redirectMode = init?.redirect;
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: "http://127.0.0.1/admin",
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      () => fetchMediaHandleRequest(createMediaHandle({
+        path: "http://1.1.1.1/hls/segment.ts",
+        basePath: "http://1.1.1.1/hls/",
+      })),
+      (err: unknown) =>
+        err instanceof ApiError
+        && err.status === 400
+        && err.code === "media_proxy_unsafe_url"
+    );
+    assert.equal(redirectMode, "manual");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 void test("sanitizes logged media paths by stripping query strings", () => {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -198,6 +198,7 @@ void test("rejects cross-origin HLS media handles to private addresses", async (
       err instanceof ApiError
       && err.status === 400
       && err.code === "media_proxy_unsafe_url"
+      && err.message === "Media URL points at an unsafe internal address"
   );
 });
 
@@ -227,6 +228,80 @@ void test("validates cross-origin media redirects before following them", async 
         && err.code === "media_proxy_unsafe_url"
     );
     assert.equal(redirectMode, "manual");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("validates same-origin media redirects before following them", async () => {
+  const originalFetch = globalThis.fetch;
+  let redirectMode: unknown;
+
+  globalThis.fetch = (async (_input, init) => {
+    redirectMode = init?.redirect;
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: "http://127.0.0.1/admin",
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      () => fetchMediaHandleRequest(createMediaHandle({
+        baseUrl: "http://192.168.1.10:32400",
+        path: "/library/parts/1/file.mp4",
+      })),
+      (err: unknown) =>
+        err instanceof ApiError
+        && err.status === 400
+        && err.code === "media_proxy_unsafe_url"
+    );
+    assert.equal(redirectMode, "manual");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("strips provider auth headers from cross-origin media redirects", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestHeaders: Headers[] = [];
+
+  globalThis.fetch = (async (_input, init) => {
+    requestHeaders.push(new Headers(init?.headers));
+    if (requestHeaders.length === 1) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: "http://1.1.1.1/hls/segment.ts",
+        },
+      });
+    }
+
+    return new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(createMediaHandle({
+      baseUrl: "http://192.168.1.10:32400",
+      path: "/video/master.m3u8",
+    }), {
+      headers: {
+        accept: "video/mp2t",
+        authorization: "MediaBrowser Token=secret",
+        "x-plex-token": "secret",
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(requestHeaders.length, 2);
+    assert.equal(requestHeaders[0]?.get("x-plex-token"), "secret");
+    assert.equal(requestHeaders[1]?.get("x-plex-token"), null);
+    assert.equal(requestHeaders[1]?.get("authorization"), null);
+    assert.equal(requestHeaders[1]?.get("accept"), "video/mp2t");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
 import { ApiError } from "../../http/errors.js";
 import {
   AUTH_TTL_MS,
@@ -13,6 +13,21 @@ import {
 } from "./shared.js";
 
 const authRequests = new Map<string, PlexAuthRequest>();
+const AUTH_POLL_TOKEN_BYTES = 32;
+
+function createAuthPollToken() {
+  return randomBytes(AUTH_POLL_TOKEN_BYTES).toString("base64url");
+}
+
+function hashAuthPollToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function authPollTokenMatches(expectedHash: string, token: string) {
+  const expected = Buffer.from(expectedHash, "hex");
+  const actual = Buffer.from(hashAuthPollToken(token), "hex");
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
 
 function pruneExpiredAuthRequests(now = Date.now()) {
   for (const [authId, authRequest] of authRequests.entries()) {
@@ -38,11 +53,13 @@ export async function startAuth(callbackUrl: string) {
   }
 
   const authId = randomUUID();
+  const pollToken = createAuthPollToken();
   const expiresAt = Date.now() + (data.expiresIn ? data.expiresIn * 1000 : AUTH_TTL_MS);
   authRequests.set(authId, {
     authId,
     pinId: data.id,
     code: data.code,
+    pollTokenHash: hashAuthPollToken(pollToken),
     expiresAt,
   });
 
@@ -58,10 +75,11 @@ export async function startAuth(callbackUrl: string) {
     authId,
     authUrl: authUrl.toString(),
     expiresAt: new Date(expiresAt).toISOString(),
+    pollToken,
   };
 }
 
-export async function pollAuth(authId: string) {
+export async function pollAuth(authId: string, pollToken: string) {
   pruneExpiredAuthRequests();
   const authRequest = authRequests.get(authId);
   if (!authRequest) {
@@ -71,6 +89,14 @@ export async function pollAuth(authId: string) {
   if (authRequest.expiresAt <= Date.now()) {
     authRequests.delete(authId);
     return { status: "expired" as const };
+  }
+
+  if (!authPollTokenMatches(authRequest.pollTokenHash, pollToken)) {
+    throw new ApiError(
+      401,
+      "invalid_plex_auth_session",
+      "Plex sign-in must be completed from the browser that started it"
+    );
   }
 
   const response = await plexFetch(`https://plex.tv/api/v2/pins/${authRequest.pinId}`);

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import {
   createProviderMediaHandle,
+  fetchMediaHandleRequest,
   mediaHandleRequestUrl,
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
@@ -943,7 +944,7 @@ export async function proxyMedia(
       range: range ?? undefined,
     },
     async () => {
-      const upstream = await fetch(url.toString(), { headers });
+      const upstream = await fetchMediaHandleRequest(handle, { headers });
       if (!upstream.ok && upstream.status !== 206) {
         const detail = (await upstream.text()).slice(0, 400).replace(/\s+/g, " ").trim();
         logger.warn("Plex media request failed for handle {handleId}.", {

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -23,6 +23,7 @@ export interface PlexAuthRequest {
   authId: string;
   pinId: number;
   code: string;
+  pollTokenHash: string;
   expiresAt: number;
 }
 

--- a/apps/server/src/providers/plexAuth.test.ts
+++ b/apps/server/src/providers/plexAuth.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ApiError } from "../http/errors.js";
+import { pollAuth, startAuth } from "./plex/auth.js";
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+async function withMockedFetch<T>(
+  handler: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>,
+  action: () => Promise<T>
+) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+void test("requires the starter poll token before completing Plex auth", async () => {
+  await withMockedFetch(async (input) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    if (url === "https://plex.tv/api/v2/pins?strong=true") {
+      return jsonResponse({
+        id: 123,
+        code: "ABCD",
+        expiresIn: 60,
+      });
+    }
+
+    if (url === "https://plex.tv/api/v2/pins/123") {
+      return jsonResponse({
+        authToken: "user-token",
+      });
+    }
+
+    if (url === "https://clients.plex.tv/api/v2/resources?includeHttps=1&includeRelay=1&includeIPv6=1") {
+      return jsonResponse([{
+        name: "Plex Server",
+        provides: "server",
+        owned: true,
+        accessToken: "server-token",
+        clientIdentifier: "server-1",
+        connections: [{
+          uri: "http://192.168.1.10:32400",
+          local: true,
+          relay: false,
+        }],
+      }]);
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }, async () => {
+    const auth = await startAuth("http://cliparr.local/auth/plex/complete");
+
+    assert.equal(auth.authId.length > 0, true);
+    assert.equal(auth.pollToken.length > 20, true);
+
+    await assert.rejects(
+      () => pollAuth(auth.authId, "wrong-token"),
+      (err: unknown) =>
+        err instanceof ApiError
+        && err.status === 401
+        && err.code === "invalid_plex_auth_session"
+    );
+
+    const status = await pollAuth(auth.authId, auth.pollToken);
+    assert.equal(status.status, "complete");
+    assert.equal(status.userToken, "user-token");
+    assert.equal(status.resources?.length, 1);
+  });
+});

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "crypto";
+import { lookup } from "dns/promises";
+import { isIP } from "net";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import type { ReadableStream as WebReadableStream } from "stream/web";
 import type { Response } from "express";
+import { ApiError } from "../../http/errors.js";
 import { getServerLogger } from "../../logging.js";
 import type { ProviderSessionRecord } from "../../session/store.js";
 import type { MediaHandle } from "../types.js";
@@ -43,6 +46,12 @@ const PROXY_HEADER_ALLOWLIST = [
 ] as const;
 const HLS_PROXY_RESPONSE_CACHE_TTL_MS = 4_000;
 const HLS_PROXY_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+const MEDIA_PROXY_MAX_REDIRECTS = 5;
+const DISALLOWED_MEDIA_HOSTNAMES = new Set([
+  "metadata",
+  "metadata.azure.internal",
+  "metadata.google.internal",
+]);
 const logger = getServerLogger(["providers", "media-proxy"]);
 const cachedProxyResponses = new Map<string, {
   expiresAt: number;
@@ -82,6 +91,168 @@ export function shouldAttachProviderAuth(handle: Pick<MediaHandle, "baseUrl" | "
   const requestUrl = mediaHandleRequestUrl(handle);
   const providerUrl = safeUrl(handle.baseUrl);
   return providerUrl ? requestUrl.origin === providerUrl.origin : true;
+}
+
+function normalizeIpCandidate(value: string) {
+  const normalized = value.toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+
+  return normalized.startsWith("::ffff:") ? normalized.slice(7) : normalized;
+}
+
+function normalizeHostname(value: string) {
+  return normalizeIpCandidate(value.trim()).replace(/\.+$/, "");
+}
+
+function ipv4Octets(hostname: string) {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return undefined;
+  }
+
+  return octets as [number, number, number, number];
+}
+
+function isUnsafeIpv4Host(hostname: string) {
+  const octets = ipv4Octets(hostname);
+  if (!octets) {
+    return false;
+  }
+
+  const [first, second] = octets;
+  return first === 0
+    || first === 10
+    || first === 127
+    || (first === 100 && second >= 64 && second <= 127)
+    || (first === 169 && second === 254)
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 168)
+    || first >= 224;
+}
+
+function isUnsafeIpv6Host(hostname: string) {
+  return hostname === "::"
+    || hostname === "::1"
+    || hostname === "0:0:0:0:0:0:0:1"
+    || /^f[cd][0-9a-f]{2}:/i.test(hostname)
+    || /^fe[89ab][0-9a-f]:/i.test(hostname)
+    || /^ff[0-9a-f]{2}:/i.test(hostname);
+}
+
+function isUnsafeMediaHostname(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  return normalized === "localhost"
+    || normalized.endsWith(".localhost")
+    || DISALLOWED_MEDIA_HOSTNAMES.has(normalized)
+    || isUnsafeIpv4Host(normalized)
+    || isUnsafeIpv6Host(normalized);
+}
+
+async function resolveHostnameAddresses(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  if (isIP(normalized)) {
+    return [];
+  }
+
+  try {
+    const records = await lookup(normalized, {
+      all: true,
+      verbatim: true,
+    });
+
+    return [...new Set(records.map((record) => normalizeIpCandidate(record.address)))];
+  } catch {
+    throw new ApiError(
+      502,
+      "media_proxy_unsafe_url",
+      "Media playlist URL hostname could not be resolved for security validation"
+    );
+  }
+}
+
+function throwUnsafeMediaUrl() {
+  throw new ApiError(
+    400,
+    "media_proxy_unsafe_url",
+    "Media playlist URL points at an unsafe internal address"
+  );
+}
+
+export async function assertAllowedMediaHandleRequestUrl(
+  handle: Pick<MediaHandle, "baseUrl" | "path">,
+  requestUrl = mediaHandleRequestUrl(handle)
+) {
+  if (requestUrl.protocol !== "http:" && requestUrl.protocol !== "https:") {
+    throw new ApiError(
+      400,
+      "media_proxy_unsafe_url",
+      "Media playlist URL must use HTTP or HTTPS"
+    );
+  }
+
+  if (requestUrl.username || requestUrl.password) {
+    throwUnsafeMediaUrl();
+  }
+
+  const providerUrl = safeUrl(handle.baseUrl);
+  if (providerUrl && requestUrl.origin === providerUrl.origin) {
+    return;
+  }
+
+  if (isUnsafeMediaHostname(requestUrl.hostname)) {
+    throwUnsafeMediaUrl();
+  }
+
+  for (const address of await resolveHostnameAddresses(requestUrl.hostname)) {
+    if (isUnsafeMediaHostname(address)) {
+      throwUnsafeMediaUrl();
+    }
+  }
+}
+
+function isRedirectStatus(status: number) {
+  return status === 301
+    || status === 302
+    || status === 303
+    || status === 307
+    || status === 308;
+}
+
+export async function fetchMediaHandleRequest(handle: MediaHandle, init: RequestInit = {}) {
+  const providerUrl = safeUrl(handle.baseUrl);
+  let requestUrl = mediaHandleRequestUrl(handle);
+
+  if (providerUrl && requestUrl.origin === providerUrl.origin) {
+    return fetch(requestUrl.toString(), init);
+  }
+
+  for (let redirectCount = 0; redirectCount <= MEDIA_PROXY_MAX_REDIRECTS; redirectCount += 1) {
+    await assertAllowedMediaHandleRequestUrl(handle, requestUrl);
+
+    const response = await fetch(requestUrl.toString(), {
+      ...init,
+      redirect: "manual",
+    });
+    const location = response.headers.get("location");
+    if (!isRedirectStatus(response.status) || !location) {
+      return response;
+    }
+
+    requestUrl = new URL(location, requestUrl);
+  }
+
+  throw new ApiError(
+    502,
+    "media_proxy_redirect_limit",
+    "Media playlist URL redirected too many times"
+  );
 }
 
 export function sanitizeLoggedMediaPath(value: string | undefined) {

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -33,6 +33,11 @@ interface CachedProxyMediaResponse {
   body: Buffer;
 }
 
+interface ResolvedHostnameCacheEntry {
+  expiresAt: number;
+  addresses: string[];
+}
+
 const RELATIVE_MEDIA_BASE_URL = "http://cliparr.local";
 const PROXY_HEADER_ALLOWLIST = [
   "accept-ranges",
@@ -47,6 +52,7 @@ const PROXY_HEADER_ALLOWLIST = [
 const HLS_PROXY_RESPONSE_CACHE_TTL_MS = 4_000;
 const HLS_PROXY_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const MEDIA_PROXY_MAX_REDIRECTS = 5;
+const DNS_VALIDATION_CACHE_TTL_MS = 60_000;
 const DISALLOWED_MEDIA_HOSTNAMES = new Set([
   "metadata",
   "metadata.azure.internal",
@@ -58,6 +64,8 @@ const cachedProxyResponses = new Map<string, {
   response: CachedProxyMediaResponse;
 }>();
 const inflightProxyResponses = new Map<string, Promise<CachedProxyMediaResponse>>();
+const resolvedHostnameCache = new Map<string, ResolvedHostnameCacheEntry>();
+const inflightHostnameResolutions = new Map<string, Promise<string[]>>();
 
 function isAbsoluteUrl(path: string) {
   return /^[a-z][a-z0-9+.-]*:/i.test(path);
@@ -161,27 +169,51 @@ async function resolveHostnameAddresses(hostname: string) {
     return [];
   }
 
-  try {
-    const records = await lookup(normalized, {
-      all: true,
-      verbatim: true,
-    });
-
-    return [...new Set(records.map((record) => normalizeIpCandidate(record.address)))];
-  } catch {
-    throw new ApiError(
-      502,
-      "media_proxy_unsafe_url",
-      "Media playlist URL hostname could not be resolved for security validation"
-    );
+  const now = Date.now();
+  const cached = resolvedHostnameCache.get(normalized);
+  if (cached && cached.expiresAt > now) {
+    return cached.addresses;
   }
+
+  let inflight = inflightHostnameResolutions.get(normalized);
+  if (!inflight) {
+    inflight = (async () => {
+      try {
+        const records = await lookup(normalized, {
+          all: true,
+          verbatim: true,
+        });
+        const addresses = [...new Set(records.map((record) => normalizeIpCandidate(record.address)))];
+        resolvedHostnameCache.set(normalized, {
+          addresses,
+          expiresAt: Date.now() + DNS_VALIDATION_CACHE_TTL_MS,
+        });
+        return addresses;
+      } catch {
+        throw new ApiError(
+          502,
+          "media_proxy_unsafe_url",
+          "Media URL hostname could not be resolved for security validation"
+        );
+      }
+    })();
+    inflightHostnameResolutions.set(normalized, inflight);
+    const cleanupInflight = () => {
+      if (inflightHostnameResolutions.get(normalized) === inflight) {
+        inflightHostnameResolutions.delete(normalized);
+      }
+    };
+    void inflight.then(cleanupInflight, cleanupInflight);
+  }
+
+  return inflight;
 }
 
 function throwUnsafeMediaUrl() {
   throw new ApiError(
     400,
     "media_proxy_unsafe_url",
-    "Media playlist URL points at an unsafe internal address"
+    "Media URL points at an unsafe internal address"
   );
 }
 
@@ -193,7 +225,7 @@ export async function assertAllowedMediaHandleRequestUrl(
     throw new ApiError(
       400,
       "media_proxy_unsafe_url",
-      "Media playlist URL must use HTTP or HTTPS"
+      "Media URL must use HTTP or HTTPS"
     );
   }
 
@@ -225,19 +257,26 @@ function isRedirectStatus(status: number) {
     || status === 308;
 }
 
-export async function fetchMediaHandleRequest(handle: MediaHandle, init: RequestInit = {}) {
-  const providerUrl = safeUrl(handle.baseUrl);
-  let requestUrl = mediaHandleRequestUrl(handle);
+function removeSensitiveRedirectHeaders(init: RequestInit) {
+  const headers = new Headers(init.headers);
+  headers.delete("authorization");
+  headers.delete("cookie");
+  headers.delete("x-plex-token");
+  return {
+    ...init,
+    headers,
+  };
+}
 
-  if (providerUrl && requestUrl.origin === providerUrl.origin) {
-    return fetch(requestUrl.toString(), init);
-  }
+export async function fetchMediaHandleRequest(handle: MediaHandle, init: RequestInit = {}) {
+  let requestUrl = mediaHandleRequestUrl(handle);
+  let requestInit = init;
 
   for (let redirectCount = 0; redirectCount <= MEDIA_PROXY_MAX_REDIRECTS; redirectCount += 1) {
     await assertAllowedMediaHandleRequestUrl(handle, requestUrl);
 
     const response = await fetch(requestUrl.toString(), {
-      ...init,
+      ...requestInit,
       redirect: "manual",
     });
     const location = response.headers.get("location");
@@ -245,13 +284,17 @@ export async function fetchMediaHandleRequest(handle: MediaHandle, init: Request
       return response;
     }
 
-    requestUrl = new URL(location, requestUrl);
+    const nextUrl = new URL(location, requestUrl);
+    if (nextUrl.origin !== requestUrl.origin) {
+      requestInit = removeSensitiveRedirectHeaders(requestInit);
+    }
+    requestUrl = nextUrl;
   }
 
   throw new ApiError(
     502,
     "media_proxy_redirect_limit",
-    "Media playlist URL redirected too many times"
+    "Media URL redirected too many times"
   );
 }
 

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -34,6 +34,7 @@ interface ProviderAuthStart {
   authId: string;
   authUrl: string;
   expiresAt: string;
+  pollToken: string;
 }
 
 type ProviderAuthStatus =
@@ -103,7 +104,7 @@ type ProviderSourceCheckResult =
 export interface ProviderImplementation {
   definition: ProviderDefinition;
   startAuth?(callbackUrl: string): Promise<ProviderAuthStart>;
-  pollAuth?(authId: string): Promise<{
+  pollAuth?(authId: string, pollToken: string): Promise<{
     status: ProviderAuthStatus["status"];
     userToken?: string;
     resources?: ProviderResource[];

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -10,11 +10,84 @@ import {
   getRememberedProviderSessionCookieOptions,
   getSessionCookieName,
   getSessionCookieOptions,
+  readCookie,
 } from "../session/store.js";
 import { setNoStore } from "../session/request.js";
 
 export const providersRouter = Router();
 const PROVIDER_AUTH_COMPLETE_PATH = (providerId: string) => `/auth/${providerId}/complete`;
+const PROVIDER_AUTH_COOKIE = "cliparr_provider_auth";
+
+interface ProviderAuthCookie {
+  providerId: string;
+  authId: string;
+  pollToken: string;
+}
+
+function providerAuthCookieOptions(secure: boolean, expiresAt: string) {
+  return {
+    path: "/api/providers",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+    maxAge: Math.max(0, new Date(expiresAt).getTime() - Date.now()),
+  };
+}
+
+function providerAuthCookieClearOptions(secure: boolean) {
+  return {
+    path: "/api/providers",
+    httpOnly: true,
+    sameSite: "strict" as const,
+    secure,
+  };
+}
+
+function encodeProviderAuthCookie(payload: ProviderAuthCookie) {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeProviderAuthCookie(value: string | undefined): ProviderAuthCookie | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as Partial<ProviderAuthCookie>;
+    if (
+      typeof payload.providerId === "string"
+      && typeof payload.authId === "string"
+      && typeof payload.pollToken === "string"
+    ) {
+      return {
+        providerId: payload.providerId,
+        authId: payload.authId,
+        pollToken: payload.pollToken,
+      };
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function requireProviderAuthCookie(
+  cookieHeader: string | undefined,
+  providerId: string,
+  authId: string
+) {
+  const authCookie = decodeProviderAuthCookie(readCookie(cookieHeader, PROVIDER_AUTH_COOKIE));
+  if (authCookie?.providerId !== providerId || authCookie.authId !== authId) {
+    throw new ApiError(
+      401,
+      "invalid_provider_auth_session",
+      "Provider sign-in must be completed from the browser that started it"
+    );
+  }
+
+  return authCookie;
+}
 
 providersRouter.get("/", (_req, res) => {
   setNoStore(res);
@@ -34,7 +107,25 @@ providersRouter.post(
       throw new ApiError(400, "provider_auth_not_supported", "This provider does not use browser PIN sign-in");
     }
 
-    res.json(await provider.startAuth(getRequestRouteUrl(req, PROVIDER_AUTH_COMPLETE_PATH(provider.definition.id))));
+    const authStart = await provider.startAuth(
+      getRequestRouteUrl(req, PROVIDER_AUTH_COMPLETE_PATH(provider.definition.id))
+    );
+
+    res.cookie(
+      PROVIDER_AUTH_COOKIE,
+      encodeProviderAuthCookie({
+        providerId: provider.definition.id,
+        authId: authStart.authId,
+        pollToken: authStart.pollToken,
+      }),
+      providerAuthCookieOptions(req.secure, authStart.expiresAt)
+    );
+
+    res.json({
+      authId: authStart.authId,
+      authUrl: authStart.authUrl,
+      expiresAt: authStart.expiresAt,
+    });
   })
 );
 
@@ -51,8 +142,13 @@ providersRouter.get(
       throw new ApiError(400, "provider_auth_not_supported", "This provider does not use browser PIN sign-in");
     }
 
-    const authStatus = await provider.pollAuth(req.params.authId as string);
+    const authId = req.params.authId as string;
+    const authCookie = requireProviderAuthCookie(req.header("cookie"), provider.definition.id, authId);
+    const authStatus = await provider.pollAuth(authId, authCookie.pollToken);
     if (authStatus.status !== "complete") {
+      if (authStatus.status === "expired") {
+        res.clearCookie(PROVIDER_AUTH_COOKIE, providerAuthCookieClearOptions(req.secure));
+      }
       res.json({ status: authStatus.status });
       return;
     }
@@ -75,6 +171,7 @@ providersRouter.get(
 
     const rememberedSession = createRememberedProviderSession(session.providerAccountId);
 
+    res.clearCookie(PROVIDER_AUTH_COOKIE, providerAuthCookieClearOptions(req.secure));
     res.cookie(getSessionCookieName(), session.id, getSessionCookieOptions(req.secure));
     res.cookie(
       getRememberedProviderSessionCookieName(),


### PR DESCRIPTION
## Summary
- bind Plex PIN polling to an httpOnly starter nonce cookie before creating Cliparr sessions
- validate cross-origin HLS media URLs and redirects before proxy fetches
- add targeted regression tests for both security fixes

## Validation
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/server lint:eslint