### PR TITLE
Fill timeline buffer within clip action

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -204,8 +204,6 @@ export default function EditorScreen({ session, onBack }: Props) {
     timelineEffects,
     activeTimelineScale,
     timelineScaleCount,
-    timelineScrollLeft,
-    timelineViewportWidth,
     handleTimelineScroll,
     handleTimelineWheel,
     handleTimelineZoomIn,
@@ -361,8 +359,6 @@ export default function EditorScreen({ session, onBack }: Props) {
                     timelineEffects={timelineEffects}
                     activeTimelineScale={activeTimelineScale}
                     timelineScaleCount={timelineScaleCount}
-                    timelineScrollLeft={timelineScrollLeft}
-                    timelineViewportWidth={timelineViewportWidth}
                     playbackReadyRange={isHlsPreviewSource ? playbackReadyRange : null}
                     loadingPreview={loadingPreview}
                     playing={playing}

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -1,13 +1,13 @@
 import { useCallback } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
-import type { RefObject, WheelEvent as ReactWheelEvent } from "react";
+import type { CSSProperties, RefObject, WheelEvent as ReactWheelEvent } from "react";
 import { Scissors } from "lucide-react";
 import type { PlaybackReadyRange } from "./useEditorPlayback";
 import { 
   formatTime,
+  getTimelineFillPercentages,
   TIMELINE_START_LEFT,
-  timelineTimeToPixel,
   type ClipTimelineData, 
   type ClipTimelineEffects, 
   type ClipTimelineAction,
@@ -21,8 +21,6 @@ interface EditorTimelineProps {
   timelineEffects: ClipTimelineEffects;
   activeTimelineScale: TimelineZoomLevel;
   timelineScaleCount: number;
-  timelineScrollLeft: number;
-  timelineViewportWidth: number;
   playbackReadyRange: PlaybackReadyRange | null;
   loadingPreview: boolean;
   playing: boolean;
@@ -44,8 +42,6 @@ export function EditorTimeline({
   timelineEffects,
   activeTimelineScale,
   timelineScaleCount,
-  timelineScrollLeft,
-  timelineViewportWidth,
   playbackReadyRange,
   loadingPreview,
   playing,
@@ -59,63 +55,48 @@ export function EditorTimeline({
   onCursorDragStart,
   onCursorDrag,
 }: EditorTimelineProps) {
+  const getReadyFillStyle = useCallback((action: ClipTimelineAction): CSSProperties | null => {
+    if (action.effectId !== "clip" || !playbackReadyRange) {
+      return null;
+    }
+
+    const fill = getTimelineFillPercentages({
+      trackStart: action.start,
+      trackEnd: action.end,
+      fillStart: playbackReadyRange.startTime,
+      fillEnd: Math.min(playbackReadyRange.readyUntilTime, playbackReadyRange.endTime),
+    });
+    if (!fill || (fill.widthPercent <= 0 && playbackReadyRange.status !== "warming")) {
+      return null;
+    }
+
+    return {
+      left: `${fill.leftPercent}%`,
+      width: `${fill.widthPercent}%`,
+    };
+  }, [playbackReadyRange]);
+
   const renderClipTimelineAction = useCallback((action: ClipTimelineAction) => {
     const isSource = action.effectId === "source";
+    const readyFillStyle = getReadyFillStyle(action);
 
     return (
       <div className="cliparr-timeline-action-content">
+        {readyFillStyle && playbackReadyRange && (
+          <span
+            className="cliparr-timeline-action-ready-fill"
+            data-status={playbackReadyRange.status}
+            style={readyFillStyle}
+            aria-hidden="true"
+          />
+        )}
         <span className="cliparr-timeline-action-label">
           {!isSource && <Scissors className="h-3.5 w-3.5" />}
           {isSource ? "Source" : "Selection"}
         </span>
       </div>
     );
-  }, []);
-
-  const playbackReadyOverlay = (() => {
-    if (!playbackReadyRange || timelineViewportWidth <= 0) {
-      return null;
-    }
-
-    const readyStartPixel = timelineTimeToPixel(
-      playbackReadyRange.startTime,
-      activeTimelineScale.scale,
-      activeTimelineScale.scaleWidth,
-      TIMELINE_START_LEFT,
-    ) - timelineScrollLeft;
-    const readyEndPixel = timelineTimeToPixel(
-      playbackReadyRange.readyUntilTime,
-      activeTimelineScale.scale,
-      activeTimelineScale.scaleWidth,
-      TIMELINE_START_LEFT,
-    ) - timelineScrollLeft;
-    if (readyEndPixel <= TIMELINE_START_LEFT || readyStartPixel >= timelineViewportWidth) {
-      return null;
-    }
-    const clippedLeft = Math.max(TIMELINE_START_LEFT, readyStartPixel);
-    const clippedRight = Math.min(timelineViewportWidth, readyEndPixel);
-    const width = Math.max(
-      playbackReadyRange.status === "warming" ? 2 : 0,
-      clippedRight - clippedLeft,
-    );
-
-    if (width <= 0) {
-      return null;
-    }
-
-    return (
-      <div
-        className="cliparr-timeline-ready-range"
-        data-status={playbackReadyRange.status}
-        aria-label="Preview ready"
-        title="Preview ready for smooth playback"
-        style={{
-          left: `${clippedLeft}px`,
-          width: `${width}px`,
-        }}
-      />
-    );
-  })();
+  }, [getReadyFillStyle, playbackReadyRange]);
 
   return (
     <div
@@ -166,7 +147,6 @@ export function EditorTimeline({
         getScaleRender={formatTime}
         getActionRender={renderClipTimelineAction}
       />
-      {playbackReadyOverlay}
     </div>
   );
 }

--- a/apps/frontend/src/components/editor/EditorUtils.ts
+++ b/apps/frontend/src/components/editor/EditorUtils.ts
@@ -204,6 +204,40 @@ export function timelineTimeToPixel(time: number, scale: number, scaleWidth: num
   return startLeft + (time / scale) * scaleWidth;
 }
 
+export function getTimelineFillPercentages({
+  trackStart,
+  trackEnd,
+  fillStart,
+  fillEnd,
+}: {
+  trackStart: number;
+  trackEnd: number;
+  fillStart: number;
+  fillEnd: number;
+}) {
+  if (
+    !Number.isFinite(trackStart)
+    || !Number.isFinite(trackEnd)
+    || !Number.isFinite(fillStart)
+    || !Number.isFinite(fillEnd)
+    || trackEnd <= trackStart
+    || fillEnd < fillStart
+    || fillEnd < trackStart
+    || fillStart > trackEnd
+  ) {
+    return null;
+  }
+
+  const trackDuration = trackEnd - trackStart;
+  const clampedStart = Math.min(Math.max(fillStart, trackStart), trackEnd);
+  const clampedEnd = Math.min(Math.max(fillEnd, trackStart), trackEnd);
+
+  return {
+    leftPercent: ((clampedStart - trackStart) / trackDuration) * 100,
+    widthPercent: ((clampedEnd - clampedStart) / trackDuration) * 100,
+  };
+}
+
 export function normalizeWheelDelta(
   deltaY: number,
   deltaMode: number,

--- a/apps/frontend/src/components/editor/timelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   formatTime,
+  getTimelineFillPercentages,
   getFocusedTimelineZoomIndex,
   type TimelineZoomLevel,
 } from "./EditorUtils";
@@ -83,6 +84,40 @@ void test("chooses an initial timeline zoom that keeps short selections editable
 void test("formats editor time with hours and sub-second precision when needed", () => {
   assert.equal(formatTime(7425), "2:03:45");
   assert.equal(formatTime(0.1), "0:00.10");
+});
+
+void test("maps buffered timeline fill into action-relative percentages", () => {
+  assert.deepEqual(getTimelineFillPercentages({
+    trackStart: 10,
+    trackEnd: 30,
+    fillStart: 15,
+    fillEnd: 25,
+  }), {
+    leftPercent: 25,
+    widthPercent: 50,
+  });
+});
+
+void test("clamps buffered timeline fill to the action bounds", () => {
+  assert.deepEqual(getTimelineFillPercentages({
+    trackStart: 10,
+    trackEnd: 30,
+    fillStart: 0,
+    fillEnd: 40,
+  }), {
+    leftPercent: 0,
+    widthPercent: 100,
+  });
+
+  assert.deepEqual(getTimelineFillPercentages({
+    trackStart: 10,
+    trackEnd: 30,
+    fillStart: 10,
+    fillEnd: 10,
+  }), {
+    leftPercent: 0,
+    widthPercent: 0,
+  });
 });
 
 void test("combines horizontal and vertical wheel deltas for timeline scrolling", () => {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -316,6 +316,7 @@
 
   .cliparr-timeline-action-content {
     display: flex;
+    position: relative;
     height: 100%;
     min-width: 0;
     align-items: center;
@@ -328,8 +329,32 @@
     -webkit-user-select: none;
   }
 
+  .cliparr-timeline-action-ready-fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+    border-radius: 1px;
+    background: color-mix(in oklch, var(--secondary) 24%, transparent);
+    box-shadow:
+      inset 1px 0 0 color-mix(in oklch, var(--secondary) 54%, transparent),
+      inset 0 0 0 1px color-mix(in oklch, var(--secondary) 22%, transparent);
+    pointer-events: none;
+  }
+
+  .cliparr-timeline-action-ready-fill[data-status="warming"] {
+    min-width: 2px;
+    background: color-mix(in oklch, var(--secondary) 18%, transparent);
+  }
+
+  .cliparr-timeline-action-ready-fill[data-status="ready"] {
+    background: color-mix(in oklch, var(--secondary) 28%, transparent);
+  }
+
   .cliparr-timeline-action-label {
     display: inline-flex;
+    position: relative;
+    z-index: 1;
     min-width: 0;
     align-items: center;
     gap: 6px;
@@ -362,25 +387,4 @@
 
   .cliparr-timeline .timeline-editor-drag-line {
     border-left-color: color-mix(in oklch, var(--ring) 75%, transparent);
-  }
-
-  .cliparr-timeline-ready-range {
-    position: absolute;
-    top: 64px;
-    height: 44px;
-    z-index: 2;
-    border-radius: 1px;
-    background: color-mix(in oklch, var(--secondary) 24%, transparent);
-    box-shadow:
-      inset 1px 0 0 color-mix(in oklch, var(--secondary) 54%, transparent),
-      inset 0 0 0 1px color-mix(in oklch, var(--secondary) 22%, transparent);
-    pointer-events: none;
-  }
-
-  .cliparr-timeline-ready-range[data-status="warming"] {
-    background: color-mix(in oklch, var(--secondary) 18%, transparent);
-  }
-
-  .cliparr-timeline-ready-range[data-status="ready"] {
-    background: color-mix(in oklch, var(--secondary) 28%, transparent);
   }


### PR DESCRIPTION
## Summary
- render preview ready/buffer state as an inner clip action fill instead of a free-floating overlay
- clamp ready fill percentages to the selection action bounds so the indicator cannot overhang the track
- add coverage for timeline fill percentage mapping and clamping

## Tests
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint
- pnpm --filter @cliparr/frontend build