### PR TITLE
[codex] Refine frontend messaging and tooltips

### DIFF
--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -64,7 +64,7 @@ function queueAuthFailureNotification() {
 
 function buildUnexpectedApiResponseError() {
   return new Error(
-    "Cliparr API returned HTML instead of JSON. Make sure the Cliparr server is running on the configured API URL and that another local app is not already serving that port."
+    "Cliparr API returned the app page instead of JSON. Check the API URL."
   );
 }
 

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -49,7 +49,7 @@ function canEditSession(session: Pick<CurrentlyPlayingItem, "mediaUrl" | "hlsUrl
 }
 
 function sessionActionLabel(session: Pick<CurrentlyPlayingItem, "mediaUrl" | "hlsUrl">) {
-  return canEditSession(session) ? "Edit Clip" : "No exportable stream";
+  return canEditSession(session) ? "Edit Clip" : "No stream";
 }
 
 function ViewerAvatar({ name, avatarUrl }: { name: string; avatarUrl?: string }) {
@@ -82,7 +82,7 @@ function WarningBanner({ sourceErrors }: { sourceErrors: SourcePlaybackError[] }
       <div className="flex items-start gap-3">
         <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
         <div className="space-y-2 text-sm">
-          <p className="font-medium">Some sources could not be reached. Showing results from the sources that responded.</p>
+          <p className="font-medium">Some sources are unavailable. Showing the rest.</p>
           <div className="space-y-1">
             {sourceErrors.map((sourceError) => (
               <p key={sourceError.sourceId}>
@@ -116,7 +116,7 @@ export default function DashboardScreen({ onSelectSession, onOpenLocalVideo, onO
       setViewers(playback.viewers);
       setSourceErrors(playback.sourceErrors);
     } catch (err: unknown) {
-      setError(errorMessage(err, "Failed to fetch sessions"));
+      setError(errorMessage(err, "Could not load sessions."));
       setViewers([]);
       setSourceErrors([]);
     } finally {
@@ -150,7 +150,7 @@ export default function DashboardScreen({ onSelectSession, onOpenLocalVideo, onO
 
   const hasPlayback = viewers.length > 0;
   const emptyMessage = sourceErrors.length > 0
-    ? "No active playback was found on the sources that responded."
+    ? "No active playback on the available sources."
     : "No one is currently watching anything.";
   const versionLabel = appVersion;
 
@@ -223,7 +223,7 @@ export default function DashboardScreen({ onSelectSession, onOpenLocalVideo, onO
           <div>
             <h2 className="text-xl font-semibold mb-2">Currently Playing</h2>
             <p className="text-muted-foreground text-sm">
-              See what everyone is watching across your enabled sources.
+              Active sessions across enabled sources.
             </p>
           </div>
 

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -303,7 +303,7 @@ export default function EditorScreen({ session, onBack }: Props) {
   useEditorKeyboardShortcuts({ togglePlay });
 
   const durationExportDisabledReason = !hasDuration
-    ? "Waiting for media duration before export is available."
+    ? "Waiting for media duration."
     : null;
   const exportDisabledReason = durationExportDisabledReason ?? subtitleExportSummary.disabledReason;
 
@@ -311,7 +311,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     return (
       <div className="flex h-dvh items-center justify-center overflow-hidden bg-background p-8 text-foreground">
         <div className="text-center">
-          <p className="text-destructive mb-4">Could not find an exportable stream for this session.</p>
+          <p className="text-destructive mb-4">No exportable stream found.</p>
           <button onClick={onBack} className="text-primary hover:underline">Go Back</button>
         </div>
       </div>
@@ -381,7 +381,7 @@ export default function EditorScreen({ session, onBack }: Props) {
 
               {!hasDuration && (
                 <div className="border-t border-border px-3 py-3 text-sm text-muted-foreground">
-                  Waiting for media duration before clip controls can be adjusted.
+                  Waiting for media duration.
                 </div>
               )}
 
@@ -533,11 +533,9 @@ function buildPlaybackFallbackReason({
     return null;
   }
 
-  const prefix = ({
-    "open-or-read": "Preview is using the direct source because Cliparr could not open or read the HLS stream",
-    "preview-only": "Preview is using the direct source because this browser could not preview the HLS stream",
-    "shared-export-blocking": "Preview is using the direct source because Cliparr cannot currently use this HLS stream for preview or export",
-  } as const)[hlsFallbackInfo.category];
+  const prefix = hlsFallbackInfo.category === "preview-only"
+    ? "Preview switched sources"
+    : "Using direct media";
 
   return `${prefix}: ${hlsFallbackInfo.message}`;
 }

--- a/apps/frontend/src/components/LocalVideoOpenModal.tsx
+++ b/apps/frontend/src/components/LocalVideoOpenModal.tsx
@@ -148,7 +148,7 @@ export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpe
               Open Video
             </h2>
             <p className="text-xs text-muted-foreground">
-              Local files stay in your browser. URL media must allow browser reads.
+              Local files stay in your browser.
             </p>
           </div>
           <button
@@ -235,7 +235,7 @@ export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpe
               </div>
               <div className="space-y-1">
                 <p className="text-sm font-medium text-foreground">Drop a video file here</p>
-                <p className="text-xs text-muted-foreground">MP4, MOV, MKV, WebM, Ogg video, and MPEG-TS are supported when your browser can decode them.</p>
+                <p className="text-xs text-muted-foreground">MP4, MOV, MKV, WebM, Ogg video, and MPEG-TS are supported.</p>
               </div>
               <button
                 type="button"
@@ -262,7 +262,7 @@ export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpe
                 />
               </label>
               <p className="text-xs leading-5 text-muted-foreground">
-                Direct media files and HLS playlists can work when the remote server permits CORS and byte-range requests from this browser.
+                Use a direct media file or HLS playlist URL.
               </p>
               <div className="flex justify-end">
                 <button

--- a/apps/frontend/src/components/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlow.tsx
@@ -74,11 +74,11 @@ export default function ProviderConnectFlow({
       return (
         <div className="space-y-4">
           <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            Cliparr will open the provider sign-in page in a new tab and keep polling here until the auth completes.
+            A new tab will open for sign-in.
           </div>
 
           <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            Connected providers stay available from this Sources screen, so you can keep adding servers over time.
+            Connected servers stay in Sources.
           </div>
 
           <div className="flex flex-wrap gap-3 pt-1">
@@ -113,11 +113,11 @@ export default function ProviderConnectFlow({
       <div className="flex h-full flex-col justify-between gap-6">
         <div className="space-y-4">
           <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            Cliparr will open the provider sign-in page in a new tab and keep polling here until the auth completes.
+            A new tab will open for sign-in.
           </div>
 
           <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            Once this account is connected, Cliparr can discover Plex servers now and you can add more sources later from the Sources screen.
+            Add more sources later from Sources.
           </div>
         </div>
 
@@ -135,7 +135,7 @@ export default function ProviderConnectFlow({
           </button>
 
           <p className="text-center text-xs leading-6 text-muted-foreground">
-            The provider picker stays here, so you can switch to another source option without the whole window jumping around.
+            You can switch providers any time.
           </p>
         </div>
       </div>
@@ -184,7 +184,7 @@ export default function ProviderConnectFlow({
               )}
             >
               <p className="leading-6">
-                Running the Docker dev setup? Cliparr can reach Jellyfin at{" "}
+                Docker Jellyfin URL:{" "}
                 <span className="font-mono text-foreground">{devJellyfinUrl}</span>.
               </p>
 
@@ -210,7 +210,7 @@ export default function ProviderConnectFlow({
 
                 {isScreen && isUsingDevJellyfinUrl && (
                   <span className="text-xs text-muted-foreground">
-                    The input above is already set to the Docker service URL.
+                    Already selected.
                   </span>
                 )}
               </div>
@@ -220,8 +220,7 @@ export default function ProviderConnectFlow({
           {jellyfinLoopbackWarning && (
             <div className="rounded-2xl border border-primary/25 bg-primary/10 px-4 py-3 text-sm text-foreground">
               <p className="leading-6">
-                In this Docker setup, <span className="font-mono">localhost</span> points at the Cliparr container. Cliparr will translate this to{" "}
-                <span className="font-mono">{devJellyfinUrl}</span> when it talks to Jellyfin.
+                Docker will use <span className="font-mono">{devJellyfinUrl}</span> for this localhost URL.
               </p>
             </div>
           )}
@@ -255,7 +254,7 @@ export default function ProviderConnectFlow({
           </div>
 
           <p className="text-xs leading-6 text-muted-foreground">
-            Cliparr stores the access token Jellyfin returns after sign-in. Your password is only used for this connection step.
+            Your password is only used to request a Jellyfin token.
           </p>
         </div>
 
@@ -273,7 +272,7 @@ export default function ProviderConnectFlow({
             </button>
 
             <p className="text-center text-xs leading-6 text-muted-foreground">
-              Connect one server now, then add more Plex or Jellyfin sources later from the Sources screen.
+              Add more servers later from Sources.
             </p>
           </div>
         ) : (
@@ -310,7 +309,7 @@ export default function ProviderConnectFlow({
       return null;
     }
 
-    const content = `Finish sign-in in the ${providerLabel(providerId)} tab. This screen will continue automatically.`;
+    const content = `Finish sign-in in the ${providerLabel(providerId)} tab.`;
 
     if (!isScreen) {
       return (
@@ -422,7 +421,7 @@ export default function ProviderConnectFlow({
     if (!error && providers.length === 0) {
       return (
         <ProviderStatusMessage isScreen={isScreen}>
-          No providers are currently available.
+          No providers available.
         </ProviderStatusMessage>
       );
     }
@@ -430,7 +429,7 @@ export default function ProviderConnectFlow({
     if (providers.length === 0) {
       return (
         <ProviderStatusMessage isScreen={isScreen}>
-          We could not load providers yet.
+          Could not load providers.
         </ProviderStatusMessage>
       );
     }

--- a/apps/frontend/src/components/ProviderConnectFlowSections.tsx
+++ b/apps/frontend/src/components/ProviderConnectFlowSections.tsx
@@ -12,20 +12,20 @@ export function providerPresentation(
       return {
         eyebrow: "Browser Sign-In",
         summary: variant === "panel"
-          ? "Authenticate with Plex in a separate tab, then Cliparr will discover and keep those servers available here."
-          : "Authenticate with Plex in a separate tab, then Cliparr will discover the Plex servers tied to that account.",
+          ? "Sign in with Plex, then choose a server."
+          : "Sign in with Plex to find your servers.",
         action: "Continue with Plex",
       };
     case "jellyfin":
       return {
         eyebrow: "Direct Server Login",
-        summary: "Connect directly to a Jellyfin server with its base URL and an administrator account.",
+        summary: "Connect with your Jellyfin server URL and account.",
         action: "Connect Jellyfin",
       };
     default:
       return {
         eyebrow: "Provider Setup",
-        summary: `Connect ${provider.name} to start pulling active sessions into Cliparr.`,
+        summary: `Connect ${provider.name} to import active sessions.`,
         action: `Continue with ${provider.name}`,
       };
   }

--- a/apps/frontend/src/components/ProviderConnectScreen.tsx
+++ b/apps/frontend/src/components/ProviderConnectScreen.tsx
@@ -23,7 +23,7 @@ export default function ProviderConnectScreen({ onConnected, onOpenLocalVideo }:
           </div>
           <h1 className="text-center text-3xl font-semibold tracking-tight">Connect A Provider</h1>
           <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-6 text-muted-foreground">
-            Select a provider. You will be able to add more providers later.
+            Choose a provider to get started.
           </p>
           <div className="mt-5 flex justify-center">
             <button

--- a/apps/frontend/src/components/SourcesModal.tsx
+++ b/apps/frontend/src/components/SourcesModal.tsx
@@ -132,12 +132,12 @@ export default function SourcesModal({ isOpen, onClose, onSourcesChanged }: Prop
             ) : sources.length === 0 ? (
               <SourcesEmptyState
                 title="No sources connected yet"
-                description="Use the add-source panel above to connect your first Plex or Jellyfin server."
+                description="Connect a Plex or Jellyfin server to get started."
               />
             ) : filteredSources.length === 0 ? (
               <SourcesEmptyState
                 title="No sources match this view"
-                description="Try a different filter, clear your search, or reconnect a provider to discover additional media servers."
+                description="Try another filter or search."
               />
             ) : (
               <div className="grid gap-4 xl:grid-cols-2">

--- a/apps/frontend/src/components/SourcesModalSections.tsx
+++ b/apps/frontend/src/components/SourcesModalSections.tsx
@@ -11,6 +11,11 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "../lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { MediaSource, ProviderSession } from "../providers/types";
 import { formatProviderName } from "./ProviderGlyph";
 import SourceConnectPanel from "./SourceConnectPanel";
@@ -20,6 +25,31 @@ export type SourceFilter = "all" | "enabled" | "disabled" | "attention";
 export interface Feedback {
   tone: "error" | "success" | "warning";
   message: string;
+}
+
+function TooltipWrap({
+  message,
+  children,
+}: {
+  message: string | null;
+  children: React.ReactElement;
+}) {
+  if (!message) {
+    return children;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex" tabIndex={0}>
+          {children}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {message}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 interface SourceCounts {
@@ -136,6 +166,19 @@ export function SourcesModalHeader({
   onRefreshAll,
   onClose,
 }: SourcesModalHeaderProps) {
+  const reloadDisabledReason = loading || reloading
+    ? "Source list is already loading."
+    : refreshingAll
+      ? "Wait for refresh to finish."
+      : null;
+  const refreshAllDisabledReason = counts.all === 0
+    ? "No sources to refresh."
+    : hasBusyActions || refreshingAll
+      ? "Wait for the current action to finish."
+      : loading || reloading
+        ? "Source list is still loading."
+        : null;
+
   return (
     <header className="border-b border-border bg-[linear-gradient(135deg,color-mix(in_oklch,var(--primary)_16%,transparent),transparent_55%),linear-gradient(180deg,color-mix(in_oklch,var(--muted)_82%,var(--card)),var(--card))] px-5 py-5 sm:px-8 sm:py-7">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
@@ -147,7 +190,7 @@ export function SourcesModalHeader({
           <div className="space-y-2">
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">Manage Sources</h2>
             <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-              Connect new servers, update saved source details, run health checks, and clean up anything you no longer want Cliparr to query.
+              Connect servers, edit details, and run health checks.
             </p>
           </div>
           <div className="flex flex-wrap gap-3 text-sm">
@@ -174,27 +217,31 @@ export function SourcesModalHeader({
               className="inline-flex items-center gap-2 rounded-xl border border-border bg-background/80 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Plus className={cn("h-4 w-4 transition-transform", showConnectPanel && "rotate-45")} />
-              {showConnectPanel ? "Hide Add Source" : "Add Source"}
+              {showConnectPanel ? "Hide" : "Add Source"}
             </button>
           )}
-          <button
-            type="button"
-            onClick={onReloadList}
-            disabled={loading || reloading || refreshingAll}
-            className="inline-flex items-center gap-2 rounded-xl border border-border bg-background/80 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <RefreshCw className={cn("h-4 w-4", (reloading || loading) && "animate-spin")} />
-            Reload List
-          </button>
-          <button
-            type="button"
-            onClick={onRefreshAll}
-            disabled={loading || reloading || refreshingAll || hasBusyActions || counts.all === 0}
-            className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <RefreshCw className={cn("h-4 w-4", refreshingAll && "animate-spin")} />
-            Refresh All
-          </button>
+          <TooltipWrap message={reloadDisabledReason}>
+            <button
+              type="button"
+              onClick={onReloadList}
+              disabled={loading || reloading || refreshingAll}
+              className="inline-flex items-center gap-2 rounded-xl border border-border bg-background/80 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw className={cn("h-4 w-4", (reloading || loading) && "animate-spin")} />
+              Reload
+            </button>
+          </TooltipWrap>
+          <TooltipWrap message={refreshAllDisabledReason}>
+            <button
+              type="button"
+              onClick={onRefreshAll}
+              disabled={loading || reloading || refreshingAll || hasBusyActions || counts.all === 0}
+              className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw className={cn("h-4 w-4", refreshingAll && "animate-spin")} />
+              Refresh All
+            </button>
+          </TooltipWrap>
           <button
             type="button"
             onClick={onClose}
@@ -363,7 +410,7 @@ export function SourcesConnectSection({
             className="inline-flex items-center gap-2 rounded-xl border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
           >
             <X className="h-4 w-4" />
-            Close Panel
+            Close
           </button>
         )}
       </div>
@@ -433,6 +480,16 @@ export function SourceCard({
     && Boolean(trimmedBaseUrl)
     && !isBusy
     && (trimmedName !== source.name || trimmedBaseUrl !== source.baseUrl);
+  const saveDisabledReason = isBusy
+    ? "Wait for the current action to finish."
+    : !trimmedName
+      ? "Enter a display name."
+      : !trimmedBaseUrl
+        ? "Enter a server URL."
+        : trimmedName === source.name && trimmedBaseUrl === source.baseUrl
+          ? "No changes to save."
+          : null;
+  const busyDisabledReason = isBusy ? "Wait for the current action to finish." : null;
   const product = stringValue(source.metadata.product);
   const platform = stringValue(source.metadata.platform);
 
@@ -526,45 +583,53 @@ export function SourceCard({
       )}
 
       <div className="mt-5 flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={() => void onSave()}
-          disabled={!canSaveEdits}
-          className="rounded-xl border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          Save Changes
-        </button>
-        <button
-          type="button"
-          onClick={() => void onToggleEnabled()}
-          disabled={isBusy}
-          className={cn(
-            "rounded-xl px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-            source.enabled
-              ? "bg-muted text-foreground hover:bg-accent"
-              : "bg-primary text-primary-foreground hover:bg-primary/90"
-          )}
-        >
-          {source.enabled ? "Disable" : "Enable"}
-        </button>
-        <button
-          type="button"
-          onClick={() => void onRefresh()}
-          disabled={isBusy}
-          className="inline-flex items-center gap-2 rounded-xl border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RefreshCw className={cn("h-4 w-4", busyAction === "Refreshing..." && "animate-spin")} />
-          Refresh
-        </button>
-        <button
-          type="button"
-          onClick={() => void onRemove()}
-          disabled={isBusy}
-          className="inline-flex items-center gap-2 rounded-xl border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <Trash2 className="h-4 w-4" />
-          Remove
-        </button>
+        <TooltipWrap message={!canSaveEdits ? saveDisabledReason : null}>
+          <button
+            type="button"
+            onClick={() => void onSave()}
+            disabled={!canSaveEdits}
+            className="rounded-xl border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Save Changes
+          </button>
+        </TooltipWrap>
+        <TooltipWrap message={busyDisabledReason}>
+          <button
+            type="button"
+            onClick={() => void onToggleEnabled()}
+            disabled={isBusy}
+            className={cn(
+              "rounded-xl px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+              source.enabled
+                ? "bg-muted text-foreground hover:bg-accent"
+                : "bg-primary text-primary-foreground hover:bg-primary/90"
+            )}
+          >
+            {source.enabled ? "Disable" : "Enable"}
+          </button>
+        </TooltipWrap>
+        <TooltipWrap message={busyDisabledReason}>
+          <button
+            type="button"
+            onClick={() => void onRefresh()}
+            disabled={isBusy}
+            className="inline-flex items-center gap-2 rounded-xl border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <RefreshCw className={cn("h-4 w-4", busyAction === "Refreshing..." && "animate-spin")} />
+            Refresh
+          </button>
+        </TooltipWrap>
+        <TooltipWrap message={busyDisabledReason}>
+          <button
+            type="button"
+            onClick={() => void onRemove()}
+            disabled={isBusy}
+            className="inline-flex items-center gap-2 rounded-xl border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Trash2 className="h-4 w-4" />
+            Remove
+          </button>
+        </TooltipWrap>
       </div>
     </article>
   );

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,5 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, type ReactElement } from "react";
 import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { EditorEditableTimecode } from "./EditorEditableTimecode";
 import { EditorPreviewTimecode } from "./EditorPreviewTimecode";
 import { formatTime, formatTimecodeInput } from "./EditorUtils";
@@ -23,6 +28,31 @@ interface EditorControlsProps {
   onPreviewTimeCommit: (time: number) => void | Promise<void>;
   onStartTimeCommit: (time: number) => void | Promise<void>;
   onEndTimeCommit: (time: number) => void | Promise<void>;
+}
+
+function ControlTooltip({
+  label,
+  disabled = false,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  children: ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {disabled ? (
+          <span className="inline-flex" tabIndex={0}>
+            {children}
+          </span>
+        ) : children}
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function EditorControls({
@@ -62,14 +92,16 @@ export function EditorControls({
     <div className="border-b border-border px-3 py-2">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
         <div className="flex items-center gap-2.5">
-          <button
-            onClick={togglePlay}
-            disabled={loadingPreview}
-            aria-label={playing ? "Pause preview" : "Play preview"}
-            className="flex h-8 w-8 items-center justify-center border border-border bg-accent text-foreground transition-colors hover:bg-accent/80 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
-          </button>
+          <ControlTooltip label={loadingPreview ? "Preview is loading." : playing ? "Pause preview" : "Play preview"} disabled={loadingPreview}>
+            <button
+              onClick={togglePlay}
+              disabled={loadingPreview}
+              aria-label={playing ? "Pause preview" : "Play preview"}
+              className="flex h-8 w-8 items-center justify-center border border-border bg-accent text-foreground transition-colors hover:bg-accent/80 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {playing ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
+            </button>
+          </ControlTooltip>
           <EditorEditableTimecode
             ariaLabel="preview time"
             buttonClassName="text-foreground"
@@ -83,14 +115,16 @@ export function EditorControls({
         </div>
         <div className="h-5 w-px bg-border" />
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setMuted((current) => !current)}
-            className="flex h-8 w-8 items-center justify-center border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            aria-label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
-          >
-            {muted || volume === 0 ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
-          </button>
+          <ControlTooltip label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}>
+            <button
+              type="button"
+              onClick={() => setMuted((current) => !current)}
+              className="flex h-8 w-8 items-center justify-center border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              aria-label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
+            >
+              {muted || volume === 0 ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+            </button>
+          </ControlTooltip>
           <input
             type="range"
             min={0}
@@ -106,26 +140,28 @@ export function EditorControls({
             aria-label="Preview volume"
           />
           <div className="ml-1 flex items-center overflow-hidden border border-border bg-background">
-            <button
-              type="button"
-              onClick={handleTimelineZoomOut}
-              disabled={!canZoomOut}
-              className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
-              aria-label="Zoom timeline out"
-              title="Zoom timeline out"
-            >
-              <ZoomOut className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={handleTimelineZoomIn}
-              disabled={!canZoomIn}
-              className="flex h-8 w-8 items-center justify-center border-l border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
-              aria-label="Zoom timeline in"
-              title="Zoom timeline in"
-            >
-              <ZoomIn className="h-4 w-4" />
-            </button>
+            <ControlTooltip label={canZoomOut ? "Zoom timeline out" : "Already fully zoomed out"} disabled={!canZoomOut}>
+              <button
+                type="button"
+                onClick={handleTimelineZoomOut}
+                disabled={!canZoomOut}
+                className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+                aria-label="Zoom timeline out"
+              >
+                <ZoomOut className="h-4 w-4" />
+              </button>
+            </ControlTooltip>
+            <ControlTooltip label={canZoomIn ? "Zoom timeline in" : "Already fully zoomed in"} disabled={!canZoomIn}>
+              <button
+                type="button"
+                onClick={handleTimelineZoomIn}
+                disabled={!canZoomIn}
+                className="flex h-8 w-8 items-center justify-center border-l border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+                aria-label="Zoom timeline in"
+              >
+                <ZoomIn className="h-4 w-4" />
+              </button>
+            </ControlTooltip>
           </div>
         </div>
         <div className="min-w-0 flex-1" />

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -136,7 +136,7 @@ export function EditorExportDialog({
                 Export Clip
               </h2>
               <p className="text-xs text-muted-foreground">
-                Configure export settings and review the output filename before download.
+                Review settings before download.
               </p>
             </div>
 

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -36,29 +36,29 @@ interface ExportOption<T extends string> {
 const formatOptions: ReadonlyArray<ExportOption<ExportFormat> & {
   extension: string;
 }> = [
-  {
-    value: "mp4",
-    label: "MP4",
-    extension: ".mp4",
-    description: "Best for everyday sharing, browser playback, and platform uploads.",
+    {
+      value: "mp4",
+      label: "MP4",
+      extension: ".mp4",
+      description: "Best for sharing and uploads.",
   },
   {
-    value: "webm",
-    label: "WEBM",
-    extension: ".webm",
-    description: "Modern web-first delivery with efficient browser-friendly playback.",
+      value: "webm",
+      label: "WEBM",
+      extension: ".webm",
+      description: "Efficient web playback.",
   },
   {
-    value: "mov",
-    label: "MOV",
-    extension: ".mov",
-    description: "A professional container that fits Adobe-style editorial workflows.",
+      value: "mov",
+      label: "MOV",
+      extension: ".mov",
+      description: "Good for editing workflows.",
   },
   {
-    value: "mkv",
-    label: "MKV",
-    extension: ".mkv",
-    description: "A flexible container for preserving a wider range of stream layouts.",
+      value: "mkv",
+      label: "MKV",
+      extension: ".mkv",
+      description: "Flexible container support.",
   },
 ];
 
@@ -121,17 +121,17 @@ function sourceOptionsFor(labels: {
     {
       value: "auto",
       label: "Auto",
-      description: "Lets Cliparr choose the safest export path for this session.",
+      description: "Chooses the best available path.",
     },
     {
       value: "direct",
       label: labels.directSourceLabel,
-      description: "Uses the direct media path when available, usually best for preserving source quality.",
+      description: "Uses direct media when available.",
     },
     {
       value: "hls",
       label: labels.hlsSourceLabel,
-      description: "Uses the playback stream or HLS playlist for this export.",
+      description: "Uses the playback stream.",
     },
   ];
 }
@@ -255,7 +255,7 @@ export function EditorExportSettingsSection({
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" align="start">
-                Track and timing detection can still use HLS metadata when Cliparr can read it. This only chooses which media path is used for the exported file.
+                Chooses the media path used for export.
               </TooltipContent>
             </Tooltip>
           </div>

--- a/apps/frontend/src/components/editor/EditorHeader.tsx
+++ b/apps/frontend/src/components/editor/EditorHeader.tsx
@@ -1,4 +1,9 @@
 import { ArrowLeft, Download } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface EditorHeaderProps {
   title: string;
@@ -18,18 +23,46 @@ export function EditorHeader({
   onExportClick,
 }: EditorHeaderProps) {
   const exportDisabled = exporting || Boolean(exportDisabledReason);
+  const exportTooltip = exportDisabledReason ?? (exporting ? "Export in progress." : null);
+  const exportButton = (
+    <button
+      type="button"
+      onClick={onExportClick}
+      disabled={exportDisabled}
+      className="flex h-8 min-w-36 items-center justify-center gap-2 rounded-[var(--radius-control)] border border-primary bg-primary px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {exporting ? (
+        <span className="flex items-center gap-2">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
+          Exporting {Math.round(progress * 100)}%
+        </span>
+      ) : (
+        <>
+          <Download className="h-3.5 w-3.5" />
+          Export
+        </>
+      )}
+    </button>
+  );
 
   return (
     <header className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border bg-card px-3 py-2">
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Back"
-          className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onBack}
+              aria-label="Back"
+              className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Back
+          </TooltipContent>
+        </Tooltip>
         <div className="flex items-center gap-2 pl-1">
           <img src="/logo-light.svg" alt="Cliparr Logo" className="h-5 w-5" />
           <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
@@ -41,25 +74,18 @@ export function EditorHeader({
         <div className="truncate">{title}</div>
       </div>
       <div className="flex items-center justify-self-end">
-        <button
-          type="button"
-          onClick={onExportClick}
-          disabled={exportDisabled}
-          title={exportDisabledReason ?? undefined}
-          className="flex h-8 min-w-36 items-center justify-center gap-2 rounded-[var(--radius-control)] border border-primary bg-primary px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {exporting ? (
-            <span className="flex items-center gap-2">
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
-              Exporting {Math.round(progress * 100)}%
-            </span>
-          ) : (
-            <>
-              <Download className="h-3.5 w-3.5" />
-              Export
-            </>
-          )}
-        </button>
+        {exportTooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex" tabIndex={exportDisabled ? 0 : -1}>
+                {exportButton}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="end">
+              {exportTooltip}
+            </TooltipContent>
+          </Tooltip>
+        ) : exportButton}
       </div>
     </header>
   );

--- a/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
@@ -27,7 +27,7 @@ export function EditorPlaybackSourcePanel({
 }: EditorPlaybackSourcePanelProps) {
   const sourceNote = fallbackMessage
     ?? (!hasHlsSource && previewSourceLabel === "Direct source"
-      ? "This session did not expose an HLS stream, so Cliparr is using the direct media path."
+      ? "Direct media only."
       : null);
 
   return (

--- a/apps/frontend/src/components/editor/EditorSidebar.tsx
+++ b/apps/frontend/src/components/editor/EditorSidebar.tsx
@@ -1,6 +1,11 @@
 import type { CSSProperties, ReactNode } from "react";
 import { PanelRightClose, PanelRightOpen, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface EditorSidebarProps {
   open: boolean;
@@ -46,14 +51,21 @@ export function EditorSidebar({
             "flex gap-3 border-b border-sidebar-border p-3",
             description ? "items-start" : "items-center",
           )}>
-            <button
-              type="button"
-              onClick={() => onOpenChange(false)}
-              className={cn(sidebarControlClassName(), "shrink-0")}
-              aria-label={`Collapse ${title.toLowerCase()} sidebar`}
-            >
-              <PanelRightClose className="h-4 w-4" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+                  className={cn(sidebarControlClassName(), "shrink-0")}
+                  aria-label={`Collapse ${title.toLowerCase()} sidebar`}
+                >
+                  <PanelRightClose className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                Collapse {title.toLowerCase()}
+              </TooltipContent>
+            </Tooltip>
 
             <div className={cn(
               "min-w-0 flex-1",
@@ -76,14 +88,21 @@ export function EditorSidebar({
         </div>
       ) : (
         <>
-          <button
-            type="button"
-            onClick={() => onOpenChange(true)}
-            className={cn(sidebarControlClassName(), "absolute left-2 top-3 z-10")}
-            aria-label={`Expand ${title.toLowerCase()} sidebar`}
-          >
-            <PanelRightOpen className="h-4 w-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onOpenChange(true)}
+                className={cn(sidebarControlClassName(), "absolute left-2 top-3 z-10")}
+                aria-label={`Expand ${title.toLowerCase()} sidebar`}
+              >
+                <PanelRightOpen className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              Expand {title.toLowerCase()}
+            </TooltipContent>
+          </Tooltip>
 
           <div className="flex w-full flex-col items-center justify-between pt-14 pb-3">
           <div className="flex flex-col items-center gap-3">

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -9,6 +9,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   subtitleTrackKey,
@@ -155,10 +160,16 @@ export function EditorSubtitlePanel({
   } = useSubtitleFontOptions(subtitleStyleSettings.fontFamily);
   const unavailableMessage = subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId);
   const subtitleWarning = subtitleTracks.length === 0
-    ? "No supported text subtitle tracks are available for this session."
+    ? "No supported subtitles found."
     : !selectedSubtitleTrack
-      ? "Choose a subtitle track to preview and burn it into the clip."
-      : unavailableMessage ?? "This subtitle track exists, but it is not yet supported for styled burn-in.";
+      ? "Choose a subtitle track."
+      : unavailableMessage ?? "This subtitle track is not supported.";
+  const subtitleToggleTooltip = !canEnableBurnIn ? subtitleWarning : null;
+  const styleTooltip = styleControlsDisabled
+    ? subtitlesEnabled
+      ? subtitleWarning
+      : "Turn subtitles on to edit style."
+    : null;
 
   function updateStyleSetting<Key extends keyof SubtitleStyleSettings>(
     key: Key,
@@ -178,26 +189,48 @@ export function EditorSubtitlePanel({
             <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
               Subtitles
             </div>
-            <p className="text-xs text-sidebar-foreground">
-              Pull provider subtitles into the editor and render them directly into the exported clip.
-            </p>
           </div>
 
-          <label className={cn(
-            "inline-flex items-center gap-2 rounded-[var(--radius-control)] border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)]",
-            subtitlesEnabled && canEnableBurnIn
-              ? "border-primary/35 bg-primary/10 text-primary"
-              : "border-sidebar-border bg-sidebar text-muted-foreground"
-          )}>
-            <input
-              type="checkbox"
-              checked={subtitlesEnabled}
-              disabled={!canEnableBurnIn}
-              onChange={(event) => onSubtitlesEnabledChange(event.target.checked)}
-              className="h-3.5 w-3.5 accent-primary"
-            />
-            Enabled
-          </label>
+          {subtitleToggleTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex" tabIndex={0}>
+                  <label className={cn(
+                    "inline-flex items-center gap-2 rounded-[var(--radius-control)] border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)]",
+                    "border-sidebar-border bg-sidebar text-muted-foreground"
+                  )}>
+                    <input
+                      type="checkbox"
+                      checked={subtitlesEnabled}
+                      disabled={!canEnableBurnIn}
+                      onChange={(event) => onSubtitlesEnabledChange(event.target.checked)}
+                      className="h-3.5 w-3.5 accent-primary"
+                    />
+                    Enabled
+                  </label>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                {subtitleToggleTooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <label className={cn(
+              "inline-flex items-center gap-2 rounded-[var(--radius-control)] border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)]",
+              subtitlesEnabled && canEnableBurnIn
+                ? "border-primary/35 bg-primary/10 text-primary"
+                : "border-sidebar-border bg-sidebar text-muted-foreground"
+            )}>
+              <input
+                type="checkbox"
+                checked={subtitlesEnabled}
+                disabled={!canEnableBurnIn}
+                onChange={(event) => onSubtitlesEnabledChange(event.target.checked)}
+                className="h-3.5 w-3.5 accent-primary"
+              />
+              Enabled
+            </label>
+          )}
         </div>
 
         <label className="space-y-1.5">
@@ -253,7 +286,7 @@ export function EditorSubtitlePanel({
         {subtitleLoading && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-            Loading subtitle cues...
+            Loading subtitles...
           </div>
         )}
 
@@ -270,9 +303,22 @@ export function EditorSubtitlePanel({
             styleControlsDisabled && "opacity-65"
           )}
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-            Style
-          </div>
+          {styleTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="w-fit text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
+                  Style
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                {styleTooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <div className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
+              Style
+            </div>
+          )}
 
           <label className="block space-y-1.5">
             <span className="text-[11px] font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
@@ -321,7 +367,7 @@ export function EditorSubtitlePanel({
                 {loadingLocalFonts && (
                   <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
                     <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                    Looking for installed fonts...
+                    Loading installed fonts...
                   </div>
                 )}
               </SelectContent>

--- a/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
@@ -121,6 +121,6 @@ void test("deduplicates playback load errors that share the same underlying mess
 
   assert.equal(
     buildPlaybackLoadError(failures),
-    "Cliparr could not open any playback stream. Network denied",
+    "Playback failed. Network denied",
   );
 });

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -158,7 +158,7 @@ export function resolvePlaybackDuration(
 
 export function buildPlaybackLoadError(failures: PlaybackLoadFailure[]) {
   if (failures.length === 0) {
-    return "Playback could not be loaded.";
+    return "Playback failed.";
   }
 
   if (failures.length === 1) {
@@ -167,10 +167,10 @@ export function buildPlaybackLoadError(failures: PlaybackLoadFailure[]) {
 
   const uniqueMessages = [...new Set(failures.map((failure) => failure.message))];
   if (uniqueMessages.length === 1) {
-    return `Cliparr could not open any playback stream. ${uniqueMessages[0]}`;
+    return `Playback failed. ${uniqueMessages[0]}`;
   }
 
-  return `Cliparr could not open any playback stream. ${failures.map(describePlaybackFailure).join(" ")}`;
+  return `Playback failed. ${failures.map(describePlaybackFailure).join(" ")}`;
 }
 
 export function browserDecoderEnvironmentWarning() {
@@ -184,10 +184,10 @@ export function browserDecoderEnvironmentWarning() {
   }
 
   if (!window.isSecureContext) {
-    return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable from ${window.location.origin}. Open Cliparr over HTTPS, localhost, or 127.0.0.1 so the editor can decode media. Jellyfin playback can still work on this origin because its native player does not use the same editor decoder APIs.`;
+    return `Browser decoding is blocked on ${window.location.origin}. Open Cliparr over HTTPS, localhost, or 127.0.0.1.`;
   }
 
-  return `Browser WebCodecs ${missingDecoders.join(" and ")} decoding is unavailable in this browser.`;
+  return `Browser ${missingDecoders.join(" and ")} decoding is unavailable.`;
 }
 
 async function assessPreviewVideoTrack(track: InputVideoTrack | null) {

--- a/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
@@ -23,7 +23,7 @@ void test("summarizes disabled subtitle burn-in with and without available track
     providerId: "plex",
   }), {
     label: "Not included",
-    detail: "Subtitle burn-in is currently turned off for this export.",
+    detail: "Subtitles are off.",
     tone: "muted",
     disabledReason: null,
   });
@@ -38,7 +38,7 @@ void test("summarizes disabled subtitle burn-in with and without available track
     providerId: "plex",
   }), {
     label: "Not included",
-    detail: "No supported text subtitle tracks are available for this session.",
+    detail: "No supported subtitles found.",
     tone: "muted",
     disabledReason: null,
   });
@@ -58,10 +58,10 @@ void test("blocks export when the selected subtitle track is unsupported", () =>
     subtitleError: null,
     providerId: "plex",
   }), {
-    label: "Unsupported track",
-    detail: "Plex detected this embedded text subtitle track, but only the currently selected embedded subtitle can be fetched for styled burn-in.",
+    label: "Not supported",
+    detail: "Select this embedded subtitle in Plex first.",
     tone: "warning",
-    disabledReason: "Choose a supported text subtitle track or turn subtitle burn-in off.",
+    disabledReason: "Choose another subtitle track or turn subtitles off.",
   });
 });
 
@@ -75,10 +75,10 @@ void test("blocks export while subtitle cues are loading or errored", () => {
     subtitleError: null,
     providerId: "jellyfin",
   }), {
-    label: "Loading cues",
-    detail: "English SDH is still being prepared for burn-in.",
+    label: "Loading",
+    detail: "Preparing subtitles.",
     tone: "warning",
-    disabledReason: "Subtitles are still loading. Please wait for the cue list to finish loading.",
+    disabledReason: "Subtitles are still loading.",
   });
 
   assert.deepEqual(buildSubtitleExportSummary({
@@ -87,13 +87,13 @@ void test("blocks export while subtitle cues are loading or errored", () => {
     subtitleTrackCount: 1,
     clippedSubtitleCueCount: 0,
     subtitleLoading: false,
-    subtitleError: "Subtitle request timed out. Please try again.",
+    subtitleError: "Subtitles timed out. Try again.",
     providerId: "jellyfin",
   }), {
-    label: "Subtitle issue",
-    detail: "Subtitle request timed out. Please try again.",
+    label: "Issue",
+    detail: "Subtitles timed out. Try again.",
     tone: "warning",
-    disabledReason: "Subtitle request timed out. Please try again.",
+    disabledReason: "Subtitles timed out. Try again.",
   });
 });
 
@@ -107,8 +107,8 @@ void test("summarizes empty and ready cue states", () => {
     subtitleError: null,
     providerId: "jellyfin",
   }), {
-    label: "No cues found",
-    detail: "English SDH has no subtitle cues inside the selected clip range.",
+    label: "None in range",
+    detail: "No subtitles in the selected range.",
     tone: "muted",
     disabledReason: null,
   });
@@ -122,8 +122,8 @@ void test("summarizes empty and ready cue states", () => {
     subtitleError: null,
     providerId: "jellyfin",
   }), {
-    label: "Burned in",
-    detail: "English SDH will be rendered into the exported video frames.",
+    label: "Included",
+    detail: "English SDH will be burned in.",
     tone: "ready",
     disabledReason: null,
   });

--- a/apps/frontend/src/components/editor/subtitleExportSummary.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.ts
@@ -43,9 +43,11 @@ export function buildSubtitleExportSummary({
   if (!selectedSubtitleTrack || !subtitleEnabled) {
     return {
       label: "Not included",
-      detail: subtitleTrackCount > 0
-        ? "Subtitle burn-in is currently turned off for this export."
-        : "No supported text subtitle tracks are available for this session.",
+      detail: !selectedSubtitleTrack
+        ? subtitleTrackCount > 0
+          ? "No subtitle track selected."
+          : "No supported subtitles found."
+        : "Subtitles are off.",
       tone: "muted",
       disabledReason: null,
     };
@@ -55,26 +57,26 @@ export function buildSubtitleExportSummary({
 
   if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
     return {
-      label: "Unsupported track",
+      label: "Not supported",
       detail: subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId)
-        ?? `${trackName} cannot be burned in yet because it is not an exposed text subtitle stream.`,
+        ?? "This subtitle track is not supported.",
       tone: "warning",
-      disabledReason: "Choose a supported text subtitle track or turn subtitle burn-in off.",
+      disabledReason: "Choose another subtitle track or turn subtitles off.",
     };
   }
 
   if (subtitleLoading) {
     return {
-      label: "Loading cues",
-      detail: `${trackName} is still being prepared for burn-in.`,
+      label: "Loading",
+      detail: "Preparing subtitles.",
       tone: "warning",
-      disabledReason: "Subtitles are still loading. Please wait for the cue list to finish loading.",
+      disabledReason: "Subtitles are still loading.",
     };
   }
 
   if (subtitleError) {
     return {
-      label: "Subtitle issue",
+      label: "Issue",
       detail: subtitleError,
       tone: "warning",
       disabledReason: subtitleError,
@@ -83,16 +85,16 @@ export function buildSubtitleExportSummary({
 
   if (clippedSubtitleCueCount === 0) {
     return {
-      label: "No cues found",
-      detail: `${trackName} has no subtitle cues inside the selected clip range.`,
+      label: "None in range",
+      detail: "No subtitles in the selected range.",
       tone: "muted",
       disabledReason: null,
     };
   }
 
   return {
-    label: "Burned in",
-    detail: `${trackName} will be rendered into the exported video frames.`,
+    label: "Included",
+    detail: `${trackName} will be burned in.`,
     tone: "ready",
     disabledReason: null,
   };

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -217,7 +217,7 @@ export function useEditorExport({
     if (!exportSource.source) return;
     if (exporting) return;
     if (endTime <= startTime) {
-      setExportError("Waiting for media duration before export is available.");
+      setExportError("Waiting for media duration.");
       return;
     }
 
@@ -226,12 +226,12 @@ export function useEditorExport({
       && clippedSubtitleCues.length > 0;
 
     if (shouldBurnSubtitles && subtitleLoading) {
-      setExportError("Subtitles are still loading. Please wait a moment and try again.");
+      setExportError("Subtitles are still loading.");
       return;
     }
 
     if (shouldBurnSubtitles && !subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
-      setExportError("This subtitle track cannot be burned in yet.");
+      setExportError("This subtitle track is not supported.");
       return;
     }
 
@@ -426,21 +426,21 @@ function buildExportSourceMessage({
   }
 
   if (resolvedSource.role === "local-file") {
-    return "Export will read the selected local file directly in this browser. The file is not uploaded to the Cliparr server.";
+    return "Export reads this local file in your browser.";
   }
 
   if (resolvedSource.role === "direct-url") {
     return isHlsEditorMediaSource(resolvedSource)
-      ? "Export will read the HLS URL directly in this browser. The Cliparr server is not used as a proxy."
-      : "Export will read the media URL directly in this browser. The Cliparr server is not used as a proxy.";
+      ? "Export reads this HLS URL in your browser."
+      : "Export reads this media URL in your browser.";
   }
 
   if (preference === "hls" && resolvedSourceKind === "hls" && !hlsFallbackInfo) {
-    return "Export will use the HLS playback stream. This follows the media server playback path and can include server-side transcoding.";
+    return "Export uses the HLS playback stream.";
   }
 
   if (resolvedSourceKind === "direct" && !hlsSource && directSource) {
-    return "This session only exposed a direct/original media path, so export will use that source.";
+    return "Export uses direct media.";
   }
 
   if (resolvedSourceKind === "direct" && preference !== "auto") {
@@ -453,16 +453,10 @@ function buildExportSourceMessage({
 
   const exportUsesDirectSource = resolvedSourceKind === "direct";
   const prefix = exportUsesDirectSource
-    ? ({
-        "open-or-read": "Export is using the direct media source because Cliparr could not open or read the HLS stream",
-        "preview-only": "Export is using the direct media source because Cliparr could not use the HLS stream for this export path",
-        "shared-export-blocking": "Export is using the direct media source because Cliparr cannot currently use this HLS stream for export",
-      } as const)[hlsFallbackInfo.category]
-    : ({
-        "open-or-read": "Export will still try the HLS stream even though preview fell back while opening or reading it",
-        "preview-only": "Export will still try the HLS stream because this limitation only affects preview in the current browser",
-        "shared-export-blocking": "Export cannot currently use this HLS stream",
-      } as const)[hlsFallbackInfo.category];
+    ? "Export switched to direct media"
+    : hlsFallbackInfo.category === "shared-export-blocking"
+      ? "Export cannot use this HLS stream"
+      : "Trying HLS";
 
   return `${prefix}: ${hlsFallbackInfo.message}`;
 }
@@ -484,7 +478,7 @@ function buildExportSourceSummaryMessage({
     && resolvedSource?.role === "direct"
     && hlsSource
   ) {
-    return "Export will use the direct/original media path. Cliparr still uses playback metadata for track and timing hints when it is available.";
+    return "Using direct media.";
   }
 
   return null;

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -49,11 +49,8 @@ async function downloadSubtitleCues(
   const response = await fetch(contentUrl, { signal });
   if (!response.ok) {
     const detail = await subtitleDownloadErrorDetail(response);
-    throw new Error(
-      detail
-        ? `Subtitle download failed (${response.status}): ${detail}`
-        : `Subtitle download failed (${response.status})`
-    );
+    console.error("Subtitle download failed", { status: response.status, detail });
+    throw new Error(`Could not load subtitles (${response.status}).`);
   }
 
   return parseSubtitleText(await response.text(), track.contentFormat);
@@ -97,7 +94,7 @@ export function useSubtitleCues({
         setSubtitleCues([]);
         setSubtitleError(
           subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId)
-            ?? "This subtitle track is not yet supported for styled burn-in."
+            ?? "This subtitle track is not supported."
         );
         return;
       }
@@ -118,12 +115,12 @@ export function useSubtitleCues({
         }
 
         setSubtitleCues(parsedSubtitleCues);
-        setSubtitleError(parsedSubtitleCues.length === 0 ? "No subtitle cues were found in this track." : null);
+        setSubtitleError(parsedSubtitleCues.length === 0 ? "No subtitles found in this track." : null);
       } catch (err) {
         if (cancelled || abortController.signal.aborted) {
           if (!cancelled) {
             setSubtitleCues([]);
-            setSubtitleError("Subtitle request timed out. Please try again.");
+            setSubtitleError("Subtitles timed out. Try again.");
             setSubtitleLoading(false);
           }
           return;
@@ -131,7 +128,7 @@ export function useSubtitleCues({
 
         console.error("Could not load subtitle cues", err);
         setSubtitleCues([]);
-        setSubtitleError(err instanceof Error ? err.message : "Could not load subtitle cues.");
+        setSubtitleError(err instanceof Error ? err.message : "Could not load subtitles.");
       } finally {
         if (!cancelled) {
           setSubtitleLoading(false);

--- a/apps/frontend/src/components/useProviderConnectFlow.ts
+++ b/apps/frontend/src/components/useProviderConnectFlow.ts
@@ -35,7 +35,7 @@ export function useProviderConnectFlow({
         }
       } catch (err: unknown) {
         if (!cancelled) {
-          setError(errorMessage(err, "Failed to load providers"));
+          setError(errorMessage(err, "Could not load providers."));
         }
       } finally {
         if (!cancelled) {
@@ -91,12 +91,12 @@ export function useProviderConnectFlow({
         if (status.status === "expired") {
           window.clearInterval(intervalId);
           resetProviderState();
-          setError(`That ${providerLabel(providerId)} sign-in expired. Start again when you're ready.`);
+          setError(`${providerLabel(providerId)} sign-in expired.`);
         }
       } catch (err: unknown) {
         window.clearInterval(intervalId);
         resetProviderState();
-        setError(errorMessage(err, `Failed to finish ${providerLabel(providerId)} sign-in`));
+        setError(errorMessage(err, `Could not finish ${providerLabel(providerId)} sign-in.`));
       }
     };
     const intervalId = window.setInterval(() => {
@@ -120,7 +120,7 @@ export function useProviderConnectFlow({
       window.open(auth.authUrl, "_blank", "noopener,noreferrer");
     } catch (err: unknown) {
       resetProviderState();
-      setError(errorMessage(err, `Failed to start ${provider.name} sign-in`));
+      setError(errorMessage(err, `Could not start ${provider.name} sign-in.`));
     }
   }, [resetProviderState]);
 
@@ -142,7 +142,7 @@ export function useProviderConnectFlow({
       setUsername("");
     } catch (err: unknown) {
       resetProviderState();
-      setError(errorMessage(err, `Failed to connect ${provider.name}`));
+      setError(errorMessage(err, `Could not connect ${provider.name}.`));
     }
   }, [onConnected, password, resetProviderState, serverUrl, username]);
 

--- a/apps/frontend/src/components/useSourcesModalState.ts
+++ b/apps/frontend/src/components/useSourcesModalState.ts
@@ -85,7 +85,7 @@ export function useSourcesModalState({
         return;
       }
 
-      const message = err instanceof Error ? err.message : "Failed to load sources";
+      const message = err instanceof Error ? err.message : "Could not load sources.";
       setSources([]);
       setDraftBaseUrls({});
       setDraftNames({});
@@ -178,7 +178,7 @@ export function useSourcesModalState({
     auth.setProviderSession(session);
     setFeedback({
       tone: "success",
-      message: "Source connected. Refreshing your library list now.",
+      message: "Source connected.",
     });
     setShowAddSource(false);
     await loadSources("reload");
@@ -195,7 +195,7 @@ export function useSourcesModalState({
       return;
     }
 
-    await runSourceAction(source, "Saving...", "Failed to update source", async () => {
+    await runSourceAction(source, "Saving...", "Could not update source.", async () => {
       const updatedSource = await cliparrClient.updateSource(source.id, {
         ...(hasNameChange ? { name: nextName } : {}),
         ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
@@ -215,7 +215,7 @@ export function useSourcesModalState({
     await runSourceAction(
       source,
       source.enabled ? "Disabling..." : "Enabling...",
-      "Failed to update source",
+      "Could not update source.",
       async () => {
         const updatedSource = await cliparrClient.updateSource(source.id, { enabled: !source.enabled });
 
@@ -231,7 +231,7 @@ export function useSourcesModalState({
   }
 
   async function checkSource(source: MediaSource) {
-    await runSourceAction(source, "Refreshing...", "Failed to refresh source", async () => {
+    await runSourceAction(source, "Refreshing...", "Could not refresh source.", async () => {
       const result = await cliparrClient.checkSource(source.id);
 
       return {
@@ -239,7 +239,7 @@ export function useSourcesModalState({
         feedback: {
           tone: result.ok ? "success" : "warning",
           message: result.ok
-            ? `${result.source.name} passed its health check.`
+            ? `${result.source.name} is healthy.`
             : `${result.source.name} still needs attention.`,
         },
       };
@@ -248,13 +248,13 @@ export function useSourcesModalState({
 
   async function deleteSource(source: MediaSource) {
     const confirmed = window.confirm(
-      `Remove ${source.name}? Cliparr will stop querying it until it is reconnected.`
+      `Remove ${source.name}? It can be reconnected later.`
     );
     if (!confirmed) {
       return;
     }
 
-    await runSourceAction(source, "Removing...", "Failed to remove source", async () => {
+    await runSourceAction(source, "Removing...", "Could not remove source.", async () => {
       await cliparrClient.deleteSource(source.id);
 
       return {
@@ -317,16 +317,16 @@ export function useSourcesModalState({
         `${attentionCount} need attention`,
       ];
       if (failedCount > 0) {
-        summaryParts.push(`${failedCount} failed to refresh`);
+        summaryParts.push(`${failedCount} failed`);
       }
 
       setFeedback({
         tone: attentionCount > 0 || failedCount > 0 ? "warning" : "success",
-        message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}: ${summaryParts.join(", ")}.`,
+        message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}. ${summaryParts.join(", ")}.`,
       });
       await refreshPlaybackView();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to refresh sources";
+      const message = err instanceof Error ? err.message : "Could not refresh sources.";
       setError(message);
     } finally {
       setRefreshingAll(false);

--- a/apps/frontend/src/lib/localMediaRegistry.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.ts
@@ -398,14 +398,14 @@ export async function resolveLocalMediaSession(
   } catch {
     return {
       status: "unavailable",
-      message: "Local media storage is unavailable. Reopen the file or URL to continue.",
+      message: "Reopen this file or URL to continue.",
     };
   }
 
   if (!storedRecord) {
     return {
       status: "missing",
-      message: "This local video is no longer available in this tab. Reopen it to continue.",
+      message: "This local video is no longer available. Reopen it to continue.",
     };
   }
 
@@ -421,7 +421,7 @@ export async function resolveLocalMediaSession(
         status: "permission-needed",
         id: storedRecord.id,
         title: storedRecord.title,
-        message: "Cliparr needs permission to reopen this local file.",
+        message: "Allow access to reopen this file.",
       };
     }
 
@@ -444,14 +444,14 @@ export async function resolveLocalMediaSession(
         status: "permission-needed",
         id: storedRecord.id,
         title: storedRecord.title,
-        message: "Cliparr needs permission to reopen this local file.",
+        message: "Allow access to reopen this file.",
       };
     }
 
     return {
       status: "unavailable",
       title: storedRecord.title,
-      message: "This local file could not be reopened. It may have moved or changed permissions.",
+      message: "Could not reopen this file.",
     };
   }
 }

--- a/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
+++ b/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
@@ -30,14 +30,14 @@ export function subtitleTrackUnavailableMessage(
   }
 
   if (track.isText && providerId === "plex") {
-    return "Plex detected this embedded text subtitle track, but only the currently selected embedded subtitle can be fetched for styled burn-in.";
+    return "Select this embedded subtitle in Plex first.";
   }
 
   if (track.isText) {
-    return "This text subtitle track is available, but the provider does not expose it as a downloadable subtitle stream for styled burn-in.";
+    return "This provider cannot download this subtitle track.";
   }
 
-  return "This subtitle track exists, but it is not yet supported for styled burn-in.";
+  return "Only text subtitle tracks are supported.";
 }
 
 export function selectPreferredSubtitleTrack(

--- a/apps/frontend/src/routes/_app.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/_app.edit.$sessionId.tsx
@@ -46,7 +46,7 @@ function EditorRouteComponent() {
       } catch (err: unknown) {
         if (!cancelled) {
           setSession(null);
-          setError(errorMessage(err, "Failed to load this playback session."));
+          setError(errorMessage(err, "Could not load this session."));
         }
       } finally {
         if (!cancelled) {

--- a/apps/frontend/src/routes/local.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/local.edit.$sessionId.tsx
@@ -51,7 +51,7 @@ function LocalEditorRouteComponent() {
   }
 
   const title = resolution?.title ?? "Local video";
-  const message = resolution?.message ?? "This local video could not be opened.";
+  const message = resolution?.message ?? "Could not open this video.";
   const needsPermission = resolution?.status === "permission-needed";
 
   return (


### PR DESCRIPTION
## Summary
- Tighten verbose frontend copy across subtitle, export, provider, source, local media, and dashboard flows.
- Add app-style tooltips for icon controls and disabled actions where the reason is useful.
- Keep diagnostic detail in console/debug paths while simplifying user-facing messages.

## Impact
Users see shorter, more actionable status and error text, plus discoverable hints for disabled controls without adding more visible copy.

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint
- pnpm --filter @cliparr/frontend build