### PR TITLE
Fix media proxy content length handling

### DIFF
--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -352,6 +352,59 @@ void test("does not throw when a proxied media stream terminates early", async (
   });
 });
 
+void test("does not forward upstream content length for streamed media responses", async () => {
+  const session = createSession();
+  const handle = createMediaHandle({
+    path: "/library/parts/1/file.mp4",
+  });
+  const response = createStreamingResponseRecorder();
+
+  await proxyUpstreamMediaResponse(
+    session,
+    handle,
+    new globalThis.Response(new Uint8Array([1, 2, 3, 4]), {
+      status: 200,
+      headers: {
+        "content-length": "1",
+        "content-type": "video/mp4",
+      },
+    }),
+    response as unknown as Response
+  );
+
+  assert.equal(response.headers.get("content-length"), undefined);
+  assert.equal(response.headers.get("content-type"), "video/mp4");
+});
+
+void test("uses buffered byte length for cached HLS-derived media responses", async () => {
+  const session = createSession();
+  const handle = createMediaHandle({
+    id: "length-handle",
+    path: "https://cdn.example.com/hls/segment0.ts",
+    basePath: "https://cdn.example.com/hls/",
+  });
+  const response = createBinaryResponseRecorder();
+
+  await proxyProviderMediaResponse(
+    session,
+    handle,
+    {
+      accept: "video/mp2t",
+    },
+    async () => new globalThis.Response(new Uint8Array([1, 2, 3, 4]), {
+      status: 200,
+      headers: {
+        "content-length": "1",
+        "content-type": "video/mp2t",
+      },
+    }),
+    response as unknown as Response,
+  );
+
+  assert.equal(response.headers.get("content-length"), "4");
+  assert.deepEqual(response.body, Buffer.from([1, 2, 3, 4]));
+});
+
 void test("dedupes concurrent HLS-derived media requests for the same handle", async () => {
   const session = createSession();
   const handle = createMediaHandle({

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -457,6 +457,10 @@ async function rewriteHlsPlaylist(
 
 function copyProxyHeaders(upstream: globalThis.Response, res: Response) {
   for (const header of PROXY_HEADER_ALLOWLIST) {
+    if (header === "content-length") {
+      continue;
+    }
+
     const value = upstream.headers.get(header);
     if (value) {
       res.setHeader(header, value);
@@ -559,13 +563,11 @@ async function createCachedProxyMediaResponse(
   }
 
   const body = Buffer.from(await upstream.arrayBuffer());
-  const nextHeaders = upstream.body
-    ? headers
-    : headers.filter(([name]) => name !== "content-length");
+  const nextHeaders = headers.filter(([name]) => name !== "content-length");
 
   if (!upstream.body) {
     nextHeaders.push(["content-length", "0"]);
-  } else if (!nextHeaders.some(([name]) => name === "content-length")) {
+  } else {
     nextHeaders.push(["content-length", String(body.byteLength)]);
   }
 
@@ -614,7 +616,6 @@ export async function proxyUpstreamMediaResponse(
   res: Response
 ) {
   res.status(upstream.status);
-  copyProxyHeaders(upstream, res);
 
   const contentType = upstream.headers.get("content-type") ?? "";
   logger.trace("Proxying upstream media response for handle {handleId}.", {
@@ -628,6 +629,7 @@ export async function proxyUpstreamMediaResponse(
 
   if (isHlsPlaylist(handle, contentType)) {
     const playlist = await rewriteHlsPlaylist(session, handle, upstream);
+    copyProxyHeaders(upstream, res);
     res.setHeader("Content-Type", "application/vnd.apple.mpegurl");
     res.setHeader("Content-Length", Buffer.byteLength(playlist));
     res.send(playlist);
@@ -635,10 +637,13 @@ export async function proxyUpstreamMediaResponse(
   }
 
   if (!upstream.body) {
+    copyProxyHeaders(upstream, res);
+    res.setHeader("Content-Length", "0");
     res.end();
     return;
   }
 
+  copyProxyHeaders(upstream, res);
   const upstreamBody = Readable.fromWeb(upstream.body as unknown as WebReadableStream<Uint8Array>);
   const closeUpstreamBody = () => {
     upstreamBody.destroy();


### PR DESCRIPTION
## Summary
- stop forwarding upstream Content-Length on streamed media proxy responses
- set Content-Length from the actual buffered body for cached HLS-derived responses
- add regression tests for streamed and cached proxy length handling

## Tests
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/server lint
- pnpm --filter @cliparr/frontend test