### PR TITLE
[codex] Display album art for audio-only media

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -89,15 +89,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitleError,
     session.source.providerId,
   ]);
-  const posterImageUrls = useMemo(
-    () => [
-      session.exportMetadata?.imageUrl,
-      session.thumbUrl,
-    ].filter((url, index, urls): url is string =>
-      Boolean(url) && urls.indexOf(url) === index
-    ),
-    [session.exportMetadata?.imageUrl, session.thumbUrl]
-  );
+  const posterImageUrl = session.thumbUrl;
 
   const {
     canvasRef,
@@ -131,7 +123,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     endTime,
     sessionId: session.id,
     selectedAudioTrack: session.selectedAudioTrack,
-    posterImageUrls,
+    posterImageUrl,
     subtitleCues,
     subtitlesEnabled: subtitlePreviewEnabled,
     subtitleStyleSettings,

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -89,6 +89,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitleError,
     session.source.providerId,
   ]);
+  const posterImageUrl = session.exportMetadata?.imageUrl ?? session.thumbUrl;
 
   const {
     canvasRef,
@@ -102,6 +103,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     exportFallbackSource,
     hlsFallbackInfo,
     sourceVideoDimensions,
+    previewVideoDimensions,
     playbackReadyRange,
     volume,
     muted,
@@ -121,6 +123,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     endTime,
     sessionId: session.id,
     selectedAudioTrack: session.selectedAudioTrack,
+    posterImageUrl,
     subtitleCues,
     subtitlesEnabled: subtitlePreviewEnabled,
     subtitleStyleSettings,
@@ -318,6 +321,7 @@ export default function EditorScreen({ session, onBack }: Props) {
             <section className="flex min-h-[12rem] flex-none items-center justify-center overflow-hidden border border-border bg-card p-3 sm:min-h-[16rem] lg:min-h-0 lg:flex-1">
               <EditorPreview
                 canvasRef={canvasRef}
+                videoDimensions={previewVideoDimensions}
                 playing={playing}
                 loadingPreview={loadingPreview}
                 previewStatus={previewStatus}

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -89,7 +89,15 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitleError,
     session.source.providerId,
   ]);
-  const posterImageUrl = session.exportMetadata?.imageUrl ?? session.thumbUrl;
+  const posterImageUrls = useMemo(
+    () => [
+      session.exportMetadata?.imageUrl,
+      session.thumbUrl,
+    ].filter((url, index, urls): url is string =>
+      Boolean(url) && urls.indexOf(url) === index
+    ),
+    [session.exportMetadata?.imageUrl, session.thumbUrl]
+  );
 
   const {
     canvasRef,
@@ -123,7 +131,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     endTime,
     sessionId: session.id,
     selectedAudioTrack: session.selectedAudioTrack,
-    posterImageUrl,
+    posterImageUrls,
     subtitleCues,
     subtitlesEnabled: subtitlePreviewEnabled,
     subtitleStyleSettings,

--- a/apps/frontend/src/components/editor/EditorPreview.tsx
+++ b/apps/frontend/src/components/editor/EditorPreview.tsx
@@ -3,6 +3,10 @@ import type { RefObject } from "react";
 
 interface EditorPreviewProps {
   canvasRef: RefObject<HTMLCanvasElement | null>;
+  videoDimensions?: {
+    width: number;
+    height: number;
+  } | null;
   playing: boolean;
   loadingPreview: boolean;
   previewStatus: string;
@@ -11,13 +15,21 @@ interface EditorPreviewProps {
 
 export function EditorPreview({
   canvasRef,
+  videoDimensions,
   playing,
   loadingPreview,
   previewStatus,
   togglePlay,
 }: EditorPreviewProps) {
+  const aspectRatio = videoDimensions && videoDimensions.width > 0 && videoDimensions.height > 0
+    ? `${videoDimensions.width} / ${videoDimensions.height}`
+    : undefined;
+
   return (
-    <div className="group relative aspect-video h-full max-h-full w-auto max-w-full overflow-hidden bg-[var(--editor-preview-stage)]">
+    <div
+      className="group relative aspect-video h-full max-h-full w-auto max-w-full overflow-hidden bg-[var(--editor-preview-stage)]"
+      style={aspectRatio ? { aspectRatio } : undefined}
+    >
       <canvas
         ref={canvasRef}
         className="h-full w-full object-contain"

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -66,6 +66,7 @@ interface UseEditorPlaybackProps {
   endTime: number;
   sessionId: string;
   selectedAudioTrack?: PlaybackAudioSelection;
+  posterImageUrl?: string;
   subtitleCues?: readonly SubtitleCue[];
   subtitlesEnabled?: boolean;
   subtitleStyleSettings?: SubtitleStyleSettings;
@@ -76,6 +77,57 @@ interface VideoDimensions {
   height: number;
 }
 
+interface StaticVideoFrame {
+  canvas: HTMLCanvasElement;
+  dimensions: VideoDimensions;
+}
+
+const MAX_STATIC_VIDEO_FRAME_SIZE = 1920;
+
+function scaledStaticFrameDimensions(width: number, height: number): VideoDimensions {
+  const safeWidth = Number.isFinite(width) && width > 0 ? width : 1280;
+  const safeHeight = Number.isFinite(height) && height > 0 ? height : 720;
+  const scale = Math.min(1, MAX_STATIC_VIDEO_FRAME_SIZE / Math.max(safeWidth, safeHeight));
+
+  return {
+    width: Math.max(1, Math.round(safeWidth * scale)),
+    height: Math.max(1, Math.round(safeHeight * scale)),
+  };
+}
+
+function loadImageElement(url: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.decoding = "async";
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Could not load artwork image."));
+    image.src = url;
+  });
+}
+
+async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
+  const image = await loadImageElement(url);
+  const dimensions = scaledStaticFrameDimensions(image.naturalWidth, image.naturalHeight);
+  const canvas = document.createElement("canvas");
+  canvas.width = dimensions.width;
+  canvas.height = dimensions.height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Could not create an artwork rendering canvas.");
+  }
+
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = "high";
+  context.drawImage(image, 0, 0, dimensions.width, dimensions.height);
+
+  return {
+    canvas,
+    dimensions,
+  };
+}
+
 export function useEditorPlayback({
   hlsSource,
   directSource,
@@ -84,6 +136,7 @@ export function useEditorPlayback({
   endTime,
   sessionId,
   selectedAudioTrack,
+  posterImageUrl,
   subtitleCues = [],
   subtitlesEnabled = false,
   subtitleStyleSettings,
@@ -100,16 +153,19 @@ export function useEditorPlayback({
   const [exportFallbackSource, setExportFallbackSource] = useState<EditorMediaSource | undefined>(undefined);
   const [hlsFallbackInfo, setHlsFallbackInfo] = useState<PlaybackFallbackInfo | null>(null);
   const [sourceVideoDimensions, setSourceVideoDimensions] = useState<VideoDimensions | null>(null);
+  const [previewVideoDimensions, setPreviewVideoDimensions] = useState<VideoDimensions | null>(null);
   const [playbackReadyRange, setPlaybackReadyRange] = useState<PlaybackReadyRange | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const inputRef = useRef<Input | null>(null);
   const videoSinkRef = useRef<CanvasSink | null>(null);
   const audioSinkRef = useRef<AudioBufferSink | null>(null);
+  const staticVideoFrameRef = useRef<HTMLCanvasElement | null>(null);
   const videoFrameIteratorRef = useRef<AsyncGenerator<WrappedCanvas, void, unknown> | null>(null);
   const audioBufferIteratorRef = useRef<AsyncGenerator<WrappedAudioBuffer, void, unknown> | null>(null);
   const nextFrameRef = useRef<WrappedCanvas | null>(null);
   const displayedFrameRef = useRef<WrappedCanvas | null>(null);
+  const displayedStaticFrameRef = useRef<{ canvas: HTMLCanvasElement; timestamp: number } | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const gainNodeRef = useRef<GainNode | null>(null);
   const queuedAudioNodesRef = useRef(new Set<AudioBufferSourceNode>());
@@ -230,9 +286,11 @@ export function useEditorPlayback({
     canvasRef,
     inputRef,
     videoSinkRef,
+    staticVideoFrameRef,
     videoFrameIteratorRef,
     nextFrameRef,
     displayedFrameRef,
+    displayedStaticFrameRef,
     animationFrameRef,
     renderIntervalRef,
     generationRef,
@@ -300,6 +358,8 @@ export function useEditorPlayback({
     if (clearActiveSource) {
       setActiveSourceLabel("");
     }
+    setSourceVideoDimensions(null);
+    setPreviewVideoDimensions(null);
     pausePlayback(false);
     stopRenderLoop();
     void videoFrameIteratorRef.current?.return();
@@ -307,11 +367,13 @@ export function useEditorPlayback({
     videoFrameIteratorRef.current = null;
     audioBufferIteratorRef.current = null;
     nextFrameRef.current = null;
+    staticVideoFrameRef.current = null;
     sourceTimelineOffsetRef.current = 0;
     skipLiveWaitRef.current = false;
     warmupPromiseRef.current = null;
     warmupTargetTimeRef.current = null;
     displayedFrameRef.current = null;
+    displayedStaticFrameRef.current = null;
     disposePlaybackSinkResources({
       inputRef,
       videoSinkRef,
@@ -326,8 +388,19 @@ export function useEditorPlayback({
     const displayedFrame = displayedFrameRef.current;
     if (displayedFrame) {
       drawFrame(displayedFrame);
+      return;
     }
-  }, [drawFrame, subtitleCues, subtitlesEnabled, subtitleStyleSettings]);
+
+    const displayedStaticFrame = displayedStaticFrameRef.current;
+    if (displayedStaticFrame) {
+      const canvas = canvasRef.current;
+      const context = canvas?.getContext("2d");
+      if (canvas && context) {
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        context.drawImage(displayedStaticFrame.canvas, 0, 0, canvas.width, canvas.height);
+      }
+    }
+  }, [canvasRef, drawFrame, subtitleCues, subtitlesEnabled, subtitleStyleSettings]);
 
   const disposePreview = useCallback(() => {
     resetPreview(true, true);
@@ -499,6 +572,7 @@ export function useEditorPlayback({
       setDuration(resetDuration);
       durationRef.current = resetDuration;
       setSourceVideoDimensions(null);
+      setPreviewVideoDimensions(null);
       setCurrentTime(0);
       playbackTimeAtStartRef.current = 0;
       sourceTimelineOffsetRef.current = 0;
@@ -564,6 +638,16 @@ export function useEditorPlayback({
             if (previewAudioAssessment.warning) {
               warnings.push(previewAudioAssessment.warning);
             }
+            const staticVideoFrame = !sourceVideoTrack && previewAudioTrack && posterImageUrl
+              ? await loadStaticVideoFrame(posterImageUrl).catch((err: unknown) => {
+                  console.warn("Could not load editor artwork for audio-only preview", {
+                    sessionId,
+                    posterImageUrl,
+                    errorMessage: errorMessage(err),
+                  });
+                  return null;
+                })
+              : null;
             playbackSourceAnalysisContext = {
               sessionId,
               source: playbackSource.label,
@@ -584,6 +668,8 @@ export function useEditorPlayback({
               return;
             }
 
+            staticVideoFrameRef.current = staticVideoFrame?.canvas ?? null;
+
             if (previewVideoTrack && allAudioTracks.length > 0 && !previewAudioTrack && playbackSourceAnalysisContext) {
               console.warn(
                 "Editor playback source loaded without preview audio",
@@ -591,7 +677,7 @@ export function useEditorPlayback({
               );
             }
 
-            if (!previewVideoTrack && previewAudioTrack && playbackSourceAnalysisContext) {
+            if (!previewVideoTrack && previewAudioTrack && !staticVideoFrame && playbackSourceAnalysisContext) {
               console.warn(
                 "Editor playback source loaded without preview video",
                 await buildPlaybackSourceAnalysis(playbackSourceAnalysisContext),
@@ -641,16 +727,21 @@ export function useEditorPlayback({
             const sourceDimensions = sourceVideoTrack
               ? await getVideoTrackDimensions(sourceVideoTrack)
               : null;
+            const previewDimensions = sourceDimensions ?? staticVideoFrame?.dimensions ?? null;
             const audioTrackSampleRate = previewAudioTrack
               ? await getAudioTrackSampleRate(previewAudioTrack)
               : undefined;
 
             if (sourceDimensions) {
               setSourceVideoDimensions(sourceDimensions);
+            }
+
+            if (previewDimensions) {
+              setPreviewVideoDimensions(previewDimensions);
               const canvas = canvasRef.current;
               if (canvas) {
-                canvas.width = sourceDimensions.width;
-                canvas.height = sourceDimensions.height;
+                canvas.width = previewDimensions.width;
+                canvas.height = previewDimensions.height;
               }
             }
 
@@ -740,6 +831,7 @@ export function useEditorPlayback({
           setError(buildPlaybackLoadError(failures));
           setHlsFallbackInfo(nextHlsFallbackInfo);
           setSourceVideoDimensions(null);
+          setPreviewVideoDimensions(null);
         }
       } finally {
         if (!cancelled) {
@@ -758,6 +850,7 @@ export function useEditorPlayback({
     directSource,
     hlsSource,
     initialDuration,
+    posterImageUrl,
     selectedAudioTrack,
     sessionId,
     disposePreview,
@@ -778,6 +871,7 @@ export function useEditorPlayback({
     exportFallbackSource,
     hlsFallbackInfo,
     sourceVideoDimensions,
+    previewVideoDimensions,
     playbackReadyRange,
     volume,
     muted,

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -66,7 +66,7 @@ interface UseEditorPlaybackProps {
   endTime: number;
   sessionId: string;
   selectedAudioTrack?: PlaybackAudioSelection;
-  posterImageUrls?: readonly string[];
+  posterImageUrl?: string;
   subtitleCues?: readonly SubtitleCue[];
   subtitlesEnabled?: boolean;
   subtitleStyleSettings?: SubtitleStyleSettings;
@@ -83,7 +83,6 @@ interface StaticVideoFrame {
 }
 
 const MAX_STATIC_VIDEO_FRAME_SIZE = 1920;
-const STATIC_VIDEO_FRAME_LOAD_TIMEOUT_MS = 2500;
 
 function scaledStaticFrameDimensions(width: number, height: number): VideoDimensions {
   const safeWidth = Number.isFinite(width) && width > 0 ? width : 1280;
@@ -106,27 +105,8 @@ function loadImageElement(url: string) {
   });
 }
 
-function loadImageElementWithTimeout(url: string) {
-  return new Promise<HTMLImageElement>((resolve, reject) => {
-    const timeout = window.setTimeout(() => {
-      reject(new Error("Timed out loading artwork image."));
-    }, STATIC_VIDEO_FRAME_LOAD_TIMEOUT_MS);
-
-    loadImageElement(url).then(
-      (image) => {
-        window.clearTimeout(timeout);
-        resolve(image);
-      },
-      (err: unknown) => {
-        window.clearTimeout(timeout);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      },
-    );
-  });
-}
-
 async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
-  const image = await loadImageElementWithTimeout(url);
+  const image = await loadImageElement(url);
   const dimensions = scaledStaticFrameDimensions(image.naturalWidth, image.naturalHeight);
   const canvas = document.createElement("canvas");
   canvas.width = dimensions.width;
@@ -147,21 +127,6 @@ async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
   };
 }
 
-async function loadFirstStaticVideoFrame(urls: readonly string[]) {
-  for (const url of urls) {
-    try {
-      return await loadStaticVideoFrame(url);
-    } catch (err) {
-      console.warn("Could not load editor artwork for audio-only preview", {
-        posterImageUrl: url,
-        errorMessage: errorMessage(err),
-      });
-    }
-  }
-
-  return null;
-}
-
 export function useEditorPlayback({
   hlsSource,
   directSource,
@@ -170,7 +135,7 @@ export function useEditorPlayback({
   endTime,
   sessionId,
   selectedAudioTrack,
-  posterImageUrls = [],
+  posterImageUrl,
   subtitleCues = [],
   subtitlesEnabled = false,
   subtitleStyleSettings,
@@ -672,8 +637,15 @@ export function useEditorPlayback({
             if (previewAudioAssessment.warning) {
               warnings.push(previewAudioAssessment.warning);
             }
-            const staticVideoFrame = !sourceVideoTrack && previewAudioTrack && posterImageUrls.length > 0
-              ? await loadFirstStaticVideoFrame(posterImageUrls)
+            const staticVideoFrame = !sourceVideoTrack && previewAudioTrack && posterImageUrl
+              ? await loadStaticVideoFrame(posterImageUrl).catch((err: unknown) => {
+                  console.warn("Could not load editor artwork for audio-only preview", {
+                    sessionId,
+                    posterImageUrl,
+                    errorMessage: errorMessage(err),
+                  });
+                  return null;
+                })
               : null;
             playbackSourceAnalysisContext = {
               sessionId,
@@ -877,7 +849,7 @@ export function useEditorPlayback({
     directSource,
     hlsSource,
     initialDuration,
-    posterImageUrls,
+    posterImageUrl,
     selectedAudioTrack,
     sessionId,
     disposePreview,

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -66,7 +66,7 @@ interface UseEditorPlaybackProps {
   endTime: number;
   sessionId: string;
   selectedAudioTrack?: PlaybackAudioSelection;
-  posterImageUrl?: string;
+  posterImageUrls?: readonly string[];
   subtitleCues?: readonly SubtitleCue[];
   subtitlesEnabled?: boolean;
   subtitleStyleSettings?: SubtitleStyleSettings;
@@ -83,6 +83,7 @@ interface StaticVideoFrame {
 }
 
 const MAX_STATIC_VIDEO_FRAME_SIZE = 1920;
+const STATIC_VIDEO_FRAME_LOAD_TIMEOUT_MS = 2500;
 
 function scaledStaticFrameDimensions(width: number, height: number): VideoDimensions {
   const safeWidth = Number.isFinite(width) && width > 0 ? width : 1280;
@@ -98,7 +99,6 @@ function scaledStaticFrameDimensions(width: number, height: number): VideoDimens
 function loadImageElement(url: string) {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const image = new Image();
-    image.crossOrigin = "anonymous";
     image.decoding = "async";
     image.onload = () => resolve(image);
     image.onerror = () => reject(new Error("Could not load artwork image."));
@@ -106,8 +106,27 @@ function loadImageElement(url: string) {
   });
 }
 
+function loadImageElementWithTimeout(url: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      reject(new Error("Timed out loading artwork image."));
+    }, STATIC_VIDEO_FRAME_LOAD_TIMEOUT_MS);
+
+    loadImageElement(url).then(
+      (image) => {
+        window.clearTimeout(timeout);
+        resolve(image);
+      },
+      (err: unknown) => {
+        window.clearTimeout(timeout);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
+}
+
 async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
-  const image = await loadImageElement(url);
+  const image = await loadImageElementWithTimeout(url);
   const dimensions = scaledStaticFrameDimensions(image.naturalWidth, image.naturalHeight);
   const canvas = document.createElement("canvas");
   canvas.width = dimensions.width;
@@ -128,6 +147,21 @@ async function loadStaticVideoFrame(url: string): Promise<StaticVideoFrame> {
   };
 }
 
+async function loadFirstStaticVideoFrame(urls: readonly string[]) {
+  for (const url of urls) {
+    try {
+      return await loadStaticVideoFrame(url);
+    } catch (err) {
+      console.warn("Could not load editor artwork for audio-only preview", {
+        posterImageUrl: url,
+        errorMessage: errorMessage(err),
+      });
+    }
+  }
+
+  return null;
+}
+
 export function useEditorPlayback({
   hlsSource,
   directSource,
@@ -136,7 +170,7 @@ export function useEditorPlayback({
   endTime,
   sessionId,
   selectedAudioTrack,
-  posterImageUrl,
+  posterImageUrls = [],
   subtitleCues = [],
   subtitlesEnabled = false,
   subtitleStyleSettings,
@@ -638,15 +672,8 @@ export function useEditorPlayback({
             if (previewAudioAssessment.warning) {
               warnings.push(previewAudioAssessment.warning);
             }
-            const staticVideoFrame = !sourceVideoTrack && previewAudioTrack && posterImageUrl
-              ? await loadStaticVideoFrame(posterImageUrl).catch((err: unknown) => {
-                  console.warn("Could not load editor artwork for audio-only preview", {
-                    sessionId,
-                    posterImageUrl,
-                    errorMessage: errorMessage(err),
-                  });
-                  return null;
-                })
+            const staticVideoFrame = !sourceVideoTrack && previewAudioTrack && posterImageUrls.length > 0
+              ? await loadFirstStaticVideoFrame(posterImageUrls)
               : null;
             playbackSourceAnalysisContext = {
               sessionId,
@@ -850,7 +877,7 @@ export function useEditorPlayback({
     directSource,
     hlsSource,
     initialDuration,
-    posterImageUrl,
+    posterImageUrls,
     selectedAudioTrack,
     sessionId,
     disposePreview,

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -277,6 +277,7 @@ export function useEditorPlayback({
   }, [getPlaybackTime, stopAudioNodes]);
 
   const {
+    drawCanvasFrame,
     drawFrame,
     startVideoIterator,
     startRenderLoop,
@@ -392,14 +393,9 @@ export function useEditorPlayback({
 
     const displayedStaticFrame = displayedStaticFrameRef.current;
     if (displayedStaticFrame) {
-      const canvas = canvasRef.current;
-      const context = canvas?.getContext("2d");
-      if (canvas && context) {
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        context.drawImage(displayedStaticFrame.canvas, 0, 0, canvas.width, canvas.height);
-      }
+      drawCanvasFrame(displayedStaticFrame);
     }
-  }, [canvasRef, drawFrame, subtitleCues, subtitlesEnabled, subtitleStyleSettings]);
+  }, [drawCanvasFrame, drawFrame, subtitleCues, subtitlesEnabled, subtitleStyleSettings]);
 
   const disposePreview = useCallback(() => {
     resetPreview(true, true);

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -10,13 +10,20 @@ type RefValue<T> = {
   current: T;
 };
 
+interface StaticVideoFrame {
+  canvas: HTMLCanvasElement;
+  timestamp: number;
+}
+
 interface UseEditorPlaybackRenderLoopOptions {
   canvasRef: RefValue<HTMLCanvasElement | null>;
   inputRef: RefValue<Input | null>;
   videoSinkRef: RefValue<CanvasSink | null>;
+  staticVideoFrameRef: RefValue<HTMLCanvasElement | null>;
   videoFrameIteratorRef: RefValue<AsyncGenerator<WrappedCanvas, void, unknown> | null>;
   nextFrameRef: RefValue<WrappedCanvas | null>;
   displayedFrameRef: RefValue<WrappedCanvas | null>;
+  displayedStaticFrameRef: RefValue<StaticVideoFrame | null>;
   animationFrameRef: RefValue<number | null>;
   renderIntervalRef: RefValue<number | null>;
   generationRef: RefValue<number>;
@@ -41,9 +48,11 @@ export function useEditorPlaybackRenderLoop({
   canvasRef,
   inputRef,
   videoSinkRef,
+  staticVideoFrameRef,
   videoFrameIteratorRef,
   nextFrameRef,
   displayedFrameRef,
+  displayedStaticFrameRef,
   animationFrameRef,
   renderIntervalRef,
   generationRef,
@@ -63,7 +72,7 @@ export function useEditorPlaybackRenderLoop({
   setCurrentTime,
   setError,
 }: UseEditorPlaybackRenderLoopOptions) {
-  const drawFrame = useCallback((frame: WrappedCanvas) => {
+  const drawCanvasFrame = useCallback((frame: Pick<WrappedCanvas, "canvas" | "timestamp">) => {
     const canvas = canvasRef.current;
     const context = canvas?.getContext("2d");
     if (!canvas || !context) {
@@ -87,15 +96,45 @@ export function useEditorPlaybackRenderLoop({
         );
       }
     }
-
-    displayedFrameRef.current = frame;
   }, [
     canvasRef,
-    displayedFrameRef,
     sourceTimelineOffsetRef,
     subtitleCuesRef,
     subtitleStyleSettingsRef,
     subtitlesEnabledRef,
+  ]);
+
+  const drawFrame = useCallback((frame: WrappedCanvas) => {
+    drawCanvasFrame(frame);
+    displayedFrameRef.current = frame;
+    displayedStaticFrameRef.current = null;
+  }, [
+    displayedFrameRef,
+    displayedStaticFrameRef,
+    drawCanvasFrame,
+  ]);
+
+  const drawStaticFrame = useCallback(() => {
+    const staticFrameCanvas = staticVideoFrameRef.current;
+    if (!staticFrameCanvas) {
+      return false;
+    }
+
+    const frame = {
+      canvas: staticFrameCanvas,
+      timestamp: toSourceTimelineTime(getPlaybackTime(), sourceTimelineOffsetRef.current),
+    };
+    drawCanvasFrame(frame);
+    displayedFrameRef.current = null;
+    displayedStaticFrameRef.current = frame;
+    return true;
+  }, [
+    displayedFrameRef,
+    displayedStaticFrameRef,
+    drawCanvasFrame,
+    getPlaybackTime,
+    sourceTimelineOffsetRef,
+    staticVideoFrameRef,
   ]);
 
   const drawPlaceholder = useCallback((message: string) => {
@@ -115,7 +154,9 @@ export function useEditorPlaybackRenderLoop({
     context.font = "24px sans-serif";
     context.textAlign = "center";
     context.fillText(message, canvas.width / 2, canvas.height / 2);
-  }, [canvasRef]);
+    displayedFrameRef.current = null;
+    displayedStaticFrameRef.current = null;
+  }, [canvasRef, displayedFrameRef, displayedStaticFrameRef]);
 
   const startVideoIterator = useCallback(async () => {
     const videoSink = videoSinkRef.current;
@@ -125,7 +166,9 @@ export function useEditorPlaybackRenderLoop({
     nextFrameRef.current = null;
 
     if (!videoSink) {
-      drawPlaceholder("Audio only");
+      if (!drawStaticFrame()) {
+        drawPlaceholder("Audio only");
+      }
       return;
     }
 
@@ -150,6 +193,7 @@ export function useEditorPlaybackRenderLoop({
     }
   }, [
     drawFrame,
+    drawStaticFrame,
     drawPlaceholder,
     generationRef,
     getPlaybackTime,

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -313,6 +313,7 @@ export function useEditorPlaybackRenderLoop({
   }, [animationFrameRef, renderFrame, renderIntervalRef, stopRenderLoop]);
 
   return {
+    drawCanvasFrame,
     drawFrame,
     drawPlaceholder,
     startVideoIterator,

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -48,6 +48,8 @@ import {
 } from "./shared.js";
 
 const logger = getServerLogger(["providers", "jellyfin"]);
+const HD_ARTWORK_SIZE = 1920;
+const HD_ARTWORK_QUALITY = 96;
 
 function createMediaHandle(
   session: ProviderSessionRecord,
@@ -98,8 +100,17 @@ function buildSourceTitle(item: JellyfinItem) {
 function itemImagePath(item: JellyfinItem) {
   const itemId = stringValue(item?.Id);
   const imageTags = item?.ImageTags ?? {};
+  const type = itemType(item).toLowerCase();
 
-  if (itemType(item) === "Episode") {
+  if (type === "audio") {
+    const albumId = stringValue(item?.AlbumId);
+    const albumTag = stringValue(item?.AlbumPrimaryImageTag);
+    if (albumId && albumTag) {
+      return `/Items/${encodeURIComponent(albumId)}/Images/Primary?tag=${encodeURIComponent(albumTag)}`;
+    }
+  }
+
+  if (type === "episode") {
     const parentThumbItemId = stringValue(item?.ParentThumbItemId);
     const parentThumbTag = stringValue(item?.ParentThumbImageTag);
     if (parentThumbItemId && parentThumbTag) {
@@ -124,6 +135,20 @@ function itemImagePath(item: JellyfinItem) {
   }
 
   return undefined;
+}
+
+function withHdImageOptions(path: string) {
+  const url = new URL(path, "http://cliparr.local");
+  url.searchParams.set("maxWidth", String(HD_ARTWORK_SIZE));
+  url.searchParams.set("maxHeight", String(HD_ARTWORK_SIZE));
+  url.searchParams.set("quality", String(HD_ARTWORK_QUALITY));
+
+  return `${url.pathname}${url.search}`;
+}
+
+function itemHdImagePath(item: JellyfinItem) {
+  const imagePath = itemImagePath(item);
+  return imagePath ? withHdImageOptions(imagePath) : undefined;
 }
 
 function playbackMediaSources(
@@ -451,7 +476,7 @@ function createExportMetadata(
   context: JellyfinSourceContext,
   item: JellyfinItem
 ): MediaExportMetadata {
-  const imagePath = itemImagePath(item);
+  const imagePath = itemHdImagePath(item) ?? itemImagePath(item);
 
   return {
     providerId: "jellyfin",

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -89,6 +89,8 @@ export interface JellyfinItem {
   ParentThumbImageTag?: string | null;
   SeriesId?: string | null;
   SeriesPrimaryImageTag?: string | null;
+  AlbumId?: string | null;
+  AlbumPrimaryImageTag?: string | null;
   ImageTags?: JellyfinImageTags | null;
   MediaSources?: JellyfinMediaSource[] | null;
   Taglines?: string[] | null;

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -191,6 +191,10 @@ export function createPreviewPath(
   playbackSessionId: string,
   selection?: PlexMediaSelection
 ) {
+  if (String(item?.type ?? "").toLowerCase() === "track") {
+    return undefined;
+  }
+
   const path = metadataPath(item);
   if (!path) {
     return undefined;
@@ -386,14 +390,19 @@ function metadataImagePath(item: any) {
   return stringValue(item?.thumb) ?? stringValue(item?.grandparentThumb) ?? stringValue(item?.parentThumb);
 }
 
-function metadataHdImagePath(item: any) {
+function appendPlexTokenToImagePath(path: string, token: string) {
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}X-Plex-Token=${encodeURIComponent(token)}`;
+}
+
+function metadataHdImagePath(item: any, context: PlexSourceContext) {
   const imagePath = metadataImagePath(item);
   if (!imagePath) {
     return undefined;
   }
 
   const params = new URLSearchParams({
-    url: imagePath,
+    url: appendPlexTokenToImagePath(imagePath, context.token),
     width: String(HD_ARTWORK_SIZE),
     height: String(HD_ARTWORK_SIZE),
     quality: "-1",
@@ -682,7 +691,7 @@ function createExportMetadata(
   context: PlexSourceContext,
   item: any
 ): MediaExportMetadata {
-  const imagePath = metadataHdImagePath(item) ?? metadataImagePath(item);
+  const imagePath = metadataHdImagePath(item, context) ?? metadataImagePath(item);
   const guid = stringValue(item?.guid);
 
   return {

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -54,6 +54,7 @@ import {
 } from "./connectionState.js";
 
 const logger = getServerLogger(["providers", "plex"]);
+const HD_ARTWORK_SIZE = 1920;
 
 function createMediaHandle(
   session: ProviderSessionRecord,
@@ -378,7 +379,28 @@ function metadataImagePath(item: any) {
     return stringValue(item.grandparentThumb) ?? stringValue(item.parentThumb) ?? stringValue(item.thumb);
   }
 
+  if (item?.type === "track") {
+    return stringValue(item?.thumb) ?? stringValue(item?.parentThumb) ?? stringValue(item?.grandparentThumb);
+  }
+
   return stringValue(item?.thumb) ?? stringValue(item?.grandparentThumb) ?? stringValue(item?.parentThumb);
+}
+
+function metadataHdImagePath(item: any) {
+  const imagePath = metadataImagePath(item);
+  if (!imagePath) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams({
+    url: imagePath,
+    width: String(HD_ARTWORK_SIZE),
+    height: String(HD_ARTWORK_SIZE),
+    quality: "-1",
+    upscale: "0",
+  });
+
+  return `/photo/:/transcode?${params.toString()}`;
 }
 
 function buildSourceTitle(item: any) {
@@ -660,7 +682,7 @@ function createExportMetadata(
   context: PlexSourceContext,
   item: any
 ): MediaExportMetadata {
-  const imagePath = metadataImagePath(item);
+  const imagePath = metadataHdImagePath(item) ?? metadataImagePath(item);
   const guid = stringValue(item?.guid);
 
   return {

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -54,6 +54,15 @@ void test("uses a stable Plex transcode session id for repeated playback polls",
   assert.match(firstPath ?? "", /subtitles=none/);
 });
 
+void test("does not create Plex HLS preview paths for audio tracks", () => {
+  const item = {
+    type: "track",
+    ratingKey: "12345",
+  };
+
+  assert.equal(createPreviewPath(item, "plex-session-1"), undefined);
+});
+
 void test("creates a direct content URL for Plex sidecar text subtitle streams", () => {
   const session = createSession();
   const context = createContext();


### PR DESCRIPTION
## Summary
- Use HD provider artwork URLs for editor media metadata.
- Render album art as the preview canvas for audio-only media from Plex or Jellyfin.
- Keep source video dimensions separate from static artwork dimensions.

## Validation
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/frontend lint:eslint
- pnpm --filter @cliparr/frontend build