### PR TITLE
[codex] Sync editor playhead from providers

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -14,6 +14,7 @@ import { EditorPlaybackSourcePanel } from "./editor/EditorPlaybackSourcePanel";
 import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
 import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
+import { buildInitialClipRange } from "./editor/initialClipRange";
 import { useSubtitleCues } from "./editor/useSubtitleCues";
 import type { PlaybackSubtitleTrack } from "../providers/types";
 import { sourceDisplayLabel, type EditorSession } from "../lib/editorMedia";
@@ -34,8 +35,9 @@ interface Props {
 }
 
 export default function EditorScreen({ session, onBack }: Props) {
-  const [startTime, setStartTime] = useState(0);
-  const [endTime, setEndTime] = useState(() => Math.min(10, Math.max(session.duration, 0)));
+  const initialClipRange = buildInitialClipRange(session.duration, session.initialPlayheadSeconds);
+  const [startTime, setStartTime] = useState(() => initialClipRange.startTime);
+  const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
   const [subtitleStyleSettings, setSubtitleStyleSettings] = useState(() => loadSubtitleStyleSettings());
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
   const [subtitleEnabled, setSubtitleEnabled] = useState(false);
@@ -119,6 +121,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     hlsSource: session.hlsSource,
     directSource: session.directSource,
     initialDuration: session.duration,
+    initialCurrentTime: initialClipRange.startTime,
     startTime,
     endTime,
     sessionId: session.id,

--- a/apps/frontend/src/components/editor/initialClipRange.test.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildInitialClipRange } from "./initialClipRange";
+
+void test("starts initial clip range at zero when no playhead is available", () => {
+  assert.deepEqual(buildInitialClipRange(120), {
+    startTime: 0,
+    endTime: 10,
+  });
+});
+
+void test("starts initial clip range at the provider playhead", () => {
+  assert.deepEqual(buildInitialClipRange(120, 42.25), {
+    startTime: 42.25,
+    endTime: 52.25,
+  });
+});
+
+void test("clamps initial clip range near the media end", () => {
+  assert.deepEqual(buildInitialClipRange(100, 99.99), {
+    startTime: 99.9,
+    endTime: 100,
+  });
+});
+
+void test("keeps rounded initial clip range within odd sub-second bounds", () => {
+  const range = buildInitialClipRange(0.205, 0.105);
+
+  assert.equal(range.endTime, 0.205);
+  assert.equal(range.startTime <= 0.105, true);
+  assert.equal(range.endTime <= 0.205, true);
+});

--- a/apps/frontend/src/components/editor/initialClipRange.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.ts
@@ -1,0 +1,44 @@
+import { MIN_CLIP_SECONDS, roundTimelineTime } from "./EditorUtils";
+
+const DEFAULT_INITIAL_CLIP_SECONDS = 10;
+
+export interface InitialClipRange {
+  startTime: number;
+  endTime: number;
+}
+
+function finiteNonNegativeSeconds(value: number | null | undefined) {
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+}
+
+function roundTimeWithinUpperBound(seconds: number, upperBound: number) {
+  return Math.min(roundTimelineTime(seconds), upperBound);
+}
+
+export function buildInitialClipRange(duration: number, playheadSeconds?: number): InitialClipRange {
+  const safeDuration = finiteNonNegativeSeconds(duration);
+  if (safeDuration <= 0) {
+    return {
+      startTime: 0,
+      endTime: 0,
+    };
+  }
+
+  const minimumClipLength = Math.min(MIN_CLIP_SECONDS, safeDuration);
+  const maximumStart = Math.max(safeDuration - minimumClipLength, 0);
+  const startTime = roundTimeWithinUpperBound(
+    Math.min(finiteNonNegativeSeconds(playheadSeconds), maximumStart),
+    maximumStart
+  );
+  const preferredEnd = startTime + DEFAULT_INITIAL_CLIP_SECONDS;
+  const endTime = roundTimeWithinUpperBound(
+    Math.min(Math.max(preferredEnd, startTime + minimumClipLength), safeDuration),
+    safeDuration
+  );
+
+  return {
+    startTime,
+    endTime,
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -62,6 +62,7 @@ interface UseEditorPlaybackProps {
   hlsSource?: EditorMediaSource;
   directSource?: EditorMediaSource;
   initialDuration: number;
+  initialCurrentTime?: number;
   startTime: number;
   endTime: number;
   sessionId: string;
@@ -127,10 +128,21 @@ async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
   };
 }
 
+function initialPlaybackTime(seconds: number | null | undefined, duration: number) {
+  const safeDuration = Math.max(Number.isFinite(duration) ? duration : 0, 0);
+  const safeSeconds = Number(seconds);
+  if (!Number.isFinite(safeSeconds) || safeSeconds < 0 || safeDuration <= 0) {
+    return 0;
+  }
+
+  return Math.min(safeSeconds, safeDuration);
+}
+
 export function useEditorPlayback({
   hlsSource,
   directSource,
   initialDuration,
+  initialCurrentTime,
   startTime,
   endTime,
   sessionId,
@@ -141,7 +153,7 @@ export function useEditorPlayback({
   subtitleStyleSettings,
 }: UseEditorPlaybackProps) {
   const [duration, setDuration] = useState(() => Math.max(initialDuration, 0));
-  const [currentTime, setCurrentTime] = useState(0);
+  const [currentTime, setCurrentTime] = useState(() => initialPlaybackTime(initialCurrentTime, initialDuration));
   const [playing, setPlaying] = useState(false);
   const [loadingPreview, setLoadingPreview] = useState(true);
   const [previewStatus, setPreviewStatus] = useState("Loading stream...");
@@ -183,7 +195,7 @@ export function useEditorPlayback({
   const wasPlayingRef = useRef(false);
   const playingRef = useRef(false);
   const audioContextStartTimeRef = useRef<number | null>(null);
-  const playbackTimeAtStartRef = useRef(0);
+  const playbackTimeAtStartRef = useRef(initialPlaybackTime(initialCurrentTime, initialDuration));
   const sourceTimelineOffsetRef = useRef(0);
   const skipLiveWaitRef = useRef(false);
   const activeSourceLabelRef = useRef(activeSourceLabel);
@@ -568,8 +580,9 @@ export function useEditorPlayback({
       durationRef.current = resetDuration;
       setSourceVideoDimensions(null);
       setPreviewVideoDimensions(null);
-      setCurrentTime(0);
-      playbackTimeAtStartRef.current = 0;
+      const resetCurrentTime = initialPlaybackTime(initialCurrentTime, resetDuration);
+      setCurrentTime(resetCurrentTime);
+      playbackTimeAtStartRef.current = resetCurrentTime;
       sourceTimelineOffsetRef.current = 0;
       skipLiveWaitRef.current = false;
 
@@ -716,8 +729,9 @@ export function useEditorPlayback({
             );
             setDuration(nextDuration);
             durationRef.current = nextDuration;
-            setCurrentTime(0);
-            playbackTimeAtStartRef.current = 0;
+            const nextCurrentTime = initialPlaybackTime(initialCurrentTime, nextDuration);
+            setCurrentTime(nextCurrentTime);
+            playbackTimeAtStartRef.current = nextCurrentTime;
 
             const sourceDimensions = sourceVideoTrack
               ? await getVideoTrackDimensions(sourceVideoTrack)
@@ -844,6 +858,7 @@ export function useEditorPlayback({
   }, [
     directSource,
     hlsSource,
+    initialCurrentTime,
     initialDuration,
     posterImageUrl,
     selectedAudioTrack,

--- a/apps/frontend/src/lib/editorMedia.test.ts
+++ b/apps/frontend/src/lib/editorMedia.test.ts
@@ -2,7 +2,8 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { titleFromUrl } from "./editorMedia";
+import { editorSessionFromCurrentlyPlaying, titleFromUrl } from "./editorMedia";
+import type { CurrentlyPlayingItem } from "../providers/types";
 
 void test("uses the URL host as the title when no path segment is present", () => {
   assert.equal(titleFromUrl("https://example.com/"), "example.com");
@@ -11,4 +12,24 @@ void test("uses the URL host as the title when no path segment is present", () =
 
 void test("uses the final URL path segment as the title when present", () => {
   assert.equal(titleFromUrl("https://example.com/media/example%20clip.mp4"), "example clip");
+});
+
+void test("passes provider playhead seconds into editor sessions", () => {
+  const item: CurrentlyPlayingItem = {
+    id: "source-1:session-1",
+    source: {
+      id: "source-1",
+      name: "Plex",
+      providerId: "plex",
+    },
+    title: "Example",
+    type: "movie",
+    duration: 600,
+    playheadSeconds: 123.456,
+    playerTitle: "Living Room",
+    playerState: "playing",
+    mediaUrl: "/api/media/direct",
+  };
+
+  assert.equal(editorSessionFromCurrentlyPlaying(item).initialPlayheadSeconds, 123.456);
 });

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -62,6 +62,7 @@ export interface EditorSession {
   title: string;
   type: string;
   duration: number;
+  initialPlayheadSeconds?: number;
   playerTitle: string;
   playerState: string;
   thumbUrl?: string;
@@ -110,6 +111,7 @@ export function editorSessionFromCurrentlyPlaying(item: CurrentlyPlayingItem): E
     title: item.title,
     type: item.type,
     duration: item.duration,
+    initialPlayheadSeconds: item.playheadSeconds,
     playerTitle: item.playerTitle,
     playerState: item.playerState,
     thumbUrl: item.thumbUrl,

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -75,6 +75,19 @@ function ticksToSeconds(value: number | null | undefined) {
   return ticks / 10_000_000;
 }
 
+export function playheadSecondsFromPositionTicks(value: number | null | undefined) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const ticks = Number(value);
+  if (!Number.isFinite(ticks) || ticks < 0) {
+    return undefined;
+  }
+
+  return ticks / 10_000_000;
+}
+
 function itemType(item: JellyfinItem) {
   return stringValue(item?.Type) ?? stringValue(item?.MediaType) ?? "Video";
 }
@@ -608,6 +621,7 @@ async function normalizeCurrentPlayback(
   const audioStreams = asArray(mediaSource?.MediaStreams).filter((stream) => isAudioMediaStream(stream));
   const videoStreams = asArray(mediaSource?.MediaStreams).filter((stream) => isVideoMediaStream(stream));
   const duration = ticksToSeconds(enrichedItem?.RunTimeTicks ?? nowPlayingItem?.RunTimeTicks);
+  const playheadSeconds = playheadSecondsFromPositionTicks(sessionInfo?.PlayState?.PositionTicks);
   const playerTitle = stringValue(sessionInfo?.DeviceName)
     ?? stringValue(sessionInfo?.Client)
     ?? stringValue(sessionInfo?.DeviceType)
@@ -630,6 +644,7 @@ async function normalizeCurrentPlayback(
       title: itemTitle(enrichedItem),
       type: itemType(enrichedItem).toLowerCase(),
       duration,
+      playheadSeconds: playheadSeconds ?? null,
       playerTitle,
       playerState,
       mediaUrl: mediaUrl ?? null,
@@ -683,6 +698,7 @@ async function normalizeCurrentPlayback(
       title: itemTitle(enrichedItem),
       type: itemType(enrichedItem).toLowerCase(),
       duration,
+      playheadSeconds,
       playerTitle,
       playerState,
       thumbUrl,

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -104,6 +104,7 @@ interface JellyfinPlayState {
   MediaSourceId?: string | null;
   AudioStreamIndex?: number | null;
   SubtitleStreamIndex?: number | null;
+  PositionTicks?: number | null;
   IsPaused?: boolean;
 }
 

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -8,6 +8,7 @@ import {
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
   listCurrentlyPlaying,
+  playheadSecondsFromPositionTicks,
   proxyMedia,
 } from "./jellyfin/playback.js";
 import type { JellyfinSourceContext } from "./jellyfin/shared.js";
@@ -170,6 +171,7 @@ function createJellyfinPlaybackFetch(options: {
           MediaSourceId: mediaSourceId,
           IsPaused: true,
           AudioStreamIndex: 1,
+          PositionTicks: 1_234_560_000,
         },
         NowPlayingItem: item,
       }]);
@@ -209,6 +211,14 @@ void test("disables Jellyfin subtitle burn-in on HLS previews", () => {
   assert.equal(url.searchParams.has("subtitleStreamIndex"), false);
 });
 
+void test("converts Jellyfin PositionTicks into playhead seconds", () => {
+  assert.equal(playheadSecondsFromPositionTicks(1234560000), 123.456);
+  assert.equal(playheadSecondsFromPositionTicks(0), 0);
+  assert.equal(playheadSecondsFromPositionTicks(-1), undefined);
+  assert.equal(playheadSecondsFromPositionTicks(null), undefined);
+  assert.equal(playheadSecondsFromPositionTicks(undefined), undefined);
+});
+
 void test("uses Jellyfin PlaybackInfo play session ids for currently playing streams", async () => {
   const session = createSession();
   const originalFetch = globalThis.fetch;
@@ -223,6 +233,7 @@ void test("uses Jellyfin PlaybackInfo play session ids for currently playing str
 
     assert.equal(entries.length, 1);
     assert.equal(entries[0]?.item.id, "source-1:client-session-1:item-1:media-source-1");
+    assert.equal(entries[0]?.item.playheadSeconds, 123.456);
     assert(entries[0]?.item.mediaUrl);
     assert(entries[0]?.item.hlsUrl);
 

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -70,9 +70,49 @@ function createMediaHandle(
   }, path, options);
 }
 
-function metadataPath(item: any) {
-  if (item?.ratingKey) {
-    return `/library/metadata/${item.ratingKey}`;
+type PlexIdValue = string | number | null | undefined;
+type PlexViewOffsetValue = number | string | null | undefined;
+
+interface PlexMetadataPathItem {
+  ratingKey?: PlexIdValue;
+  key?: string | null;
+}
+
+interface PlexPlaybackUser {
+  id?: PlexIdValue;
+  thumb?: string | null;
+  title?: string | null;
+}
+
+interface PlexPlaybackPlayer {
+  machineIdentifier?: string | null;
+  state?: string | null;
+  title?: string | null;
+}
+
+interface PlexPlaybackSession {
+  id?: PlexIdValue;
+}
+
+interface PlexCurrentlyPlayingMetadata extends PlexMetadataPathItem {
+  Media?: unknown[] | null;
+  Player?: PlexPlaybackPlayer | null;
+  Session?: PlexPlaybackSession | null;
+  User?: PlexPlaybackUser | null;
+  sessionKey?: PlexIdValue;
+  viewOffset?: PlexViewOffsetValue;
+}
+
+interface PlexCurrentlyPlayingData {
+  MediaContainer?: {
+    Metadata?: PlexCurrentlyPlayingMetadata[] | null;
+  } | null;
+}
+
+function metadataPath(item: PlexMetadataPathItem | null | undefined) {
+  const ratingKey = idValue(item?.ratingKey);
+  if (ratingKey) {
+    return `/library/metadata/${ratingKey}`;
   }
   if (typeof item?.key === "string" && item.key.startsWith("/library/metadata/")) {
     return item.key;
@@ -119,6 +159,19 @@ function streamEntries(part: any) {
 function selectedIndex(entries: any[]) {
   const index = entries.findIndex((entry) => isSelectedEntry(entry));
   return index >= 0 ? index : 0;
+}
+
+export function playheadSecondsFromViewOffset(value: PlexViewOffsetValue) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const milliseconds = Number(value);
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) {
+    return undefined;
+  }
+
+  return milliseconds / 1000;
 }
 
 function deriveMediaSelection(item: any): PlexMediaSelection | undefined {
@@ -297,7 +350,7 @@ async function fetchCurrentlyPlayingData(source: MediaSource) {
     try {
       const data = await fetchPmsJson(context, "/status/sessions", {
         timeoutMs: CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS,
-      });
+      }) as PlexCurrentlyPlayingData;
       persistWorkingSourceConnection(source, persistedConnections, connection, {
         baseUrlMode,
         manualConnectionId,
@@ -319,7 +372,7 @@ async function fetchCurrentlyPlayingData(source: MediaSource) {
   );
 }
 
-function playbackFallbackIdentity(item: any) {
+function playbackFallbackIdentity(item: PlexCurrentlyPlayingMetadata) {
   const userId = idValue(item?.User?.id);
   const playerId = stringValue(item?.Player?.machineIdentifier) ?? stringValue(item?.Player?.title);
   const itemId = idValue(item?.ratingKey) ?? stringValue(item?.key) ?? metadataPath(item);
@@ -328,7 +381,7 @@ function playbackFallbackIdentity(item: any) {
   return parts.length > 0 ? parts.join(":") : undefined;
 }
 
-function playbackDeduplicationKey(item: any) {
+function playbackDeduplicationKey(item: PlexCurrentlyPlayingMetadata) {
   const sessionKey = idValue(item?.sessionKey);
   if (sessionKey) {
     return `session:${sessionKey}`;
@@ -347,7 +400,7 @@ function playbackDeduplicationKey(item: any) {
   return undefined;
 }
 
-function dedupeCurrentlyPlayingMetadata(metadata: any[]) {
+function dedupeCurrentlyPlayingMetadata(metadata: PlexCurrentlyPlayingMetadata[]) {
   // Plex can emit duplicate rows for one live session, especially from web clients.
   const seen = new Set<string>();
 
@@ -777,7 +830,7 @@ async function resolveMediaPath(
   }
 }
 
-function playbackSessionIdentity(item: any) {
+function playbackSessionIdentity(item: PlexCurrentlyPlayingMetadata) {
   return String(
     item?.sessionKey
     ?? item?.Session?.id
@@ -786,7 +839,7 @@ function playbackSessionIdentity(item: any) {
   );
 }
 
-function playbackViewer(item: any, sourceId: string, sessionId: string) {
+function playbackViewer(item: PlexCurrentlyPlayingMetadata, sourceId: string, sessionId: string) {
   const externalId = stringValue(item?.User?.id);
   return {
     id: externalId ? `plex:user:${externalId}` : `plex:synthetic:${sourceId}:${sessionId}`,
@@ -801,7 +854,7 @@ async function normalizeCurrentPlayback(
   session: ProviderSessionRecord,
   source: MediaSource,
   context: PlexSourceContext,
-  data: any
+  data: PlexCurrentlyPlayingData
 ): Promise<CurrentlyPlayingEntry[]> {
   const metadata = data?.MediaContainer?.Metadata;
   if (!Array.isArray(metadata)) {
@@ -810,7 +863,7 @@ async function normalizeCurrentPlayback(
 
   const uniqueMetadata = dedupeCurrentlyPlayingMetadata(metadata);
 
-  return Promise.all(uniqueMetadata.map(async (item: any) => {
+  return Promise.all(uniqueMetadata.map(async (item) => {
     const sessionId = playbackSessionIdentity(item);
     const mediaSelection = deriveMediaSelection(item);
     const enrichedItem = await enrichMetadataItem(context, item);
@@ -825,6 +878,7 @@ async function normalizeCurrentPlayback(
     const audioStreams = selectedPart ? streamEntries(selectedPart).filter((stream) => isAudioStream(stream)) : [];
     const videoStreams = selectedPart ? streamEntries(selectedPart).filter((stream) => isVideoStream(stream)) : [];
     const duration = Number(enrichedItem.duration ?? asArray(enrichedItem.Media)[0]?.duration ?? 0) / 1000;
+    const playheadSeconds = playheadSecondsFromViewOffset(item?.viewOffset);
     const playerTitle = String(item.Player?.title ?? "Unknown Device");
     const playerState = String(item.Player?.state ?? "unknown");
     const thumbUrl = thumbPath ? createMediaHandle(session, context, thumbPath) : undefined;
@@ -842,6 +896,7 @@ async function normalizeCurrentPlayback(
         title: String(enrichedItem.title ?? "Untitled"),
         type: String(enrichedItem.type ?? "video"),
         duration,
+        playheadSeconds: playheadSeconds ?? null,
         playerTitle,
         playerState,
         mediaUrl: mediaUrl ?? null,
@@ -900,6 +955,7 @@ async function normalizeCurrentPlayback(
         title: String(enrichedItem.title ?? "Untitled"),
         type: String(enrichedItem.type ?? "video"),
         duration,
+        playheadSeconds,
         playerTitle,
         playerState,
         thumbUrl,

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ProviderSessionRecord } from "../session/store.js";
-import { createPreviewPath, deriveSelectedSubtitleTrack, deriveSubtitleTracks } from "./plex/playback.js";
+import {
+  createPreviewPath,
+  deriveSelectedSubtitleTrack,
+  deriveSubtitleTracks,
+  playheadSecondsFromViewOffset,
+} from "./plex/playback.js";
 import type { PlexSourceContext } from "./plex/shared.js";
 
 function createSession(): ProviderSessionRecord {
@@ -61,6 +66,16 @@ void test("does not create Plex HLS preview paths for audio tracks", () => {
   };
 
   assert.equal(createPreviewPath(item, "plex-session-1"), undefined);
+});
+
+void test("converts Plex viewOffset milliseconds into playhead seconds", () => {
+  assert.equal(playheadSecondsFromViewOffset(123456), 123.456);
+  assert.equal(playheadSecondsFromViewOffset("123456"), 123.456);
+  assert.equal(playheadSecondsFromViewOffset(0), 0);
+  assert.equal(playheadSecondsFromViewOffset(-1), undefined);
+  assert.equal(playheadSecondsFromViewOffset(null), undefined);
+  assert.equal(playheadSecondsFromViewOffset(undefined), undefined);
+  assert.equal(playheadSecondsFromViewOffset("nope"), undefined);
 });
 
 void test("creates a direct content URL for Plex sidecar text subtitle streams", () => {

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -74,6 +74,7 @@ export interface CurrentlyPlayingItem {
   title: string;
   type: string;
   duration: number;
+  playheadSeconds?: number;
   playerTitle: string;
   playerState: string;
   thumbUrl?: string;


### PR DESCRIPTION
On load, the editor will perform a one-time sync, starting the playhead/clip at the current position of the media in the media server. Now, if you play a video in Plex/Jellyfin and pause at the point you would like to clip, Cliparr will automatically start at that point.

Solves #70 

## Summary
- add provider-neutral `playheadSeconds` to currently-playing items
- derive Plex playhead position from `viewOffset` and Jellyfin position from `PlayState.PositionTicks`
- initialize the editor clip range and preview playhead from the provider snapshot once when opening a session