### PR TITLE
[codex] Fix HLS playlist preview seeking

### DIFF
--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -18,6 +18,7 @@ import {
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
+  shouldForwardMediaRange,
 } from "../shared/mediaProxy.js";
 import {
   isTextSubtitleCodec,
@@ -756,7 +757,8 @@ export async function proxyMedia(
         accept,
       })
     : new Headers(accept ? { Accept: accept } : undefined);
-  const range = req.header("range");
+  const requestedRange = req.header("range") ?? undefined;
+  const range = shouldForwardMediaRange(handle, requestedRange);
   if (range) {
     headers.set("Range", range);
   }

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -12,6 +12,7 @@ import {
   proxyUpstreamMediaResponse,
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
+  shouldForwardMediaRange,
 } from "./shared/mediaProxy.js";
 
 function createSession(): ProviderSessionRecord {
@@ -166,6 +167,56 @@ void test("preserves absolute HLS origins when rewriting nested playlist resourc
   const handlePaths = [...session.mediaHandles.values()].map((handle) => handle.path);
   assert(handlePaths.includes("https://cdn.example.com/hls/720p/key.key?sig=1"));
   assert(handlePaths.includes("https://cdn.example.com/hls/720p/segment0.ts"));
+});
+
+void test("strips HLS start hints so editor seeks control playback position", async () => {
+  const session = createSession();
+  const handle = createMediaHandle();
+  const response = createResponseRecorder();
+
+  await proxyUpstreamMediaResponse(
+    session,
+    handle,
+    new globalThis.Response(
+      [
+        "#EXTM3U",
+        "#EXT-X-TARGETDURATION:1",
+        "#EXT-X-START:TIME-OFFSET=1054.000000",
+        "#EXTINF:1, nodesc",
+        "segment0.ts",
+        "#EXT-X-ENDLIST",
+        "",
+      ].join("\n"),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.apple.mpegurl",
+        },
+      }
+    ),
+    response as unknown as Response
+  );
+
+  assert.doesNotMatch(response.body, /#EXT-X-START/);
+  assert.match(response.body, /#EXT-X-TARGETDURATION:1/);
+  assert.match(response.body, /#EXTINF:1, nodesc/);
+  assert.match(response.body, /\/api\/media\//);
+  assert.equal(session.mediaHandles.size, 1);
+});
+
+void test("does not forward range requests for HLS playlists that Cliparr rewrites", () => {
+  assert.equal(
+    shouldForwardMediaRange(createMediaHandle({
+      path: "/video/:/transcode/universal/start.m3u8?session=1",
+    }), "bytes=148-"),
+    undefined,
+  );
+  assert.equal(
+    shouldForwardMediaRange(createMediaHandle({
+      path: "/library/parts/1/file.mp4",
+    }), "bytes=148-"),
+    "bytes=148-",
+  );
 });
 
 void test("does not attach provider auth to cross-origin absolute media handles", () => {

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -20,6 +20,7 @@ import {
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
+  shouldForwardMediaRange,
 } from "../shared/mediaProxy.js";
 import {
   booleanFlag,
@@ -999,7 +1000,8 @@ export async function proxyMedia(
     : new Headers();
 
   const accept = req.header("accept");
-  const range = req.header("range");
+  const requestedRange = req.header("range") ?? undefined;
+  const range = shouldForwardMediaRange(handle, requestedRange);
   if (accept) {
     headers.set("Accept", accept);
   }

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -421,24 +421,30 @@ async function rewriteHlsPlaylist(
   const body = await upstream.text();
   const basePath = handle.basePath ?? playlistBasePath(handle.path);
   let rewrittenUriCount = 0;
+  let strippedStartHintCount = 0;
 
   const playlist = body
     .split("\n")
-    .map((line) => {
+    .flatMap((line) => {
       const trimmed = line.trim();
       if (!trimmed) {
-        return line;
+        return [line];
       }
 
       if (trimmed.startsWith("#")) {
-        return line.replace(/URI="([^"]+)"/g, (_match, uri: string) => {
+        if (trimmed.toUpperCase().startsWith("#EXT-X-START:")) {
+          strippedStartHintCount += 1;
+          return [];
+        }
+
+        return [line.replace(/URI="([^"]+)"/g, (_match, uri: string) => {
           rewrittenUriCount += 1;
           return `URI="${rewritePlaylistUri(session, handle, basePath, uri)}"`;
-        });
+        })];
       }
 
       rewrittenUriCount += 1;
-      return rewritePlaylistUri(session, handle, basePath, trimmed);
+      return [rewritePlaylistUri(session, handle, basePath, trimmed)];
     })
     .join("\n");
 
@@ -450,6 +456,7 @@ async function rewriteHlsPlaylist(
     basePath: sanitizeLoggedMediaPath(basePath),
     upstreamStatus: upstream.status,
     rewrittenUriCount,
+    strippedStartHintCount,
   });
 
   return playlist;
@@ -481,6 +488,14 @@ function isHlsPlaylist(handle: MediaHandle, contentType: string) {
   } catch {
     return handle.path.split("?")[0].endsWith(".m3u8");
   }
+}
+
+export function shouldForwardMediaRange(handle: MediaHandle, range: string | undefined) {
+  if (!range || isHlsPlaylist(handle, "")) {
+    return undefined;
+  }
+
+  return range;
 }
 
 function snapshotProxyHeaders(upstream: globalThis.Response) {


### PR DESCRIPTION
## Summary
- Strip upstream `#EXT-X-START` hints from proxied HLS playlists so Cliparr editor seeks own the preview position.
- Stop forwarding `Range` headers for rewritten HLS playlist requests so generated `/api/media/...` handles cannot be truncated by partial playlist responses.
- Apply playlist range handling to both Plex and Jellyfin proxy paths.

## Root Cause
Plex can return HLS playlists with `#EXT-X-START:TIME-OFFSET=...`. MediaBunny honored that playlist hint instead of Cliparr's provider playhead, which made the UI jump to the Plex playhead while the decoded preview stayed at a different time. The browser also issued range requests for playlists after Cliparr rewrote segment URLs, which could slice through generated media handle ids and cause missing-handle failures.

## Validation
- `pnpm --filter @cliparr/server test -- mediaProxy plexPlayback jellyfinPlayback`
- `pnpm --filter @cliparr/server lint:types`
- `pnpm --filter @cliparr/server lint:eslint`
- `git diff --check origin/main`
- Manual retest confirmed this fixed the Plex preview freeze.