### PR TITLE
fix(jellyfin): use playback info session ids

### DIFF
--- a/apps/server/src/providers/jellyfin/auth.ts
+++ b/apps/server/src/providers/jellyfin/auth.ts
@@ -13,6 +13,8 @@ import {
   normalizeBaseUrl,
   resolveCredentialServerUrl,
   sourceContext,
+  type JellyfinAuthenticationResult,
+  type JellyfinPublicSystemInfo,
 } from "./shared.js";
 
 async function parseCredentialsInput(body: unknown) {
@@ -49,7 +51,7 @@ async function parseCredentialsInput(body: unknown) {
 
 export async function authenticateWithCredentials(body: unknown) {
   const { serverUrl, username, password } = await parseCredentialsInput(body);
-  const publicInfo = await jellyfinJson<any>(serverUrl, "/System/Info/Public", {
+  const publicInfo = await jellyfinJson<JellyfinPublicSystemInfo>(serverUrl, "/System/Info/Public", {
     deviceId: JELLYFIN_DEVICE_ID,
     timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
     errorCode: "jellyfin_server_unreachable",
@@ -57,9 +59,9 @@ export async function authenticateWithCredentials(body: unknown) {
     exposeFailureDetail: false,
   });
 
-  let authResult: any;
+  let authResult: JellyfinAuthenticationResult;
   try {
-    authResult = await jellyfinJson<any>(serverUrl, "/Users/AuthenticateByName", {
+    authResult = await jellyfinJson<JellyfinAuthenticationResult>(serverUrl, "/Users/AuthenticateByName", {
       deviceId: JELLYFIN_DEVICE_ID,
       timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
       method: "POST",
@@ -134,7 +136,7 @@ export async function checkSource(source: MediaSource) {
   try {
     const context = sourceContext(source);
     const [publicInfo, currentUser] = await Promise.all([
-      jellyfinJson<any>(context.baseUrl, "/System/Info/Public", {
+      jellyfinJson<JellyfinPublicSystemInfo>(context.baseUrl, "/System/Info/Public", {
         deviceId: context.deviceId,
         timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
         errorCode: "jellyfin_server_unreachable",

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -64,7 +64,7 @@ function createMediaHandle(
   }, path, options);
 }
 
-function ticksToSeconds(value: unknown) {
+function ticksToSeconds(value: number | null | undefined) {
   const ticks = Number(value);
   if (!Number.isFinite(ticks) || ticks <= 0) {
     return 0;
@@ -175,7 +175,7 @@ function currentMediaSource(
   return mediaSources[0];
 }
 
-function normalizedString(value: unknown) {
+function normalizedString(value: string | null | undefined) {
   return stringValue(value)?.toLowerCase() ?? "";
 }
 
@@ -435,7 +435,7 @@ function providerGuids(item: JellyfinItem) {
   }
 
   return uniqueStrings(
-    Object.entries(providerIds as Record<string, unknown>).map(([provider, id]) => {
+    Object.entries(providerIds).map(([provider, id]) => {
       const normalizedId = stringValue(id);
       return normalizedId ? `${provider.toLowerCase()}://${normalizedId}` : undefined;
     })

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -509,7 +509,13 @@ async function enrichMetadataItem(context: JellyfinSourceContext, item: Jellyfin
 async function loadPlaybackInfo(context: JellyfinSourceContext, itemId: string) {
   try {
     return await fetchPlaybackInfo(context, itemId);
-  } catch {
+  } catch (err) {
+    logger.warn("Could not fetch Jellyfin playback info for item {itemId}.", {
+      itemId,
+      sourceId: context.sourceId,
+      baseUrl: context.baseUrl,
+      errorMessage: errorMessage(err),
+    });
     return undefined;
   }
 }

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -40,6 +40,10 @@ import {
   jellyfinHeaders,
   JELLYFIN_REQUEST_TIMEOUT_MS,
   sourceContext,
+  type JellyfinItem,
+  type JellyfinMediaStream,
+  type JellyfinPlaybackInfo,
+  type JellyfinSessionInfo,
   type JellyfinSourceContext,
 } from "./shared.js";
 
@@ -69,15 +73,15 @@ function ticksToSeconds(value: unknown) {
   return ticks / 10_000_000;
 }
 
-function itemType(item: any) {
+function itemType(item: JellyfinItem) {
   return stringValue(item?.Type) ?? stringValue(item?.MediaType) ?? "Video";
 }
 
-function itemTitle(item: any) {
+function itemTitle(item: JellyfinItem) {
   return stringValue(item?.Name) ?? stringValue(item?.EpisodeTitle) ?? "Untitled";
 }
 
-function buildSourceTitle(item: any) {
+function buildSourceTitle(item: JellyfinItem) {
   const title = itemTitle(item);
   if (itemType(item) !== "Episode") {
     return title;
@@ -91,7 +95,7 @@ function buildSourceTitle(item: any) {
   }) ?? title;
 }
 
-function itemImagePath(item: any) {
+function itemImagePath(item: JellyfinItem) {
   const itemId = stringValue(item?.Id);
   const imageTags = item?.ImageTags ?? {};
 
@@ -122,7 +126,11 @@ function itemImagePath(item: any) {
   return undefined;
 }
 
-function playbackMediaSources(sessionInfo: any, item: any, playbackInfo?: any) {
+function playbackMediaSources(
+  sessionInfo: JellyfinSessionInfo | undefined,
+  item: JellyfinItem,
+  playbackInfo?: JellyfinPlaybackInfo
+) {
   return [
     ...asArray(playbackInfo?.MediaSources),
     ...asArray(item?.MediaSources),
@@ -130,7 +138,11 @@ function playbackMediaSources(sessionInfo: any, item: any, playbackInfo?: any) {
   ];
 }
 
-function currentMediaSourceId(sessionInfo: any, item: any, playbackInfo?: any) {
+function currentMediaSourceId(
+  sessionInfo: JellyfinSessionInfo,
+  item: JellyfinItem,
+  playbackInfo?: JellyfinPlaybackInfo
+) {
   const playbackInfoMediaSources = asArray(playbackInfo?.MediaSources);
   const playStateMediaSourceId = stringValue(sessionInfo?.PlayState?.MediaSourceId);
   if (
@@ -146,7 +158,12 @@ function currentMediaSourceId(sessionInfo: any, item: any, playbackInfo?: any) {
     ?? stringValue(asArray(sessionInfo?.NowPlayingItem?.MediaSources)[0]?.Id);
 }
 
-function currentMediaSource(sessionInfo: any, item: any, mediaSourceId: string | undefined, playbackInfo?: any) {
+function currentMediaSource(
+  sessionInfo: JellyfinSessionInfo | undefined,
+  item: JellyfinItem,
+  mediaSourceId: string | undefined,
+  playbackInfo?: JellyfinPlaybackInfo
+) {
   const mediaSources = playbackMediaSources(sessionInfo, item, playbackInfo);
   if (mediaSourceId) {
     const matchingMediaSource = mediaSources.find((mediaSource) => stringValue(mediaSource?.Id) === mediaSourceId);
@@ -158,34 +175,38 @@ function currentMediaSource(sessionInfo: any, item: any, mediaSourceId: string |
   return mediaSources[0];
 }
 
-function isAudioMediaStream(stream: any) {
-  return String(stream?.Type ?? "").toLowerCase() === "audio";
+function normalizedString(value: unknown) {
+  return stringValue(value)?.toLowerCase() ?? "";
 }
 
-function isVideoMediaStream(stream: any) {
-  return String(stream?.Type ?? "").toLowerCase() === "video";
+function isAudioMediaStream(stream: JellyfinMediaStream) {
+  return normalizedString(stream?.Type) === "audio";
 }
 
-function isSubtitleMediaStream(stream: any) {
-  return String(stream?.Type ?? "").toLowerCase() === "subtitle";
+function isVideoMediaStream(stream: JellyfinMediaStream) {
+  return normalizedString(stream?.Type) === "video";
 }
 
-function jellyfinAudioTrackTitle(stream: any) {
+function isSubtitleMediaStream(stream: JellyfinMediaStream) {
+  return normalizedString(stream?.Type) === "subtitle";
+}
+
+function jellyfinAudioTrackTitle(stream: JellyfinMediaStream) {
   return stringValue(stream?.Title)
     ?? stringValue(stream?.DisplayTitle);
 }
 
-function jellyfinSubtitleTrackTitle(stream: any) {
+function jellyfinSubtitleTrackTitle(stream: JellyfinMediaStream) {
   return stringValue(stream?.Title)
     ?? stringValue(stream?.DisplayTitle)
     ?? stringValue(stream?.Language);
 }
 
 function deriveSelectedAudioTrack(
-  sessionInfo: any,
-  item: any,
+  sessionInfo: JellyfinSessionInfo,
+  item: JellyfinItem,
   mediaSourceId: string | undefined,
-  playbackInfo?: any
+  playbackInfo?: JellyfinPlaybackInfo
 ): PlaybackAudioSelection | undefined {
   const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
@@ -246,7 +267,7 @@ function jellyfinSubtitleTrack(
   context: JellyfinSourceContext,
   itemId: string | undefined,
   mediaSourceId: string | undefined,
-  stream: any
+  stream: JellyfinMediaStream
 ): PlaybackSubtitleTrack {
   const codec = normalizeSubtitleCodec(stream?.Codec);
   const isText = booleanValue(stream?.IsTextSubtitleStream) ?? isTextSubtitleCodec(codec);
@@ -273,10 +294,10 @@ function jellyfinSubtitleTrack(
 export function deriveSubtitleTracks(
   session: ProviderSessionRecord,
   context: JellyfinSourceContext,
-  item: any,
+  item: JellyfinItem,
   mediaSourceId: string | undefined,
-  sessionInfo?: any,
-  playbackInfo?: any
+  sessionInfo?: JellyfinSessionInfo,
+  playbackInfo?: JellyfinPlaybackInfo
 ) {
   const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
@@ -292,10 +313,10 @@ export function deriveSubtitleTracks(
 }
 
 export function deriveSelectedSubtitleTrack(
-  sessionInfo: any,
-  item: any,
+  sessionInfo: JellyfinSessionInfo,
+  item: JellyfinItem,
   mediaSourceId: string | undefined,
-  playbackInfo?: any
+  playbackInfo?: JellyfinPlaybackInfo
 ): PlaybackSubtitleSelection | undefined {
   const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
@@ -339,7 +360,7 @@ function subtitleTrackSupportsBurnIn(track: PlaybackSubtitleTrack) {
 }
 
 function buildStaticStreamPath(
-  item: any,
+  item: JellyfinItem,
   mediaSourceId: string | undefined,
   context: JellyfinSourceContext,
   playSessionId: string
@@ -349,7 +370,7 @@ function buildStaticStreamPath(
     return undefined;
   }
 
-  const isAudio = String(item?.MediaType ?? "").toLowerCase() === "audio";
+  const isAudio = normalizedString(item?.MediaType) === "audio";
   const params = new URLSearchParams({
     static: "true",
     deviceId: context.deviceId,
@@ -365,13 +386,13 @@ function buildStaticStreamPath(
 }
 
 export function buildPreviewPath(
-  item: any,
+  item: JellyfinItem,
   mediaSourceId: string | undefined,
   context: JellyfinSourceContext,
   playSessionId: string
 ) {
   const itemId = stringValue(item?.Id);
-  if (!itemId || String(item?.MediaType ?? "").toLowerCase() === "audio" || !mediaSourceId) {
+  if (!itemId || normalizedString(item?.MediaType) === "audio" || !mediaSourceId) {
     return undefined;
   }
 
@@ -388,9 +409,9 @@ export function buildPreviewPath(
   return `/Videos/${encodeURIComponent(itemId)}/master.m3u8?${params.toString()}`;
 }
 
-function peopleNames(item: any, kind: string) {
+function peopleNames(item: JellyfinItem, kind: string) {
   return uniqueStrings(
-    asArray(item?.People).flatMap((person: any) => {
+    asArray(item?.People).flatMap((person) => {
       if (stringValue(person?.Type) !== kind) {
         return [];
       }
@@ -401,13 +422,13 @@ function peopleNames(item: any, kind: string) {
   );
 }
 
-function studios(item: any) {
+function studios(item: JellyfinItem) {
   return uniqueStrings(
-    asArray(item?.Studios).map((entry: any) => stringValue(entry?.Name) ?? stringValue(entry?.name))
+    asArray(item?.Studios).map((entry) => stringValue(entry?.Name) ?? stringValue(entry?.name))
   );
 }
 
-function providerGuids(item: any) {
+function providerGuids(item: JellyfinItem) {
   const providerIds = item?.ProviderIds;
   if (!providerIds || typeof providerIds !== "object" || Array.isArray(providerIds)) {
     return [];
@@ -421,14 +442,14 @@ function providerGuids(item: any) {
   );
 }
 
-function firstTagline(item: any) {
+function firstTagline(item: JellyfinItem) {
   return uniqueStrings(asArray(item?.Taglines).map((value) => stringValue(value)))[0];
 }
 
 function createExportMetadata(
   session: ProviderSessionRecord,
   context: JellyfinSourceContext,
-  item: any
+  item: JellyfinItem
 ): MediaExportMetadata {
   const imagePath = itemImagePath(item);
 
@@ -462,7 +483,7 @@ function createExportMetadata(
   };
 }
 
-async function enrichMetadataItem(context: JellyfinSourceContext, item: any) {
+async function enrichMetadataItem(context: JellyfinSourceContext, item: JellyfinItem) {
   const itemId = stringValue(item?.Id);
   if (!itemId) {
     return item;
@@ -507,7 +528,7 @@ function playbackItemIdentity(
   ].join(":");
 }
 
-function playbackViewer(sourceId: string, sessionId: string, sessionInfo: any) {
+function playbackViewer(sourceId: string, sessionId: string, sessionInfo: JellyfinSessionInfo) {
   const externalId = stringValue(sessionInfo?.UserId);
   return {
     id: externalId ? `jellyfin:user:${externalId}` : `jellyfin:synthetic:${sourceId}:${sessionId}`,
@@ -521,10 +542,14 @@ async function normalizeCurrentPlayback(
   session: ProviderSessionRecord,
   source: MediaSource,
   context: JellyfinSourceContext,
-  sessionInfo: any
+  sessionInfo: JellyfinSessionInfo
 ): Promise<CurrentlyPlayingEntry | undefined> {
   const nowPlayingItem = sessionInfo?.NowPlayingItem;
-  const itemId = stringValue(nowPlayingItem?.Id);
+  if (!nowPlayingItem) {
+    return undefined;
+  }
+
+  const itemId = stringValue(nowPlayingItem.Id);
   if (!itemId) {
     return undefined;
   }
@@ -562,7 +587,7 @@ async function normalizeCurrentPlayback(
     ? createMediaHandle(session, context, previewPath, { basePath: playlistBasePath(previewPath) })
     : undefined;
   const playbackItemId = playbackItemIdentity(source.id, clientSessionId, itemId, mediaSourceId);
-  const missingPreviewPath = !previewPath && String(enrichedItem?.MediaType ?? "").toLowerCase() !== "audio";
+  const missingPreviewPath = !previewPath && normalizedString(enrichedItem?.MediaType) !== "audio";
   const unresolvedSelectedAudioTrack = !selectedAudioTrack && audioStreams.length > 1;
   const playbackDiagnostics = {
     sessionId: session.id,

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import type { Request, Response } from "express";
 import type { MediaSource } from "../../db/mediaSourcesRepository.js";
 import { ApiError } from "../../http/errors.js";
@@ -36,6 +35,7 @@ import {
 import {
   booleanValue,
   fetchItem,
+  fetchPlaybackInfo,
   fetchSessions,
   jellyfinHeaders,
   JELLYFIN_REQUEST_TIMEOUT_MS,
@@ -122,17 +122,32 @@ function itemImagePath(item: any) {
   return undefined;
 }
 
-function currentMediaSourceId(sessionInfo: any, item: any) {
-  return stringValue(sessionInfo?.PlayState?.MediaSourceId)
+function playbackMediaSources(sessionInfo: any, item: any, playbackInfo?: any) {
+  return [
+    ...asArray(playbackInfo?.MediaSources),
+    ...asArray(item?.MediaSources),
+    ...asArray(sessionInfo?.NowPlayingItem?.MediaSources),
+  ];
+}
+
+function currentMediaSourceId(sessionInfo: any, item: any, playbackInfo?: any) {
+  const playbackInfoMediaSources = asArray(playbackInfo?.MediaSources);
+  const playStateMediaSourceId = stringValue(sessionInfo?.PlayState?.MediaSourceId);
+  if (
+    playStateMediaSourceId
+    && playbackInfoMediaSources.some((mediaSource) => stringValue(mediaSource?.Id) === playStateMediaSourceId)
+  ) {
+    return playStateMediaSourceId;
+  }
+
+  return stringValue(playbackInfoMediaSources[0]?.Id)
+    ?? playStateMediaSourceId
     ?? stringValue(asArray(item?.MediaSources)[0]?.Id)
     ?? stringValue(asArray(sessionInfo?.NowPlayingItem?.MediaSources)[0]?.Id);
 }
 
-function currentMediaSource(sessionInfo: any, item: any, mediaSourceId: string | undefined) {
-  const itemMediaSources = asArray(item?.MediaSources);
-  const sessionMediaSources = asArray(sessionInfo?.NowPlayingItem?.MediaSources);
-  const mediaSources = [...itemMediaSources, ...sessionMediaSources];
-
+function currentMediaSource(sessionInfo: any, item: any, mediaSourceId: string | undefined, playbackInfo?: any) {
+  const mediaSources = playbackMediaSources(sessionInfo, item, playbackInfo);
   if (mediaSourceId) {
     const matchingMediaSource = mediaSources.find((mediaSource) => stringValue(mediaSource?.Id) === mediaSourceId);
     if (matchingMediaSource) {
@@ -169,9 +184,10 @@ function jellyfinSubtitleTrackTitle(stream: any) {
 function deriveSelectedAudioTrack(
   sessionInfo: any,
   item: any,
-  mediaSourceId: string | undefined
+  mediaSourceId: string | undefined,
+  playbackInfo?: any
 ): PlaybackAudioSelection | undefined {
-  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId);
+  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
     return undefined;
   }
@@ -259,9 +275,10 @@ export function deriveSubtitleTracks(
   context: JellyfinSourceContext,
   item: any,
   mediaSourceId: string | undefined,
-  sessionInfo?: any
+  sessionInfo?: any,
+  playbackInfo?: any
 ) {
-  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId);
+  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
     return [];
   }
@@ -277,9 +294,10 @@ export function deriveSubtitleTracks(
 export function deriveSelectedSubtitleTrack(
   sessionInfo: any,
   item: any,
-  mediaSourceId: string | undefined
+  mediaSourceId: string | undefined,
+  playbackInfo?: any
 ): PlaybackSubtitleSelection | undefined {
-  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId);
+  const mediaSource = currentMediaSource(sessionInfo, item, mediaSourceId, playbackInfo);
   if (!mediaSource) {
     return undefined;
   }
@@ -467,6 +485,28 @@ async function enrichMetadataItem(context: JellyfinSourceContext, item: any) {
   }
 }
 
+async function loadPlaybackInfo(context: JellyfinSourceContext, itemId: string) {
+  try {
+    return await fetchPlaybackInfo(context, itemId);
+  } catch {
+    return undefined;
+  }
+}
+
+function playbackItemIdentity(
+  sourceId: string,
+  clientSessionId: string | undefined,
+  itemId: string,
+  mediaSourceId: string | undefined
+) {
+  return [
+    sourceId,
+    clientSessionId ?? "unknown-session",
+    itemId,
+    mediaSourceId ?? "unknown-media-source",
+  ].join(":");
+}
+
 function playbackViewer(sourceId: string, sessionId: string, sessionInfo: any) {
   const externalId = stringValue(sessionInfo?.UserId);
   return {
@@ -489,16 +529,24 @@ async function normalizeCurrentPlayback(
     return undefined;
   }
 
-  const enrichedItem = await enrichMetadataItem(context, nowPlayingItem);
-  const playSessionId = stringValue(sessionInfo?.Id) ?? randomUUID();
-  const mediaSourceId = currentMediaSourceId(sessionInfo, enrichedItem);
-  const mediaSource = currentMediaSource(sessionInfo, enrichedItem, mediaSourceId);
-  const mediaPath = buildStaticStreamPath(enrichedItem, mediaSourceId, context, playSessionId);
-  const previewPath = buildPreviewPath(enrichedItem, mediaSourceId, context, playSessionId);
+  const [enrichedItem, playbackInfo] = await Promise.all([
+    enrichMetadataItem(context, nowPlayingItem),
+    loadPlaybackInfo(context, itemId),
+  ]);
+  const playSessionId = stringValue(playbackInfo?.PlaySessionId);
+  const clientSessionId = stringValue(sessionInfo?.Id);
+  const mediaSourceId = currentMediaSourceId(sessionInfo, enrichedItem, playbackInfo);
+  const mediaSource = currentMediaSource(sessionInfo, enrichedItem, mediaSourceId, playbackInfo);
+  const mediaPath = playSessionId
+    ? buildStaticStreamPath(enrichedItem, mediaSourceId, context, playSessionId)
+    : undefined;
+  const previewPath = playSessionId
+    ? buildPreviewPath(enrichedItem, mediaSourceId, context, playSessionId)
+    : undefined;
   const imagePath = itemImagePath(enrichedItem);
-  const selectedAudioTrack = deriveSelectedAudioTrack(sessionInfo, enrichedItem, mediaSourceId);
-  const selectedSubtitleTrack = deriveSelectedSubtitleTrack(sessionInfo, enrichedItem, mediaSourceId);
-  const subtitleTracks = deriveSubtitleTracks(session, context, enrichedItem, mediaSourceId, sessionInfo)
+  const selectedAudioTrack = deriveSelectedAudioTrack(sessionInfo, enrichedItem, mediaSourceId, playbackInfo);
+  const selectedSubtitleTrack = deriveSelectedSubtitleTrack(sessionInfo, enrichedItem, mediaSourceId, playbackInfo);
+  const subtitleTracks = deriveSubtitleTracks(session, context, enrichedItem, mediaSourceId, sessionInfo, playbackInfo)
     .filter((track) => subtitleTrackSupportsBurnIn(track));
   const playerState = sessionInfo?.PlayState?.IsPaused ? "paused" : "playing";
   const audioStreams = asArray(mediaSource?.MediaStreams).filter((stream) => isAudioMediaStream(stream));
@@ -513,6 +561,7 @@ async function normalizeCurrentPlayback(
   const hlsUrl = previewPath
     ? createMediaHandle(session, context, previewPath, { basePath: playlistBasePath(previewPath) })
     : undefined;
+  const playbackItemId = playbackItemIdentity(source.id, clientSessionId, itemId, mediaSourceId);
   const missingPreviewPath = !previewPath && String(enrichedItem?.MediaType ?? "").toLowerCase() !== "audio";
   const unresolvedSelectedAudioTrack = !selectedAudioTrack && audioStreams.length > 1;
   const playbackDiagnostics = {
@@ -521,7 +570,7 @@ async function normalizeCurrentPlayback(
     providerAccountId: session.providerAccountId,
     playSessionId,
     currentlyPlayingItem: {
-      id: `${source.id}:${playSessionId}`,
+      id: playbackItemId,
       title: itemTitle(enrichedItem),
       type: itemType(enrichedItem).toLowerCase(),
       duration,
@@ -567,9 +616,9 @@ async function normalizeCurrentPlayback(
   }
 
   return {
-    viewer: playbackViewer(source.id, playSessionId, sessionInfo),
+    viewer: playbackViewer(source.id, clientSessionId ?? itemId, sessionInfo),
     item: {
-      id: `${source.id}:${playSessionId}`,
+      id: playbackItemId,
       source: {
         id: source.id,
         name: source.name,

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -29,18 +29,18 @@ export interface JellyfinSourceContext {
   deviceId: string;
 }
 
-export interface JellyfinImageTags {
+interface JellyfinImageTags {
   [key: string]: string | undefined;
   Primary?: string;
   Thumb?: string;
 }
 
-export interface JellyfinPerson {
+interface JellyfinPerson {
   Name?: string | null;
   Type?: string;
 }
 
-export interface JellyfinStudio {
+interface JellyfinStudio {
   Name?: string | null;
   name?: string | null;
 }
@@ -61,7 +61,7 @@ export interface JellyfinMediaStream {
   IsTextSubtitleStream?: boolean;
 }
 
-export interface JellyfinMediaSource {
+interface JellyfinMediaSource {
   Id?: string | null;
   DefaultAudioStreamIndex?: number | null;
   DefaultSubtitleStreamIndex?: number | null;
@@ -98,7 +98,7 @@ export interface JellyfinItem {
   ProviderIds?: Record<string, string | null> | null;
 }
 
-export interface JellyfinPlayState {
+interface JellyfinPlayState {
   MediaSourceId?: string | null;
   AudioStreamIndex?: number | null;
   SubtitleStreamIndex?: number | null;
@@ -128,7 +128,7 @@ export interface JellyfinPublicSystemInfo {
   Version?: string | null;
 }
 
-export interface JellyfinUserPolicy {
+interface JellyfinUserPolicy {
   IsAdministrator?: boolean;
 }
 

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -495,3 +495,17 @@ export async function fetchItem(context: JellyfinSourceContext, itemId: string) 
     }
   );
 }
+
+export async function fetchPlaybackInfo(context: JellyfinSourceContext, itemId: string) {
+  return jellyfinJson<any>(
+    context.baseUrl,
+    `/Items/${encodeURIComponent(itemId)}/PlaybackInfo?userId=${encodeURIComponent(context.userId)}`,
+    {
+      token: context.token,
+      deviceId: context.deviceId,
+      timeoutMs: CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS,
+      errorCode: "jellyfin_playback_info_failed",
+      failureMessage: "Jellyfin playback info request failed",
+    }
+  );
+}

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -29,97 +29,119 @@ export interface JellyfinSourceContext {
   deviceId: string;
 }
 
-export type JellyfinApiList<T> = T | T[] | null;
-
 export interface JellyfinImageTags {
-  Primary?: unknown;
-  Thumb?: unknown;
+  [key: string]: string | undefined;
+  Primary?: string;
+  Thumb?: string;
 }
 
 export interface JellyfinPerson {
-  Name?: unknown;
-  Type?: unknown;
+  Name?: string | null;
+  Type?: string;
 }
 
 export interface JellyfinStudio {
-  Name?: unknown;
-  name?: unknown;
+  Name?: string | null;
+  name?: string | null;
 }
 
 export interface JellyfinMediaStream {
-  Type?: unknown;
-  Index?: unknown;
-  Codec?: unknown;
-  Language?: unknown;
-  Title?: unknown;
-  DisplayTitle?: unknown;
-  Width?: unknown;
-  Height?: unknown;
-  IsDefault?: unknown;
-  IsForced?: unknown;
-  IsHearingImpaired?: unknown;
-  IsExternal?: unknown;
-  IsTextSubtitleStream?: unknown;
+  Type?: string;
+  Index?: number;
+  Codec?: string | null;
+  Language?: string | null;
+  Title?: string | null;
+  DisplayTitle?: string | null;
+  Width?: number | null;
+  Height?: number | null;
+  IsDefault?: boolean;
+  IsForced?: boolean;
+  IsHearingImpaired?: boolean;
+  IsExternal?: boolean;
+  IsTextSubtitleStream?: boolean;
 }
 
 export interface JellyfinMediaSource {
-  Id?: unknown;
-  DefaultAudioStreamIndex?: unknown;
-  DefaultSubtitleStreamIndex?: unknown;
-  MediaStreams?: JellyfinApiList<JellyfinMediaStream>;
+  Id?: string | null;
+  DefaultAudioStreamIndex?: number | null;
+  DefaultSubtitleStreamIndex?: number | null;
+  MediaStreams?: JellyfinMediaStream[] | null;
 }
 
 export interface JellyfinItem {
-  Id?: unknown;
-  Type?: unknown;
-  MediaType?: unknown;
-  Name?: unknown;
-  EpisodeTitle?: unknown;
-  SeriesName?: unknown;
-  SeasonName?: unknown;
-  ParentIndexNumber?: unknown;
-  IndexNumber?: unknown;
-  RunTimeTicks?: unknown;
-  ProductionYear?: unknown;
-  PremiereDate?: unknown;
-  Overview?: unknown;
-  SeriesStudio?: unknown;
-  ChannelName?: unknown;
-  OfficialRating?: unknown;
-  ParentThumbItemId?: unknown;
-  ParentThumbImageTag?: unknown;
-  SeriesId?: unknown;
-  SeriesPrimaryImageTag?: unknown;
+  Id?: string;
+  Type?: string;
+  MediaType?: string;
+  Name?: string | null;
+  EpisodeTitle?: string | null;
+  SeriesName?: string | null;
+  SeasonName?: string | null;
+  ParentIndexNumber?: number | null;
+  IndexNumber?: number | null;
+  RunTimeTicks?: number | null;
+  ProductionYear?: number | null;
+  PremiereDate?: string | null;
+  Overview?: string | null;
+  SeriesStudio?: string | null;
+  ChannelName?: string | null;
+  OfficialRating?: string | null;
+  ParentThumbItemId?: string | null;
+  ParentThumbImageTag?: string | null;
+  SeriesId?: string | null;
+  SeriesPrimaryImageTag?: string | null;
   ImageTags?: JellyfinImageTags | null;
-  MediaSources?: JellyfinApiList<JellyfinMediaSource>;
-  Taglines?: JellyfinApiList<string>;
-  Genres?: JellyfinApiList<string>;
-  People?: JellyfinApiList<JellyfinPerson>;
-  Studios?: JellyfinApiList<JellyfinStudio>;
-  ProviderIds?: unknown;
+  MediaSources?: JellyfinMediaSource[] | null;
+  Taglines?: string[] | null;
+  Genres?: string[] | null;
+  People?: JellyfinPerson[] | null;
+  Studios?: JellyfinStudio[] | null;
+  ProviderIds?: Record<string, string | null> | null;
 }
 
 export interface JellyfinPlayState {
-  MediaSourceId?: unknown;
-  AudioStreamIndex?: unknown;
-  SubtitleStreamIndex?: unknown;
-  IsPaused?: unknown;
+  MediaSourceId?: string | null;
+  AudioStreamIndex?: number | null;
+  SubtitleStreamIndex?: number | null;
+  IsPaused?: boolean;
 }
 
 export interface JellyfinSessionInfo {
-  Id?: unknown;
-  UserId?: unknown;
-  UserName?: unknown;
-  DeviceName?: unknown;
-  Client?: unknown;
-  DeviceType?: unknown;
+  Id?: string | null;
+  UserId?: string;
+  UserName?: string | null;
+  DeviceName?: string | null;
+  Client?: string | null;
+  DeviceType?: string | null;
   PlayState?: JellyfinPlayState | null;
   NowPlayingItem?: JellyfinItem | null;
 }
 
 export interface JellyfinPlaybackInfo {
-  PlaySessionId?: unknown;
-  MediaSources?: JellyfinApiList<JellyfinMediaSource>;
+  PlaySessionId?: string | null;
+  MediaSources?: JellyfinMediaSource[];
+}
+
+export interface JellyfinPublicSystemInfo {
+  Id?: string | null;
+  ServerName?: string | null;
+  ProductName?: string | null;
+  Version?: string | null;
+}
+
+export interface JellyfinUserPolicy {
+  IsAdministrator?: boolean;
+}
+
+export interface JellyfinUser {
+  Id?: string;
+  Name?: string | null;
+  Policy?: JellyfinUserPolicy | null;
+}
+
+export interface JellyfinAuthenticationResult {
+  AccessToken?: string | null;
+  ServerId?: string | null;
+  User?: JellyfinUser | null;
 }
 
 export function booleanValue(value: unknown) {
@@ -316,7 +338,7 @@ function looksLikeGeneratedServerName(value: string) {
   return /^[a-f0-9]{12,64}$/i.test(value.trim());
 }
 
-export function jellyfinSourceName(serverName: unknown, baseUrl: string) {
+export function jellyfinSourceName(serverName: string | null | undefined, baseUrl: string) {
   const normalizedServerName = stringValue(serverName);
   if (normalizedServerName && !looksLikeGeneratedServerName(normalizedServerName)) {
     return normalizedServerName;
@@ -556,7 +578,7 @@ export function sourceContext(source: MediaSource): JellyfinSourceContext {
 }
 
 export async function fetchCurrentUser(context: JellyfinSourceContext) {
-  return jellyfinJson<any>(context.baseUrl, "/Users/Me", {
+  return jellyfinJson<JellyfinUser>(context.baseUrl, "/Users/Me", {
     token: context.token,
     deviceId: context.deviceId,
     timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -29,6 +29,99 @@ export interface JellyfinSourceContext {
   deviceId: string;
 }
 
+export type JellyfinApiList<T> = T | T[] | null;
+
+export interface JellyfinImageTags {
+  Primary?: unknown;
+  Thumb?: unknown;
+}
+
+export interface JellyfinPerson {
+  Name?: unknown;
+  Type?: unknown;
+}
+
+export interface JellyfinStudio {
+  Name?: unknown;
+  name?: unknown;
+}
+
+export interface JellyfinMediaStream {
+  Type?: unknown;
+  Index?: unknown;
+  Codec?: unknown;
+  Language?: unknown;
+  Title?: unknown;
+  DisplayTitle?: unknown;
+  Width?: unknown;
+  Height?: unknown;
+  IsDefault?: unknown;
+  IsForced?: unknown;
+  IsHearingImpaired?: unknown;
+  IsExternal?: unknown;
+  IsTextSubtitleStream?: unknown;
+}
+
+export interface JellyfinMediaSource {
+  Id?: unknown;
+  DefaultAudioStreamIndex?: unknown;
+  DefaultSubtitleStreamIndex?: unknown;
+  MediaStreams?: JellyfinApiList<JellyfinMediaStream>;
+}
+
+export interface JellyfinItem {
+  Id?: unknown;
+  Type?: unknown;
+  MediaType?: unknown;
+  Name?: unknown;
+  EpisodeTitle?: unknown;
+  SeriesName?: unknown;
+  SeasonName?: unknown;
+  ParentIndexNumber?: unknown;
+  IndexNumber?: unknown;
+  RunTimeTicks?: unknown;
+  ProductionYear?: unknown;
+  PremiereDate?: unknown;
+  Overview?: unknown;
+  SeriesStudio?: unknown;
+  ChannelName?: unknown;
+  OfficialRating?: unknown;
+  ParentThumbItemId?: unknown;
+  ParentThumbImageTag?: unknown;
+  SeriesId?: unknown;
+  SeriesPrimaryImageTag?: unknown;
+  ImageTags?: JellyfinImageTags | null;
+  MediaSources?: JellyfinApiList<JellyfinMediaSource>;
+  Taglines?: JellyfinApiList<string>;
+  Genres?: JellyfinApiList<string>;
+  People?: JellyfinApiList<JellyfinPerson>;
+  Studios?: JellyfinApiList<JellyfinStudio>;
+  ProviderIds?: unknown;
+}
+
+export interface JellyfinPlayState {
+  MediaSourceId?: unknown;
+  AudioStreamIndex?: unknown;
+  SubtitleStreamIndex?: unknown;
+  IsPaused?: unknown;
+}
+
+export interface JellyfinSessionInfo {
+  Id?: unknown;
+  UserId?: unknown;
+  UserName?: unknown;
+  DeviceName?: unknown;
+  Client?: unknown;
+  DeviceType?: unknown;
+  PlayState?: JellyfinPlayState | null;
+  NowPlayingItem?: JellyfinItem | null;
+}
+
+export interface JellyfinPlaybackInfo {
+  PlaySessionId?: unknown;
+  MediaSources?: JellyfinApiList<JellyfinMediaSource>;
+}
+
 export function booleanValue(value: unknown) {
   return typeof value === "boolean" ? value : undefined;
 }
@@ -473,7 +566,7 @@ export async function fetchCurrentUser(context: JellyfinSourceContext) {
 }
 
 export async function fetchSessions(context: JellyfinSourceContext) {
-  return jellyfinJson<any[]>(context.baseUrl, "/Sessions?activeWithinSeconds=300", {
+  return jellyfinJson<JellyfinSessionInfo[]>(context.baseUrl, "/Sessions?activeWithinSeconds=300", {
     token: context.token,
     deviceId: context.deviceId,
     timeoutMs: CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS,
@@ -483,7 +576,7 @@ export async function fetchSessions(context: JellyfinSourceContext) {
 }
 
 export async function fetchItem(context: JellyfinSourceContext, itemId: string) {
-  return jellyfinJson<any>(
+  return jellyfinJson<JellyfinItem>(
     context.baseUrl,
     `/Items/${encodeURIComponent(itemId)}?userId=${encodeURIComponent(context.userId)}`,
     {
@@ -497,7 +590,7 @@ export async function fetchItem(context: JellyfinSourceContext, itemId: string) 
 }
 
 export async function fetchPlaybackInfo(context: JellyfinSourceContext, itemId: string) {
-  return jellyfinJson<any>(
+  return jellyfinJson<JellyfinPlaybackInfo>(
     context.baseUrl,
     `/Items/${encodeURIComponent(itemId)}/PlaybackInfo?userId=${encodeURIComponent(context.userId)}`,
     {

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { Request, Response } from "express";
+import type { MediaSource } from "../db/mediaSourcesRepository.js";
 import type { ProviderSessionRecord } from "../session/store.js";
 import {
   buildPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
+  listCurrentlyPlaying,
   proxyMedia,
 } from "./jellyfin/playback.js";
 import type { JellyfinSourceContext } from "./jellyfin/shared.js";
@@ -29,6 +31,26 @@ function createContext(): JellyfinSourceContext {
     token: "provider-token",
     userId: "user-1",
     deviceId: "cliparr-device-1",
+  };
+}
+
+function createSource(): MediaSource {
+  return {
+    id: "source-1",
+    providerId: "jellyfin",
+    providerAccountId: "account-1",
+    name: "Jellyfin",
+    enabled: true,
+    baseUrl: "http://jellyfin.local:8096",
+    connection: {},
+    credentials: {
+      accessToken: "provider-token",
+      userId: "user-1",
+      deviceId: "cliparr-device-1",
+    },
+    metadata: {},
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
   };
 }
 
@@ -67,6 +89,107 @@ function createResponseRecorder() {
   };
 }
 
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function fetchInputUrl(input: Parameters<typeof fetch>[0]) {
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+
+  if (input instanceof URL) {
+    return input;
+  }
+
+  return new URL(input.url);
+}
+
+function createJellyfinPlaybackFetch(options: {
+  itemId: string;
+  playSessionId?: string | null;
+  clientSessionId?: string;
+  mediaSourceId?: string;
+  title?: string;
+}) {
+  const {
+    itemId,
+    playSessionId = "playback-info-session-1",
+    clientSessionId = "client-session-1",
+    mediaSourceId = "media-source-1",
+    title = "Chapter 1: The Dark Revenge",
+  } = options;
+  const mediaSource = {
+    Id: mediaSourceId,
+    DefaultAudioStreamIndex: 1,
+    MediaStreams: [
+      {
+        Type: "Video",
+        Index: 0,
+        Codec: "h264",
+        Width: 1920,
+        Height: 1080,
+      },
+      {
+        Type: "Audio",
+        Index: 1,
+        Codec: "aac",
+        Language: "eng",
+        Title: "English",
+        IsDefault: true,
+      },
+    ],
+  };
+  const item = {
+    Id: itemId,
+    Name: title,
+    Type: "Episode",
+    MediaType: "Video",
+    RunTimeTicks: 1_698_000_0000,
+    MediaSources: [{
+      Id: "stale-session-media-source",
+      MediaStreams: [],
+    }],
+  };
+
+  return (async (input) => {
+    const url = fetchInputUrl(input);
+
+    if (url.pathname === "/Sessions") {
+      return jsonResponse([{
+        Id: clientSessionId,
+        UserId: "user-1",
+        UserName: "Rick",
+        DeviceName: "Chrome",
+        PlayState: {
+          MediaSourceId: mediaSourceId,
+          IsPaused: true,
+          AudioStreamIndex: 1,
+        },
+        NowPlayingItem: item,
+      }]);
+    }
+
+    if (url.pathname === `/Items/${itemId}`) {
+      return jsonResponse(item);
+    }
+
+    if (url.pathname === `/Items/${itemId}/PlaybackInfo`) {
+      return jsonResponse({
+        ...(playSessionId ? { PlaySessionId: playSessionId } : {}),
+        MediaSources: [mediaSource],
+      });
+    }
+
+    return jsonResponse({ message: `Unexpected URL: ${url.toString()}` }, 404);
+  }) as typeof fetch;
+}
+
 void test("disables Jellyfin subtitle burn-in on HLS previews", () => {
   const path = buildPreviewPath(
     { Id: "item-1", MediaType: "Video" },
@@ -84,6 +207,91 @@ void test("disables Jellyfin subtitle burn-in on HLS previews", () => {
   assert.equal(url.searchParams.get("playSessionId"), "play-session-1");
   assert.equal(url.searchParams.get("alwaysBurnInSubtitleWhenTranscoding"), "false");
   assert.equal(url.searchParams.has("subtitleStreamIndex"), false);
+});
+
+void test("uses Jellyfin PlaybackInfo play session ids for currently playing streams", async () => {
+  const session = createSession();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createJellyfinPlaybackFetch({
+    itemId: "item-1",
+    playSessionId: "playback-info-session-1",
+    clientSessionId: "client-session-1",
+  });
+
+  try {
+    const entries = await listCurrentlyPlaying(session, createSource());
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.item.id, "source-1:client-session-1:item-1:media-source-1");
+    assert(entries[0]?.item.mediaUrl);
+    assert(entries[0]?.item.hlsUrl);
+
+    const streamHandle = [...session.mediaHandles.values()].find((handle) =>
+      handle.path.includes("/stream?")
+    );
+    const hlsHandle = [...session.mediaHandles.values()].find((handle) =>
+      handle.path.includes("/master.m3u8?")
+    );
+    assert(streamHandle);
+    assert(hlsHandle);
+
+    const streamUrl = new URL(streamHandle.path, "http://cliparr.local");
+    const hlsUrl = new URL(hlsHandle.path, "http://cliparr.local");
+    assert.equal(streamUrl.searchParams.get("playSessionId"), "playback-info-session-1");
+    assert.equal(hlsUrl.searchParams.get("playSessionId"), "playback-info-session-1");
+    assert.notEqual(streamUrl.searchParams.get("playSessionId"), "client-session-1");
+    assert.notEqual(hlsUrl.searchParams.get("playSessionId"), "client-session-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("keeps Jellyfin currently playing item ids stable and item-scoped", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = createJellyfinPlaybackFetch({
+      itemId: "item-1",
+      clientSessionId: "client-session-1",
+    });
+    const firstEntries = await listCurrentlyPlaying(createSession(), createSource());
+    const secondEntries = await listCurrentlyPlaying(createSession(), createSource());
+
+    globalThis.fetch = createJellyfinPlaybackFetch({
+      itemId: "item-2",
+      clientSessionId: "client-session-1",
+    });
+    const differentItemEntries = await listCurrentlyPlaying(createSession(), createSource());
+
+    assert.equal(firstEntries[0]?.item.id, secondEntries[0]?.item.id);
+    assert.notEqual(firstEntries[0]?.item.id, differentItemEntries[0]?.item.id);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("omits Jellyfin stream URLs when PlaybackInfo has no play session id", async () => {
+  const session = createSession();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createJellyfinPlaybackFetch({
+    itemId: "item-1",
+    playSessionId: null,
+    clientSessionId: "client-session-1",
+  });
+
+  try {
+    const entries = await listCurrentlyPlaying(session, createSource());
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.item.id, "source-1:client-session-1:item-1:media-source-1");
+    assert.equal(entries[0]?.item.mediaUrl, undefined);
+    assert.equal(entries[0]?.item.hlsUrl, undefined);
+    assert.equal(entries[0]?.item.previewUrl, undefined);
+    assert.equal(entries[0]?.item.previewFormat, undefined);
+    assert.equal(session.mediaHandles.size, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 void test("creates a downloadable content URL for Jellyfin text subtitle streams", () => {


### PR DESCRIPTION
## Summary
- fetch Jellyfin PlaybackInfo for currently playing items
- use PlaybackInfo.PlaySessionId for HLS/static stream URLs instead of /Sessions client ids
- keep Jellyfin editor item ids item-scoped and separate from stream session ids

## Root cause
Jellyfin /Sessions exposes client session ids, while media stream endpoints expect playback session ids. Reusing the client session id can allow Jellyfin to resolve a preview stream for the wrong item after playback changes.

## Validation
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/server lint:eslint