### PR TITLE
[codex] Stabilize preview timecode layout

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Eye } from "lucide-react";
-import { MIN_CLIP_SECONDS, roundTimelineTime } from "./editor/EditorUtils";
+import {
+  clampClipEndTime,
+  clampClipStartTime,
+  clampPlaybackTime,
+  MIN_CLIP_SECONDS,
+  roundTimelineTime,
+} from "./editor/EditorUtils";
 import { useEditorPlayback, type PlaybackFallbackInfo } from "./editor/useEditorPlayback";
 import { useEditorExport } from "./editor/useEditorExport";
 import { useEditorKeyboardShortcuts } from "./editor/useEditorKeyboardShortcuts";
@@ -202,6 +208,25 @@ export default function EditorScreen({ session, onBack }: Props) {
       nextEnd - nextStart >= minClipLength
     );
   }, [duration]);
+  const handlePreviewTimeCommit = useCallback((nextTime: number) => {
+    if (!duration || duration <= 0) return;
+
+    void seekToTime(clampPlaybackTime(nextTime, duration));
+  }, [duration, seekToTime]);
+  const handleStartTimeCommit = useCallback((nextStart: number) => {
+    if (!duration || duration <= 0) return;
+
+    const nextClampedStart = clampClipStartTime(nextStart, endTime, duration);
+    updateClipRange(nextClampedStart, endTime);
+    void warmClipSelection(nextClampedStart, endTime);
+  }, [duration, endTime, updateClipRange, warmClipSelection]);
+  const handleEndTimeCommit = useCallback((nextEnd: number) => {
+    if (!duration || duration <= 0) return;
+
+    const nextClampedEnd = clampClipEndTime(nextEnd, startTime, duration);
+    updateClipRange(startTime, nextClampedEnd);
+    void warmClipSelection(startTime, nextClampedEnd);
+  }, [duration, startTime, updateClipRange, warmClipSelection]);
 
   const {
     timelineRef,
@@ -349,6 +374,9 @@ export default function EditorScreen({ session, onBack }: Props) {
                 handleTimelineZoomOut={handleTimelineZoomOut}
                 canZoomIn={canZoomIn}
                 canZoomOut={canZoomOut}
+                onPreviewTimeCommit={handlePreviewTimeCommit}
+                onStartTimeCommit={handleStartTimeCommit}
+                onEndTimeCommit={handleEndTimeCommit}
               />
 
               {!hasDuration && (

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -48,12 +48,6 @@ export function EditorControls({
   const hasDuration = duration > 0;
   const canEditPreviewTime = !loadingPreview && hasDuration;
   const canEditClipRange = !loadingPreview && !playing && hasDuration;
-  const previewInputWidth = useMemo(() => {
-    const currentValueLength = formatTimecodeInput(currentTime).length;
-    const durationValueLength = formatTimecodeInput(duration).length;
-
-    return `${Math.max(currentValueLength, durationValueLength, "0:00.00".length) + 1}ch`;
-  }, [currentTime, duration]);
   const clipMetrics = useMemo(() => {
     const clipDuration = Math.max(0, endTime - startTime);
 
@@ -80,7 +74,6 @@ export function EditorControls({
             ariaLabel="preview time"
             buttonClassName="text-foreground"
             disabled={!canEditPreviewTime}
-            inputWidth={previewInputWidth}
             onCommit={onPreviewTimeCommit}
             value={currentTime}
             valueLabel={`${formatTimecodeInput(currentTime)} of ${formatTimecodeInput(duration)}`}
@@ -147,7 +140,6 @@ export function EditorControls({
                   ariaLabel={`${metric.label} time`}
                   buttonClassName="font-mono text-sm font-semibold text-muted-foreground hover:text-foreground"
                   disabled={!canEditClipRange}
-                  inputWidth={`${Math.max(formatTimecodeInput(metric.value).length, "0:00.00".length) + 1}ch`}
                   onCommit={metric.onCommit}
                   value={metric.value}
                 >

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
+import { EditorPreviewTimecode } from "./EditorPreviewTimecode";
 import { formatTime } from "./EditorUtils";
 
 interface EditorControlsProps {
@@ -37,12 +38,6 @@ export function EditorControls({
   canZoomIn,
   canZoomOut,
 }: EditorControlsProps) {
-  const currentTimeCode = formatTime(currentTime);
-  const durationTimeCode = useMemo(() => formatTime(duration), [duration]);
-  const previewTimeCodeWidth = useMemo(() => {
-    const wholeDurationWidth = durationTimeCode.split(".")[0].length;
-    return `${Math.max("0:00.00".length, wholeDurationWidth + ".00".length)}ch`;
-  }, [durationTimeCode]);
   const clipMetrics = useMemo(() => {
     const clipDuration = Math.max(0, endTime - startTime);
 
@@ -65,18 +60,7 @@ export function EditorControls({
           >
             {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
           </button>
-          <div className="flex shrink-0 items-center whitespace-nowrap font-mono text-sm font-semibold tabular-nums text-foreground">
-            <span className="inline-block text-right" style={{ width: previewTimeCodeWidth }}>
-              {currentTimeCode}
-            </span>
-            <span className="sr-only"> of </span>
-            <span className="px-1.5 text-muted-foreground" aria-hidden="true">
-              /
-            </span>
-            <span className="inline-block text-left" style={{ width: previewTimeCodeWidth }}>
-              {durationTimeCode}
-            </span>
-          </div>
+          <EditorPreviewTimecode currentTime={currentTime} duration={duration} />
         </div>
         <div className="h-5 w-px bg-border" />
         <div className="flex items-center gap-2">

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
+import { EditorEditableTimecode } from "./EditorEditableTimecode";
 import { EditorPreviewTimecode } from "./EditorPreviewTimecode";
-import { formatTime } from "./EditorUtils";
+import { formatTime, formatTimecodeInput } from "./EditorUtils";
 
 interface EditorControlsProps {
   playing: boolean;
@@ -19,6 +20,9 @@ interface EditorControlsProps {
   handleTimelineZoomOut: () => void;
   canZoomIn: boolean;
   canZoomOut: boolean;
+  onPreviewTimeCommit: (time: number) => void | Promise<void>;
+  onStartTimeCommit: (time: number) => void | Promise<void>;
+  onEndTimeCommit: (time: number) => void | Promise<void>;
 }
 
 export function EditorControls({
@@ -37,16 +41,28 @@ export function EditorControls({
   handleTimelineZoomOut,
   canZoomIn,
   canZoomOut,
+  onPreviewTimeCommit,
+  onStartTimeCommit,
+  onEndTimeCommit,
 }: EditorControlsProps) {
+  const hasDuration = duration > 0;
+  const canEditPreviewTime = !loadingPreview && hasDuration;
+  const canEditClipRange = !loadingPreview && !playing && hasDuration;
+  const previewInputWidth = useMemo(() => {
+    const currentValueLength = formatTimecodeInput(currentTime).length;
+    const durationValueLength = formatTimecodeInput(duration).length;
+
+    return `${Math.max(currentValueLength, durationValueLength, "0:00.00".length) + 1}ch`;
+  }, [currentTime, duration]);
   const clipMetrics = useMemo(() => {
     const clipDuration = Math.max(0, endTime - startTime);
 
     return [
-      { label: "In", value: formatTime(startTime) },
-      { label: "Out", value: formatTime(endTime) },
-      { label: "Duration", value: formatTime(clipDuration), emphasized: true },
+      { label: "In", value: startTime, onCommit: onStartTimeCommit },
+      { label: "Out", value: endTime, onCommit: onEndTimeCommit },
+      { label: "Duration", value: clipDuration, emphasized: true },
     ];
-  }, [endTime, startTime]);
+  }, [endTime, onEndTimeCommit, onStartTimeCommit, startTime]);
 
   return (
     <div className="border-b border-border px-3 py-2">
@@ -60,7 +76,17 @@ export function EditorControls({
           >
             {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
           </button>
-          <EditorPreviewTimecode currentTime={currentTime} duration={duration} />
+          <EditorEditableTimecode
+            ariaLabel="preview time"
+            buttonClassName="text-foreground"
+            disabled={!canEditPreviewTime}
+            inputWidth={previewInputWidth}
+            onCommit={onPreviewTimeCommit}
+            value={currentTime}
+            valueLabel={`${formatTimecodeInput(currentTime)} of ${formatTimecodeInput(duration)}`}
+          >
+            <EditorPreviewTimecode ariaHidden currentTime={currentTime} duration={duration} />
+          </EditorEditableTimecode>
         </div>
         <div className="h-5 w-px bg-border" />
         <div className="flex items-center gap-2">
@@ -116,13 +142,26 @@ export function EditorControls({
               <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
                 {metric.label}
               </span>
-              <span
-                className={`font-mono text-sm font-semibold ${
-                  metric.emphasized ? "text-foreground" : "text-muted-foreground"
-                }`}
-              >
-                {metric.value}
-              </span>
+              {metric.onCommit ? (
+                <EditorEditableTimecode
+                  ariaLabel={`${metric.label} time`}
+                  buttonClassName="font-mono text-sm font-semibold text-muted-foreground hover:text-foreground"
+                  disabled={!canEditClipRange}
+                  inputWidth={`${Math.max(formatTimecodeInput(metric.value).length, "0:00.00".length) + 1}ch`}
+                  onCommit={metric.onCommit}
+                  value={metric.value}
+                >
+                  <span>{formatTime(metric.value)}</span>
+                </EditorEditableTimecode>
+              ) : (
+                <span
+                  className={`font-mono text-sm font-semibold ${
+                    metric.emphasized ? "text-foreground" : "text-muted-foreground"
+                  }`}
+                >
+                  {formatTime(metric.value)}
+                </span>
+              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
 import { formatTime } from "./EditorUtils";
 
@@ -36,12 +37,21 @@ export function EditorControls({
   canZoomIn,
   canZoomOut,
 }: EditorControlsProps) {
-  const clipDuration = Math.max(0, endTime - startTime);
-  const clipMetrics = [
-    { label: "In", value: formatTime(startTime) },
-    { label: "Out", value: formatTime(endTime) },
-    { label: "Duration", value: formatTime(clipDuration), emphasized: true },
-  ];
+  const currentTimeCode = formatTime(currentTime);
+  const durationTimeCode = useMemo(() => formatTime(duration), [duration]);
+  const previewTimeCodeWidth = useMemo(() => {
+    const wholeDurationWidth = durationTimeCode.split(".")[0].length;
+    return `${Math.max("0:00.00".length, wholeDurationWidth + ".00".length)}ch`;
+  }, [durationTimeCode]);
+  const clipMetrics = useMemo(() => {
+    const clipDuration = Math.max(0, endTime - startTime);
+
+    return [
+      { label: "In", value: formatTime(startTime) },
+      { label: "Out", value: formatTime(endTime) },
+      { label: "Duration", value: formatTime(clipDuration), emphasized: true },
+    ];
+  }, [endTime, startTime]);
 
   return (
     <div className="border-b border-border px-3 py-2">
@@ -55,8 +65,17 @@ export function EditorControls({
           >
             {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
           </button>
-          <div className="font-mono text-sm font-semibold text-foreground">
-            {formatTime(currentTime)} / {formatTime(duration)}
+          <div className="flex shrink-0 items-center whitespace-nowrap font-mono text-sm font-semibold tabular-nums text-foreground">
+            <span className="inline-block text-right" style={{ width: previewTimeCodeWidth }}>
+              {currentTimeCode}
+            </span>
+            <span className="sr-only"> of </span>
+            <span className="px-1.5 text-muted-foreground" aria-hidden="true">
+              /
+            </span>
+            <span className="inline-block text-left" style={{ width: previewTimeCodeWidth }}>
+              {durationTimeCode}
+            </span>
           </div>
         </div>
         <div className="h-5 w-px bg-border" />

--- a/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
@@ -1,5 +1,7 @@
 import {
   useEffect,
+  useId,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent,
@@ -33,24 +35,35 @@ export function EditorEditableTimecode({
   value,
   valueLabel,
 }: EditorEditableTimecodeProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const restoreFocusAfterEditRef = useRef(false);
   const [editing, setEditing] = useState(false);
   const [draftValue, setDraftValue] = useState("");
   const [invalid, setInvalid] = useState(false);
   const formattedValue = formatTimecodeInput(value);
   const accessibleValue = valueLabel ?? formattedValue;
+  const descriptionId = useId();
+  const hintId = `${descriptionId}-hint`;
+  const errorId = `${descriptionId}-error`;
+  const describedBy = invalid ? `${hintId} ${errorId}` : hintId;
 
-  useEffect(() => {
-    if (!editing) {
+  useLayoutEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
       return;
     }
 
-    inputRef.current?.focus();
-    inputRef.current?.select();
+    if (restoreFocusAfterEditRef.current) {
+      restoreFocusAfterEditRef.current = false;
+      buttonRef.current?.focus();
+    }
   }, [editing]);
 
   useEffect(() => {
     if (disabled && editing) {
+      restoreFocusAfterEditRef.current = false;
       setInvalid(false);
       setEditing(false);
     }
@@ -66,23 +79,31 @@ export function EditorEditableTimecode({
     setEditing(true);
   }
 
-  function cancelEditing() {
+  function cancelEditing({ restoreFocus }: { restoreFocus: boolean }) {
+    restoreFocusAfterEditRef.current = restoreFocus;
     setInvalid(false);
     setEditing(false);
   }
 
-  function commitParsedValue(nextValue: number) {
+  function commitParsedValue(nextValue: number, { restoreFocus }: { restoreFocus: boolean }) {
+    restoreFocusAfterEditRef.current = restoreFocus;
     setInvalid(false);
     setEditing(false);
     void onCommit(nextValue);
   }
 
-  function commitDraft({ cancelOnInvalid }: { cancelOnInvalid: boolean }) {
+  function commitDraft({
+    cancelOnInvalid,
+    restoreFocus,
+  }: {
+    cancelOnInvalid: boolean;
+    restoreFocus: boolean;
+  }) {
     const parsedValue = parseTimecodeInput(draftValue);
 
     if (parsedValue === null) {
       if (cancelOnInvalid) {
-        cancelEditing();
+        cancelEditing({ restoreFocus });
         return;
       }
 
@@ -90,49 +111,64 @@ export function EditorEditableTimecode({
       return;
     }
 
-    commitParsedValue(parsedValue);
+    commitParsedValue(parsedValue, { restoreFocus });
   }
 
   function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Enter") {
       event.preventDefault();
-      commitDraft({ cancelOnInvalid: false });
+      commitDraft({ cancelOnInvalid: false, restoreFocus: true });
       return;
     }
 
     if (event.key === "Escape") {
       event.preventDefault();
-      cancelEditing();
+      cancelEditing({ restoreFocus: true });
     }
   }
 
   if (editing) {
     return (
-      <input
-        ref={inputRef}
-        aria-invalid={invalid || undefined}
-        aria-label={ariaLabel}
-        className={`h-7 border bg-background px-1.5 font-mono text-sm font-semibold text-foreground outline-none transition-colors focus:ring-2 ${
-          invalid
-            ? "border-destructive focus:border-destructive focus:ring-destructive/20"
-            : "border-input focus:border-ring focus:ring-ring/40"
-        } ${inputClassName}`}
-        inputMode="text"
-        onBlur={() => commitDraft({ cancelOnInvalid: true })}
-        onChange={(event) => {
-          setDraftValue(event.target.value);
-          setInvalid(false);
-        }}
-        onKeyDown={handleInputKeyDown}
-        style={inputWidth ? { width: inputWidth } : undefined}
-        type="text"
-        value={draftValue}
-      />
+      <>
+        <input
+          ref={inputRef}
+          aria-describedby={describedBy}
+          aria-errormessage={invalid ? errorId : undefined}
+          aria-invalid={invalid || undefined}
+          aria-label={`Edit ${ariaLabel}`}
+          autoComplete="off"
+          className={`h-7 border bg-background px-1.5 font-mono text-sm font-semibold text-foreground outline-none transition-colors focus:ring-2 ${
+            invalid
+              ? "border-destructive focus:border-destructive focus:ring-destructive/20"
+              : "border-input focus:border-ring focus:ring-ring/40"
+          } ${inputClassName}`}
+          inputMode="text"
+          onBlur={() => commitDraft({ cancelOnInvalid: true, restoreFocus: false })}
+          onChange={(event) => {
+            setDraftValue(event.target.value);
+            setInvalid(false);
+          }}
+          onKeyDown={handleInputKeyDown}
+          spellCheck={false}
+          style={inputWidth ? { width: inputWidth } : undefined}
+          type="text"
+          value={draftValue}
+        />
+        <span id={hintId} className="sr-only">
+          Enter seconds, minutes and seconds, or hours minutes and seconds. Press Enter to apply or Escape to cancel.
+        </span>
+        {invalid && (
+          <span id={errorId} className="sr-only" role="alert">
+            Invalid timecode. Use seconds, m:ss, or h:mm:ss.
+          </span>
+        )}
+      </>
     );
   }
 
   return (
     <button
+      ref={buttonRef}
       aria-label={disabled ? `${ariaLabel}: ${accessibleValue}` : `Edit ${ariaLabel}: ${accessibleValue}`}
       className={`inline-flex min-w-0 items-center border-0 bg-transparent p-0 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/45 disabled:cursor-default disabled:opacity-100 ${buttonClassName}`}
       disabled={disabled}

--- a/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
@@ -41,6 +41,7 @@ export function EditorEditableTimecode({
   const [editing, setEditing] = useState(false);
   const [draftValue, setDraftValue] = useState("");
   const [invalid, setInvalid] = useState(false);
+  const [measuredInputWidth, setMeasuredInputWidth] = useState<string | undefined>(undefined);
   const formattedValue = formatTimecodeInput(value);
   const accessibleValue = valueLabel ?? formattedValue;
   const descriptionId = useId();
@@ -74,6 +75,8 @@ export function EditorEditableTimecode({
       return;
     }
 
+    const buttonWidth = buttonRef.current?.getBoundingClientRect().width ?? 0;
+    setMeasuredInputWidth(buttonWidth > 0 ? `${Math.ceil(buttonWidth)}px` : undefined);
     setDraftValue(formattedValue);
     setInvalid(false);
     setEditing(true);
@@ -150,7 +153,10 @@ export function EditorEditableTimecode({
           }}
           onKeyDown={handleInputKeyDown}
           spellCheck={false}
-          style={inputWidth ? { width: inputWidth } : undefined}
+          style={{
+            minWidth: measuredInputWidth,
+            width: inputWidth ?? measuredInputWidth,
+          }}
           type="text"
           value={draftValue}
         />

--- a/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
@@ -41,7 +41,7 @@ export function EditorEditableTimecode({
   const [editing, setEditing] = useState(false);
   const [draftValue, setDraftValue] = useState("");
   const [invalid, setInvalid] = useState(false);
-  const [measuredInputWidth, setMeasuredInputWidth] = useState<string | undefined>(undefined);
+  const [reservedWidth, setReservedWidth] = useState<string | undefined>(undefined);
   const formattedValue = formatTimecodeInput(value);
   const accessibleValue = valueLabel ?? formattedValue;
   const descriptionId = useId();
@@ -76,7 +76,7 @@ export function EditorEditableTimecode({
     }
 
     const buttonWidth = buttonRef.current?.getBoundingClientRect().width ?? 0;
-    setMeasuredInputWidth(buttonWidth > 0 ? `${Math.ceil(buttonWidth)}px` : undefined);
+    setReservedWidth(buttonWidth > 0 ? `${buttonWidth.toFixed(3)}px` : undefined);
     setDraftValue(formattedValue);
     setInvalid(false);
     setEditing(true);
@@ -130,9 +130,9 @@ export function EditorEditableTimecode({
     }
   }
 
-  if (editing) {
-    return (
-      <>
+  return (
+    <span className="inline-flex min-w-0" style={{ width: editing ? reservedWidth : undefined }}>
+      {editing ? (
         <input
           ref={inputRef}
           aria-describedby={describedBy}
@@ -153,35 +153,34 @@ export function EditorEditableTimecode({
           }}
           onKeyDown={handleInputKeyDown}
           spellCheck={false}
-          style={{
-            minWidth: measuredInputWidth,
-            width: inputWidth ?? measuredInputWidth,
-          }}
+          style={{ width: inputWidth ?? "100%" }}
           type="text"
           value={draftValue}
         />
-        <span id={hintId} className="sr-only">
-          Enter seconds, minutes and seconds, or hours minutes and seconds. Press Enter to apply or Escape to cancel.
-        </span>
-        {invalid && (
-          <span id={errorId} className="sr-only" role="alert">
-            Invalid timecode. Use seconds, m:ss, or h:mm:ss.
+      ) : (
+        <button
+          ref={buttonRef}
+          aria-label={disabled ? `${ariaLabel}: ${accessibleValue}` : `Edit ${ariaLabel}: ${accessibleValue}`}
+          className={`inline-flex min-w-0 items-center border-0 bg-transparent p-0 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/45 disabled:cursor-default disabled:opacity-100 ${buttonClassName}`}
+          disabled={disabled}
+          onClick={startEditing}
+          type="button"
+        >
+          {children}
+        </button>
+      )}
+      {editing && (
+        <>
+          <span id={hintId} className="sr-only">
+            Enter seconds, minutes and seconds, or hours minutes and seconds. Press Enter to apply or Escape to cancel.
           </span>
-        )}
-      </>
-    );
-  }
-
-  return (
-    <button
-      ref={buttonRef}
-      aria-label={disabled ? `${ariaLabel}: ${accessibleValue}` : `Edit ${ariaLabel}: ${accessibleValue}`}
-      className={`inline-flex min-w-0 items-center border-0 bg-transparent p-0 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/45 disabled:cursor-default disabled:opacity-100 ${buttonClassName}`}
-      disabled={disabled}
-      onClick={startEditing}
-      type="button"
-    >
-      {children}
-    </button>
+          {invalid && (
+            <span id={errorId} className="sr-only" role="alert">
+              Invalid timecode. Use seconds, m:ss, or h:mm:ss.
+            </span>
+          )}
+        </>
+      )}
+    </span>
   );
 }

--- a/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
@@ -1,0 +1,145 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import {
+  formatTimecodeInput,
+  parseTimecodeInput,
+} from "./EditorUtils";
+
+interface EditorEditableTimecodeProps {
+  ariaLabel: string;
+  buttonClassName?: string;
+  children: ReactNode;
+  disabled?: boolean;
+  inputClassName?: string;
+  inputWidth?: string;
+  onCommit: (seconds: number) => void | Promise<void>;
+  value: number;
+  valueLabel?: string;
+}
+
+export function EditorEditableTimecode({
+  ariaLabel,
+  buttonClassName = "",
+  children,
+  disabled = false,
+  inputClassName = "",
+  inputWidth,
+  onCommit,
+  value,
+  valueLabel,
+}: EditorEditableTimecodeProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [editing, setEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState("");
+  const [invalid, setInvalid] = useState(false);
+  const formattedValue = formatTimecodeInput(value);
+  const accessibleValue = valueLabel ?? formattedValue;
+
+  useEffect(() => {
+    if (!editing) {
+      return;
+    }
+
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [editing]);
+
+  useEffect(() => {
+    if (disabled && editing) {
+      setInvalid(false);
+      setEditing(false);
+    }
+  }, [disabled, editing]);
+
+  function startEditing() {
+    if (disabled) {
+      return;
+    }
+
+    setDraftValue(formattedValue);
+    setInvalid(false);
+    setEditing(true);
+  }
+
+  function cancelEditing() {
+    setInvalid(false);
+    setEditing(false);
+  }
+
+  function commitParsedValue(nextValue: number) {
+    setInvalid(false);
+    setEditing(false);
+    void onCommit(nextValue);
+  }
+
+  function commitDraft({ cancelOnInvalid }: { cancelOnInvalid: boolean }) {
+    const parsedValue = parseTimecodeInput(draftValue);
+
+    if (parsedValue === null) {
+      if (cancelOnInvalid) {
+        cancelEditing();
+        return;
+      }
+
+      setInvalid(true);
+      return;
+    }
+
+    commitParsedValue(parsedValue);
+  }
+
+  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitDraft({ cancelOnInvalid: false });
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEditing();
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        aria-invalid={invalid || undefined}
+        aria-label={ariaLabel}
+        className={`h-7 border bg-background px-1.5 font-mono text-sm font-semibold text-foreground outline-none transition-colors focus:ring-2 ${
+          invalid
+            ? "border-destructive focus:border-destructive focus:ring-destructive/20"
+            : "border-input focus:border-ring focus:ring-ring/40"
+        } ${inputClassName}`}
+        inputMode="text"
+        onBlur={() => commitDraft({ cancelOnInvalid: true })}
+        onChange={(event) => {
+          setDraftValue(event.target.value);
+          setInvalid(false);
+        }}
+        onKeyDown={handleInputKeyDown}
+        style={inputWidth ? { width: inputWidth } : undefined}
+        type="text"
+        value={draftValue}
+      />
+    );
+  }
+
+  return (
+    <button
+      aria-label={disabled ? `${ariaLabel}: ${accessibleValue}` : `Edit ${ariaLabel}: ${accessibleValue}`}
+      className={`inline-flex min-w-0 items-center border-0 bg-transparent p-0 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/45 disabled:cursor-default disabled:opacity-100 ${buttonClassName}`}
+      disabled={disabled}
+      onClick={startEditing}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
@@ -1,21 +1,21 @@
-import { memo, useMemo } from "react";
+import {
+  memo,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type RefObject,
+} from "react";
 
 interface EditorPreviewTimecodeProps {
   currentTime: number;
   duration: number;
 }
 
-interface SegmentedTimecodeProps {
-  parts: PreviewTimecodeParts;
+interface TimecodeShellProps {
   hoursWidth: string;
   minutesWidth: string;
   showHours: boolean;
-}
-
-interface TimecodeSlotProps {
-  className?: string;
-  value: string;
-  width: string;
+  slotRefs: TimecodeSlotRefs;
 }
 
 interface PreviewTimecodeParts {
@@ -26,9 +26,15 @@ interface PreviewTimecodeParts {
   seconds: string;
 }
 
+type TimecodeSlotRefs = Record<
+  "fraction" | "hours" | "minutes" | "seconds",
+  RefObject<HTMLSpanElement | null>
+>;
+
 const CENTISECONDS_PER_SECOND = 100;
 const CENTISECONDS_PER_MINUTE = 60 * CENTISECONDS_PER_SECOND;
 const CENTISECONDS_PER_HOUR = 60 * CENTISECONDS_PER_MINUTE;
+const FIXED_DIGIT_WIDTH = "2ch";
 
 function getPreviewCentiseconds(seconds: number) {
   if (!Number.isFinite(seconds)) {
@@ -63,37 +69,72 @@ function getPreviewTimecodeParts(centiseconds: number, showHours: boolean): Prev
   };
 }
 
-const TimecodeSlot = memo(function TimecodeSlot({
-  className = "",
-  value,
-  width,
-}: TimecodeSlotProps) {
-  return (
-    <span className={`inline-block ${className}`} style={{ width }}>
-      {value}
-    </span>
-  );
-});
+function setSlotText(ref: RefObject<HTMLSpanElement | null>, value: string) {
+  const slot = ref.current;
 
-const SegmentedTimecode = memo(function SegmentedTimecode({
-  parts,
+  if (slot && slot.textContent !== value) {
+    slot.textContent = value;
+  }
+}
+
+function updateTimecodeSlots(slotRefs: TimecodeSlotRefs, parts: PreviewTimecodeParts) {
+  setSlotText(slotRefs.hours, parts.hours);
+  setSlotText(slotRefs.minutes, parts.minutes);
+  setSlotText(slotRefs.seconds, parts.seconds);
+  setSlotText(slotRefs.fraction, parts.fraction);
+}
+
+function useTimecodeSlotRefs(): TimecodeSlotRefs {
+  const hours = useRef<HTMLSpanElement>(null);
+  const minutes = useRef<HTMLSpanElement>(null);
+  const seconds = useRef<HTMLSpanElement>(null);
+  const fraction = useRef<HTMLSpanElement>(null);
+
+  return useMemo(() => ({
+    fraction,
+    hours,
+    minutes,
+    seconds,
+  }), []);
+}
+
+function getHoursWidth(durationParts: PreviewTimecodeParts) {
+  return `${Math.max(1, durationParts.hours.length)}ch`;
+}
+
+function getMinutesWidth(durationParts: PreviewTimecodeParts, showHours: boolean) {
+  return `${Math.max(showHours ? 2 : 1, durationParts.minutes.length)}ch`;
+}
+
+function arePreviewTimecodePropsEqual(
+  previous: EditorPreviewTimecodeProps,
+  next: EditorPreviewTimecodeProps,
+) {
+  return (
+    getPreviewCentiseconds(previous.currentTime) === getPreviewCentiseconds(next.currentTime)
+    && getPreviewCentiseconds(previous.duration) === getPreviewCentiseconds(next.duration)
+  );
+}
+
+const TimecodeShell = memo(function TimecodeShell({
   hoursWidth,
   minutesWidth,
   showHours,
-}: SegmentedTimecodeProps) {
+  slotRefs,
+}: TimecodeShellProps) {
   return (
     <span className="inline-flex items-baseline">
       {showHours && (
         <>
-          <TimecodeSlot className="text-right" value={parts.hours} width={hoursWidth} />
+          <span ref={slotRefs.hours} className="inline-block text-right" style={{ width: hoursWidth }} />
           <span>:</span>
         </>
       )}
-      <TimecodeSlot className="text-right" value={parts.minutes} width={minutesWidth} />
+      <span ref={slotRefs.minutes} className="inline-block text-right" style={{ width: minutesWidth }} />
       <span>:</span>
-      <TimecodeSlot className="text-right" value={parts.seconds} width="2ch" />
+      <span ref={slotRefs.seconds} className="inline-block text-right" style={{ width: FIXED_DIGIT_WIDTH }} />
       <span>.</span>
-      <TimecodeSlot className="text-left" value={parts.fraction} width="2ch" />
+      <span ref={slotRefs.fraction} className="inline-block text-left" style={{ width: FIXED_DIGIT_WIDTH }} />
     </span>
   );
 });
@@ -102,44 +143,60 @@ export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
   currentTime,
   duration,
 }: EditorPreviewTimecodeProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const currentSlotRefs = useTimecodeSlotRefs();
+  const durationSlotRefs = useTimecodeSlotRefs();
   const currentCentiseconds = getPreviewCentiseconds(currentTime);
   const durationCentiseconds = getPreviewCentiseconds(duration);
   const showHours = durationCentiseconds >= CENTISECONDS_PER_HOUR;
-  const currentParts = useMemo(
-    () => getPreviewTimecodeParts(currentCentiseconds, showHours),
-    [currentCentiseconds, showHours],
-  );
   const durationParts = useMemo(
     () => getPreviewTimecodeParts(durationCentiseconds, showHours),
     [durationCentiseconds, showHours],
   );
-  const hoursWidth = useMemo(() => {
-    return `${Math.max(1, durationParts.hours.length)}ch`;
-  }, [durationParts.hours.length]);
-  const minutesWidth = useMemo(() => {
-    return `${Math.max(showHours ? 2 : 1, durationParts.minutes.length)}ch`;
-  }, [durationParts.minutes.length, showHours]);
+  const hoursWidth = useMemo(() => getHoursWidth(durationParts), [durationParts]);
+  const minutesWidth = useMemo(
+    () => getMinutesWidth(durationParts, showHours),
+    [durationParts, showHours],
+  );
+
+  useLayoutEffect(() => {
+    const currentParts = getPreviewTimecodeParts(currentCentiseconds, showHours);
+
+    updateTimecodeSlots(currentSlotRefs, currentParts);
+    updateTimecodeSlots(durationSlotRefs, durationParts);
+    containerRef.current?.setAttribute(
+      "aria-label",
+      `${currentParts.label} of ${durationParts.label}`,
+    );
+  }, [
+    currentCentiseconds,
+    currentSlotRefs,
+    durationParts,
+    durationSlotRefs,
+    showHours,
+  ]);
 
   return (
     <div
+      ref={containerRef}
       className="flex shrink-0 items-center whitespace-nowrap font-mono text-sm font-semibold tabular-nums text-foreground"
-      aria-label={`${currentParts.label} of ${durationParts.label}`}
+      style={{ contain: "layout style paint" }}
     >
       <span aria-hidden="true" className="inline-flex items-baseline">
-        <SegmentedTimecode
+        <TimecodeShell
           hoursWidth={hoursWidth}
           minutesWidth={minutesWidth}
-          parts={currentParts}
           showHours={showHours}
+          slotRefs={currentSlotRefs}
         />
         <span className="px-1.5 text-muted-foreground">/</span>
-        <SegmentedTimecode
+        <TimecodeShell
           hoursWidth={hoursWidth}
           minutesWidth={minutesWidth}
-          parts={durationParts}
           showHours={showHours}
+          slotRefs={durationSlotRefs}
         />
       </span>
     </div>
   );
-});
+}, arePreviewTimecodePropsEqual);

--- a/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 interface EditorPreviewTimecodeProps {
+  ariaHidden?: boolean;
   currentTime: number;
   duration: number;
 }
@@ -111,7 +112,8 @@ function arePreviewTimecodePropsEqual(
   next: EditorPreviewTimecodeProps,
 ) {
   return (
-    getPreviewCentiseconds(previous.currentTime) === getPreviewCentiseconds(next.currentTime)
+    previous.ariaHidden === next.ariaHidden
+    && getPreviewCentiseconds(previous.currentTime) === getPreviewCentiseconds(next.currentTime)
     && getPreviewCentiseconds(previous.duration) === getPreviewCentiseconds(next.duration)
   );
 }
@@ -140,10 +142,11 @@ const TimecodeShell = memo(function TimecodeShell({
 });
 
 export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
+  ariaHidden = false,
   currentTime,
   duration,
 }: EditorPreviewTimecodeProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLSpanElement>(null);
   const currentSlotRefs = useTimecodeSlotRefs();
   const durationSlotRefs = useTimecodeSlotRefs();
   const currentCentiseconds = getPreviewCentiseconds(currentTime);
@@ -164,11 +167,16 @@ export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
 
     updateTimecodeSlots(currentSlotRefs, currentParts);
     updateTimecodeSlots(durationSlotRefs, durationParts);
-    containerRef.current?.setAttribute(
-      "aria-label",
-      `${currentParts.label} of ${durationParts.label}`,
-    );
+    if (ariaHidden) {
+      containerRef.current?.removeAttribute("aria-label");
+    } else {
+      containerRef.current?.setAttribute(
+        "aria-label",
+        `${currentParts.label} of ${durationParts.label}`,
+      );
+    }
   }, [
+    ariaHidden,
     currentCentiseconds,
     currentSlotRefs,
     durationParts,
@@ -177,8 +185,9 @@ export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
   ]);
 
   return (
-    <div
+    <span
       ref={containerRef}
+      aria-hidden={ariaHidden || undefined}
       className="flex shrink-0 items-center whitespace-nowrap font-mono text-sm font-semibold tabular-nums text-foreground"
       style={{ contain: "layout style paint" }}
     >
@@ -197,6 +206,6 @@ export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
           slotRefs={durationSlotRefs}
         />
       </span>
-    </div>
+    </span>
   );
 }, arePreviewTimecodePropsEqual);

--- a/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorPreviewTimecode.tsx
@@ -1,0 +1,145 @@
+import { memo, useMemo } from "react";
+
+interface EditorPreviewTimecodeProps {
+  currentTime: number;
+  duration: number;
+}
+
+interface SegmentedTimecodeProps {
+  parts: PreviewTimecodeParts;
+  hoursWidth: string;
+  minutesWidth: string;
+  showHours: boolean;
+}
+
+interface TimecodeSlotProps {
+  className?: string;
+  value: string;
+  width: string;
+}
+
+interface PreviewTimecodeParts {
+  fraction: string;
+  hours: string;
+  label: string;
+  minutes: string;
+  seconds: string;
+}
+
+const CENTISECONDS_PER_SECOND = 100;
+const CENTISECONDS_PER_MINUTE = 60 * CENTISECONDS_PER_SECOND;
+const CENTISECONDS_PER_HOUR = 60 * CENTISECONDS_PER_MINUTE;
+
+function getPreviewCentiseconds(seconds: number) {
+  if (!Number.isFinite(seconds)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round(seconds * CENTISECONDS_PER_SECOND));
+}
+
+function getPreviewTimecodeParts(centiseconds: number, showHours: boolean): PreviewTimecodeParts {
+  const hours = Math.floor(centiseconds / CENTISECONDS_PER_HOUR);
+  const remainingAfterHours = centiseconds % CENTISECONDS_PER_HOUR;
+  const minutes = Math.floor(remainingAfterHours / CENTISECONDS_PER_MINUTE);
+  const totalMinutes = Math.floor(centiseconds / CENTISECONDS_PER_MINUTE);
+  const seconds = Math.floor((centiseconds % CENTISECONDS_PER_MINUTE) / CENTISECONDS_PER_SECOND);
+  const fraction = centiseconds % CENTISECONDS_PER_SECOND;
+
+  const hoursText = hours.toString();
+  const minutesText = showHours ? minutes.toString().padStart(2, "0") : totalMinutes.toString();
+  const secondsText = seconds.toString().padStart(2, "0");
+  const fractionText = fraction.toString().padStart(2, "0");
+  const label = showHours
+    ? `${hoursText}:${minutesText}:${secondsText}.${fractionText}`
+    : `${minutesText}:${secondsText}.${fractionText}`;
+
+  return {
+    fraction: fractionText,
+    hours: hoursText,
+    label,
+    minutes: minutesText,
+    seconds: secondsText,
+  };
+}
+
+const TimecodeSlot = memo(function TimecodeSlot({
+  className = "",
+  value,
+  width,
+}: TimecodeSlotProps) {
+  return (
+    <span className={`inline-block ${className}`} style={{ width }}>
+      {value}
+    </span>
+  );
+});
+
+const SegmentedTimecode = memo(function SegmentedTimecode({
+  parts,
+  hoursWidth,
+  minutesWidth,
+  showHours,
+}: SegmentedTimecodeProps) {
+  return (
+    <span className="inline-flex items-baseline">
+      {showHours && (
+        <>
+          <TimecodeSlot className="text-right" value={parts.hours} width={hoursWidth} />
+          <span>:</span>
+        </>
+      )}
+      <TimecodeSlot className="text-right" value={parts.minutes} width={minutesWidth} />
+      <span>:</span>
+      <TimecodeSlot className="text-right" value={parts.seconds} width="2ch" />
+      <span>.</span>
+      <TimecodeSlot className="text-left" value={parts.fraction} width="2ch" />
+    </span>
+  );
+});
+
+export const EditorPreviewTimecode = memo(function EditorPreviewTimecode({
+  currentTime,
+  duration,
+}: EditorPreviewTimecodeProps) {
+  const currentCentiseconds = getPreviewCentiseconds(currentTime);
+  const durationCentiseconds = getPreviewCentiseconds(duration);
+  const showHours = durationCentiseconds >= CENTISECONDS_PER_HOUR;
+  const currentParts = useMemo(
+    () => getPreviewTimecodeParts(currentCentiseconds, showHours),
+    [currentCentiseconds, showHours],
+  );
+  const durationParts = useMemo(
+    () => getPreviewTimecodeParts(durationCentiseconds, showHours),
+    [durationCentiseconds, showHours],
+  );
+  const hoursWidth = useMemo(() => {
+    return `${Math.max(1, durationParts.hours.length)}ch`;
+  }, [durationParts.hours.length]);
+  const minutesWidth = useMemo(() => {
+    return `${Math.max(showHours ? 2 : 1, durationParts.minutes.length)}ch`;
+  }, [durationParts.minutes.length, showHours]);
+
+  return (
+    <div
+      className="flex shrink-0 items-center whitespace-nowrap font-mono text-sm font-semibold tabular-nums text-foreground"
+      aria-label={`${currentParts.label} of ${durationParts.label}`}
+    >
+      <span aria-hidden="true" className="inline-flex items-baseline">
+        <SegmentedTimecode
+          hoursWidth={hoursWidth}
+          minutesWidth={minutesWidth}
+          parts={currentParts}
+          showHours={showHours}
+        />
+        <span className="px-1.5 text-muted-foreground">/</span>
+        <SegmentedTimecode
+          hoursWidth={hoursWidth}
+          minutesWidth={minutesWidth}
+          parts={durationParts}
+          showHours={showHours}
+        />
+      </span>
+    </div>
+  );
+});

--- a/apps/frontend/src/components/editor/EditorUtils.ts
+++ b/apps/frontend/src/components/editor/EditorUtils.ts
@@ -58,6 +58,75 @@ export function formatTime(seconds: number) {
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}${fraction}`;
 }
 
+export function formatTimecodeInput(seconds: number) {
+  const roundedCentiseconds = Math.max(
+    0,
+    Math.round((Number.isFinite(seconds) ? seconds : 0) * 100),
+  );
+  const totalSeconds = Math.floor(roundedCentiseconds / 100);
+  const centiseconds = roundedCentiseconds % 100;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const remainingSeconds = totalSeconds % 60;
+  const fraction = centiseconds.toString().padStart(2, "0");
+
+  if (hours > 0) {
+    return [
+      hours,
+      minutes.toString().padStart(2, "0"),
+      remainingSeconds.toString().padStart(2, "0"),
+    ].join(":") + `.${fraction}`;
+  }
+
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}.${fraction}`;
+}
+
+export function parseTimecodeInput(value: string) {
+  const trimmed = value.trim();
+
+  if (!trimmed || trimmed.startsWith("-")) {
+    return null;
+  }
+
+  const numberPattern = /^\d+(?:\.\d+)?$/;
+  if (numberPattern.test(trimmed)) {
+    const seconds = Number(trimmed);
+    return Number.isFinite(seconds) ? roundTimelineTime(seconds) : null;
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length < 2 || parts.length > 3) {
+    return null;
+  }
+
+  const hasHours = parts.length === 3;
+  const [hoursPart, minutesPart, secondsPart] = hasHours
+    ? parts
+    : ["0", parts[0], parts[1]];
+  if (
+    !/^\d+$/.test(hoursPart)
+    || !/^\d+$/.test(minutesPart)
+    || !numberPattern.test(secondsPart)
+  ) {
+    return null;
+  }
+
+  const hours = Number(hoursPart);
+  const minutes = Number(minutesPart);
+  const seconds = Number(secondsPart);
+  if (
+    !Number.isFinite(hours)
+    || !Number.isFinite(minutes)
+    || !Number.isFinite(seconds)
+    || (hasHours && minutes >= 60)
+    || seconds >= 60
+  ) {
+    return null;
+  }
+
+  return roundTimelineTime((hours * 3600) + (minutes * 60) + seconds);
+}
+
 export function errorMessage(err: unknown) {
   return err instanceof Error ? err.message : "Preview failed to load";
 }
@@ -72,6 +141,38 @@ export function roundTimelineTime(seconds: number) {
   }
 
   return Math.round(seconds * 100) / 100;
+}
+
+export function clampPlaybackTime(seconds: number, duration: number) {
+  if (!Number.isFinite(seconds) || !Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+
+  return roundTimelineTime(Math.min(Math.max(seconds, 0), duration));
+}
+
+export function clampClipStartTime(nextStart: number, currentEnd: number, duration: number) {
+  if (!Number.isFinite(nextStart) || !Number.isFinite(currentEnd) || !Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+
+  const minClipLength = Math.min(MIN_CLIP_SECONDS, duration);
+  const boundedEnd = Math.min(Math.max(currentEnd, minClipLength), duration);
+  const maxStart = Math.max(boundedEnd - minClipLength, 0);
+
+  return roundTimelineTime(Math.min(Math.max(nextStart, 0), maxStart));
+}
+
+export function clampClipEndTime(nextEnd: number, currentStart: number, duration: number) {
+  if (!Number.isFinite(nextEnd) || !Number.isFinite(currentStart) || !Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+
+  const minClipLength = Math.min(MIN_CLIP_SECONDS, duration);
+  const boundedStart = Math.min(Math.max(currentStart, 0), Math.max(duration - minClipLength, 0));
+  const minEnd = boundedStart + minClipLength;
+
+  return roundTimelineTime(Math.min(Math.max(nextEnd, minEnd), duration));
 }
 
 export function timelineScaleForDuration(seconds: number) {

--- a/apps/frontend/src/components/editor/timelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.test.ts
@@ -3,9 +3,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  clampClipEndTime,
+  clampClipStartTime,
+  clampPlaybackTime,
   formatTime,
+  formatTimecodeInput,
   getTimelineFillPercentages,
   getFocusedTimelineZoomIndex,
+  parseTimecodeInput,
   type TimelineZoomLevel,
 } from "./EditorUtils";
 import {
@@ -84,6 +89,40 @@ void test("chooses an initial timeline zoom that keeps short selections editable
 void test("formats editor time with hours and sub-second precision when needed", () => {
   assert.equal(formatTime(7425), "2:03:45");
   assert.equal(formatTime(0.1), "0:00.10");
+  assert.equal(formatTimecodeInput(7425), "2:03:45.00");
+  assert.equal(formatTimecodeInput(0), "0:00.00");
+});
+
+void test("parses flexible editor timecode input", () => {
+  assert.equal(parseTimecodeInput("90"), 90);
+  assert.equal(parseTimecodeInput("90.5"), 90.5);
+  assert.equal(parseTimecodeInput("1:30"), 90);
+  assert.equal(parseTimecodeInput("1:30.25"), 90.25);
+  assert.equal(parseTimecodeInput("1:02:03.04"), 3723.04);
+  assert.equal(parseTimecodeInput("90:00"), 5400);
+  assert.equal(parseTimecodeInput("0.105"), 0.11);
+});
+
+void test("rejects malformed editor timecode input", () => {
+  assert.equal(parseTimecodeInput(""), null);
+  assert.equal(parseTimecodeInput("-1"), null);
+  assert.equal(parseTimecodeInput("1:"), null);
+  assert.equal(parseTimecodeInput(":30"), null);
+  assert.equal(parseTimecodeInput("1::30"), null);
+  assert.equal(parseTimecodeInput("1:02:03:04"), null);
+  assert.equal(parseTimecodeInput("1:60"), null);
+  assert.equal(parseTimecodeInput("1:02:60"), null);
+  assert.equal(parseTimecodeInput("1:60:00"), null);
+});
+
+void test("clamps direct timecode commits", () => {
+  assert.equal(clampPlaybackTime(-1, 100), 0);
+  assert.equal(clampPlaybackTime(101, 100), 100);
+  assert.equal(clampPlaybackTime(0.105, 100), 0.11);
+  assert.equal(clampClipStartTime(-1, 10, 100), 0);
+  assert.equal(clampClipStartTime(9.95, 10, 100), 9.9);
+  assert.equal(clampClipEndTime(5, 5, 100), 5.1);
+  assert.equal(clampClipEndTime(120, 5, 100), 100);
 });
 
 void test("maps buffered timeline fill into action-relative percentages", () => {


### PR DESCRIPTION
## Summary

- Stabilizes the editor preview timecode layout by giving both sides of the separator a fixed width.
- Splits preview timecodes into a fixed DOM shell of hour/minute/second/fraction slots.
- Updates timecode slot `textContent` imperatively from a layout effect so only changed slots are touched during playback.
- Keeps the separator and duration side stable while the current timestamp advances.
- Memoizes duration-derived formatting, fixed slot widths, and clip metric values that do not change on every playback tick.
- Adds click-to-edit direct timecode entry for preview seek time and clip In/Out values.
- Parses flexible seconds, `m:ss`, and `h:mm:ss` input with centisecond rounding and clamps commits to valid ranges.
- Improves direct-entry accessibility with explicit edit labels, screen-reader hints, announced invalid input, and focus restoration after keyboard commit/cancel.

## Why

The current preview timestamp updates rapidly during playback. Because its text width changes as centiseconds and digit counts change, the toolbar row can shift while rendering. Reserving width for the timecode cells keeps the rest of the row stable, and the fixed shell avoids React text reconciliation for the ticking digits.

The toolbar now also supports precise keyboard entry for users who want to seek or set clip boundaries directly instead of dragging the timeline handles.

## Validation

- `pnpm --filter @cliparr/frontend lint:types`
- `pnpm --filter @cliparr/frontend lint:eslint`
- `pnpm --filter @cliparr/frontend test`
