### PR TITLE
[codex] Proxy local URL media

### DIFF
--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -19,6 +19,11 @@ interface HealthResponse {
   version?: string;
 }
 
+interface LocalMediaUrlResponse {
+  mediaUrl: string;
+  hls: boolean;
+}
+
 class CliparrRequestError extends Error {
   status: number;
   code?: string;
@@ -212,5 +217,12 @@ export const cliparrClient = {
 
   async getCurrentlyPlaying() {
     return request<CurrentlyPlayingResponse>("/api/media/currently-playing");
+  },
+
+  async createLocalMediaUrl(url: string) {
+    return request<LocalMediaUrlResponse>("/api/media/local-url", {
+      method: "POST",
+      body: JSON.stringify({ url }),
+    });
   },
 };

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -20,7 +20,10 @@ import { EditorPlaybackSourcePanel } from "./editor/EditorPlaybackSourcePanel";
 import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
 import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
-import { buildInitialClipRange } from "./editor/initialClipRange";
+import {
+  buildClipRangeAfterDurationDiscovery,
+  buildInitialClipRange,
+} from "./editor/initialClipRange";
 import { useSubtitleCues } from "./editor/useSubtitleCues";
 import type { PlaybackSubtitleTrack } from "../providers/types";
 import { sourceDisplayLabel, type EditorSession } from "../lib/editorMedia";
@@ -262,12 +265,32 @@ export default function EditorScreen({ session, onBack }: Props) {
       return;
     }
 
+    const discoveredInitialRange = buildClipRangeAfterDurationDiscovery({
+      initialDuration: session.duration,
+      currentStartTime: startTime,
+      currentEndTime: endTime,
+      discoveredDuration: duration,
+      playheadSeconds: session.initialPlayheadSeconds,
+    });
+    if (discoveredInitialRange) {
+      updateClipRange(discoveredInitialRange.startTime, discoveredInitialRange.endTime);
+      return;
+    }
+
     if (isValidTimelineRange(startTime, endTime)) {
       return;
     }
 
     updateClipRange(startTime, endTime);
-  }, [duration, endTime, isValidTimelineRange, startTime, updateClipRange]);
+  }, [
+    duration,
+    endTime,
+    isValidTimelineRange,
+    session.duration,
+    session.initialPlayheadSeconds,
+    startTime,
+    updateClipRange,
+  ]);
 
   useEffect(() => {
     saveSubtitleStyleSettings(subtitleStyleSettings);

--- a/apps/frontend/src/components/LocalVideoOpenModal.tsx
+++ b/apps/frontend/src/components/LocalVideoOpenModal.tsx
@@ -148,7 +148,7 @@ export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpe
               Open Video
             </h2>
             <p className="text-xs text-muted-foreground">
-              Local files stay in your browser. URL media must allow browser reads.
+              Local files stay in your browser. URL media is read through Cliparr.
             </p>
           </div>
           <button
@@ -262,7 +262,7 @@ export function LocalVideoOpenModal({ isOpen, onClose, onOpened }: LocalVideoOpe
                 />
               </label>
               <p className="text-xs leading-5 text-muted-foreground">
-                Direct media files and HLS playlists can work when the remote server permits CORS and byte-range requests from this browser.
+                Direct media files and HLS playlists can work when the remote server permits server-side reads and byte-range requests.
               </p>
               <div className="flex justify-end">
                 <button

--- a/apps/frontend/src/components/editor/initialClipRange.test.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.test.ts
@@ -2,7 +2,10 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildInitialClipRange } from "./initialClipRange";
+import {
+  buildClipRangeAfterDurationDiscovery,
+  buildInitialClipRange,
+} from "./initialClipRange";
 
 void test("starts initial clip range at zero when no playhead is available", () => {
   assert.deepEqual(buildInitialClipRange(120), {
@@ -31,4 +34,31 @@ void test("keeps rounded initial clip range within odd sub-second bounds", () =>
   assert.equal(range.endTime, 0.205);
   assert.equal(range.startTime <= 0.105, true);
   assert.equal(range.endTime <= 0.205, true);
+});
+
+void test("rebuilds initial clip range when duration is discovered later", () => {
+  assert.deepEqual(buildClipRangeAfterDurationDiscovery({
+    initialDuration: 0,
+    currentStartTime: 0,
+    currentEndTime: 0,
+    discoveredDuration: 120,
+  }), {
+    startTime: 0,
+    endTime: 10,
+  });
+});
+
+void test("does not replace an existing clip range when duration is discovered later", () => {
+  assert.equal(buildClipRangeAfterDurationDiscovery({
+    initialDuration: 0,
+    currentStartTime: 0,
+    currentEndTime: 0.1,
+    discoveredDuration: 120,
+  }), null);
+  assert.equal(buildClipRangeAfterDurationDiscovery({
+    initialDuration: 120,
+    currentStartTime: 0,
+    currentEndTime: 10,
+    discoveredDuration: 120,
+  }), null);
 });

--- a/apps/frontend/src/components/editor/initialClipRange.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.ts
@@ -7,6 +7,14 @@ export interface InitialClipRange {
   endTime: number;
 }
 
+interface DiscoveredDurationClipRangeInput {
+  initialDuration: number;
+  currentStartTime: number;
+  currentEndTime: number;
+  discoveredDuration: number;
+  playheadSeconds?: number;
+}
+
 function finiteNonNegativeSeconds(value: number | null | undefined) {
   const seconds = Number(value);
   return Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
@@ -41,4 +49,23 @@ export function buildInitialClipRange(duration: number, playheadSeconds?: number
     startTime,
     endTime,
   };
+}
+
+export function buildClipRangeAfterDurationDiscovery({
+  initialDuration,
+  currentStartTime,
+  currentEndTime,
+  discoveredDuration,
+  playheadSeconds,
+}: DiscoveredDurationClipRangeInput): InitialClipRange | null {
+  if (
+    finiteNonNegativeSeconds(initialDuration) > 0
+    || finiteNonNegativeSeconds(discoveredDuration) <= 0
+    || currentStartTime !== 0
+    || currentEndTime !== 0
+  ) {
+    return null;
+  }
+
+  return buildInitialClipRange(discoveredDuration, playheadSeconds);
 }

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -431,8 +431,8 @@ function buildExportSourceMessage({
 
   if (resolvedSource.role === "direct-url") {
     return isHlsEditorMediaSource(resolvedSource)
-      ? "Export will read the HLS URL directly in this browser. The Cliparr server is not used as a proxy."
-      : "Export will read the media URL directly in this browser. The Cliparr server is not used as a proxy.";
+      ? "Export will read the HLS URL through Cliparr so remote CORS settings do not block the browser."
+      : "Export will read the media URL through Cliparr so remote CORS settings do not block the browser.";
   }
 
   if (preference === "hls" && resolvedSourceKind === "hls" && !hlsFallbackInfo) {

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -30,6 +30,7 @@ interface BaseEditorMediaSource {
 export interface EditorUrlMediaSource extends BaseEditorMediaSource {
   kind: "url";
   url: string;
+  originalUrl?: string;
   hls?: boolean;
 }
 

--- a/apps/frontend/src/lib/localMediaRegistry.test.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.test.ts
@@ -11,6 +11,41 @@ import {
   validateLocalMediaUrl,
 } from "./localMediaRegistry";
 
+async function withMockedLocalMediaUrl<T>(callback: () => Promise<T>) {
+  const originalFetch = globalThis.fetch;
+  let requestCount = 0;
+
+  globalThis.fetch = (async (input, init) => {
+    assert.equal(input, "/api/media/local-url");
+    assert.equal(init?.method, "POST");
+    requestCount += 1;
+
+    const requestBody = init?.body;
+    assert.equal(typeof requestBody, "string");
+    if (typeof requestBody !== "string") {
+      throw new Error("Expected JSON request body.");
+    }
+    const body = JSON.parse(requestBody) as { url?: string };
+    assert.equal(body.url, "https://example.com/video.mp4");
+
+    return new Response(JSON.stringify({
+      mediaUrl: `/api/media/local-url/proxy-${requestCount}`,
+      hls: false,
+    }), {
+      status: 201,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    return await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 void test("validates local media URLs", () => {
   assert.deepEqual(validateLocalMediaUrl(""), {
     ok: false,
@@ -39,16 +74,27 @@ void test("creates and resolves memory-backed local file sessions", async () => 
 });
 
 void test("creates and resolves memory-backed URL sessions when IndexedDB is unavailable", async () => {
-  const result = await createLocalSessionFromUrl("https://example.com/video.mp4");
+  await withMockedLocalMediaUrl(async () => {
+    const result = await createLocalSessionFromUrl("https://example.com/video.mp4");
 
-  assert.equal(result.status, "ready");
-  assert.equal(result.status === "ready" ? result.session.directSource?.kind : null, "url");
+    assert.equal(result.status, "ready");
+    assert.equal(result.status === "ready" ? result.session.directSource?.kind : null, "url");
+    assert.equal(result.status === "ready" && result.session.directSource?.kind === "url"
+      ? result.session.directSource.url
+      : null, "/api/media/local-url/proxy-1");
+    assert.equal(result.status === "ready" && result.session.directSource?.kind === "url"
+      ? result.session.directSource.originalUrl
+      : null, "https://example.com/video.mp4");
 
-  const resolved = result.status === "ready"
-    ? await resolveLocalMediaSession(result.session.id)
-    : null;
-  assert.equal(resolved?.status, "ready");
-  assert.equal(resolved?.status === "ready" ? resolved.session.directSource?.kind : null, "url");
+    const resolved = result.status === "ready"
+      ? await resolveLocalMediaSession(result.session.id)
+      : null;
+    assert.equal(resolved?.status, "ready");
+    assert.equal(resolved?.status === "ready" ? resolved.session.directSource?.kind : null, "url");
+    assert.equal(resolved?.status === "ready" && resolved.session.directSource?.kind === "url"
+      ? resolved.session.directSource.url
+      : null, "/api/media/local-url/proxy-2");
+  });
 });
 
 void test("resolves file handle permission states", async () => {

--- a/apps/frontend/src/lib/localMediaRegistry.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.ts
@@ -9,6 +9,7 @@ import {
   titleFromFileName,
   titleFromUrl,
 } from "./editorMedia";
+import { cliparrClient } from "../api/cliparrClient";
 import { isHlsPlaylistUrl } from "./mediabunnyInput";
 
 const DATABASE_NAME = "cliparr-local-media";
@@ -186,17 +187,24 @@ function createFileHandleSource(record: StoredFileHandleRecord): EditorFileHandl
   };
 }
 
-function createUrlSource(record: StoredUrlRecord): EditorUrlMediaSource {
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+async function createUrlSource(record: StoredUrlRecord): Promise<EditorUrlMediaSource> {
+  const proxied = await cliparrClient.createLocalMediaUrl(record.url);
+
   return {
     kind: "url",
     role: "direct-url",
     label: record.hls ? "HLS URL" : "URL",
-    url: record.url,
-    hls: record.hls,
+    url: proxied.mediaUrl,
+    originalUrl: record.url,
+    hls: record.hls || proxied.hls,
   };
 }
 
-function sessionFromRecord(record: LocalMediaRecord) {
+async function sessionFromRecord(record: LocalMediaRecord) {
   if (record.kind === "memory-file") {
     return buildLocalEditorSession({
       id: record.id,
@@ -216,7 +224,7 @@ function sessionFromRecord(record: LocalMediaRecord) {
   return buildLocalEditorSession({
     id: record.id,
     title: record.title,
-    source: createUrlSource(record),
+    source: await createUrlSource(record),
   });
 }
 
@@ -340,7 +348,7 @@ export async function createLocalSessionFromPicker() {
 
     return {
       status: "ready" as const,
-      session: sessionFromRecord(record),
+      session: await sessionFromRecord(record),
     };
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") {
@@ -374,12 +382,22 @@ export async function createLocalSessionFromUrl(value: string) {
     updatedAt: timestamps,
   };
 
+  let session: EditorSession;
+  try {
+    session = await sessionFromRecord(record);
+  } catch (err) {
+    return {
+      status: "invalid" as const,
+      message: errorMessage(err, "Could not open that URL."),
+    };
+  }
+
   memoryRecords.set(record.id, record);
   await putStoredRecord(record).catch(() => undefined);
 
   return {
     status: "ready" as const,
-    session: sessionFromRecord(record),
+    session,
   };
 }
 
@@ -389,7 +407,15 @@ export async function resolveLocalMediaSession(
 ): Promise<LocalMediaResolution> {
   const memoryRecord = memoryRecords.get(id);
   if (memoryRecord) {
-    return { status: "ready", session: sessionFromRecord(memoryRecord) };
+    try {
+      return { status: "ready", session: await sessionFromRecord(memoryRecord) };
+    } catch (err) {
+      return {
+        status: "unavailable",
+        title: memoryRecord.title,
+        message: errorMessage(err, "This local video URL could not be opened."),
+      };
+    }
   }
 
   let storedRecord: StoredLocalMediaRecord | undefined;
@@ -410,7 +436,15 @@ export async function resolveLocalMediaSession(
   }
 
   if (storedRecord.kind === "url") {
-    return { status: "ready", session: sessionFromRecord(storedRecord) };
+    try {
+      return { status: "ready", session: await sessionFromRecord(storedRecord) };
+    } catch (err) {
+      return {
+        status: "unavailable",
+        title: storedRecord.title,
+        message: errorMessage(err, "This local video URL could not be opened."),
+      };
+    }
   }
 
   try {
@@ -437,7 +471,7 @@ export async function resolveLocalMediaSession(
 
     await putStoredRecord(nextRecord).catch(() => undefined);
 
-    return { status: "ready", session: sessionFromRecord(nextRecord) };
+    return { status: "ready", session: await sessionFromRecord(nextRecord) };
   } catch (err) {
     if (err instanceof DOMException && err.name === "NotAllowedError") {
       return {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -169,6 +169,50 @@ void test("preserves absolute HLS origins when rewriting nested playlist resourc
   assert(handlePaths.includes("https://cdn.example.com/hls/720p/segment0.ts"));
 });
 
+void test("uses custom media handle URLs when rewriting HLS playlists", async () => {
+  const session = createSession();
+  const rootHandle = createMediaHandle({
+    path: "https://cdn.example.com/hls/master.m3u8",
+    basePath: "https://cdn.example.com/hls/",
+  });
+  const response = createResponseRecorder();
+  const createdHandles: Array<{ nextPath: string; basePath: string }> = [];
+
+  await proxyUpstreamMediaResponse(
+    session,
+    rootHandle,
+    new globalThis.Response(
+      "#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI=\"key.key?sig=1\"\nsegment0.ts\n",
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.apple.mpegurl",
+        },
+      }
+    ),
+    response as unknown as Response,
+    {
+      createMediaHandleUrl: (_session, _handle, nextPath, basePath) => {
+        createdHandles.push({ nextPath, basePath });
+        return `/api/media/local-url/${createdHandles.length}`;
+      },
+    }
+  );
+
+  assert.match(response.body, /\/api\/media\/local-url\/1/);
+  assert.match(response.body, /\/api\/media\/local-url\/2/);
+  assert.deepEqual(createdHandles, [
+    {
+      nextPath: "https://cdn.example.com/hls/key.key?sig=1",
+      basePath: "https://cdn.example.com/hls/",
+    },
+    {
+      nextPath: "https://cdn.example.com/hls/segment0.ts",
+      basePath: "https://cdn.example.com/hls/",
+    },
+  ]);
+});
+
 void test("strips HLS start hints so editor seeks control playback position", async () => {
   const session = createSession();
   const handle = createMediaHandle();

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -27,6 +27,15 @@ interface ProxyMediaRequestOptions {
   range?: string;
 }
 
+interface ProxyMediaResponseOptions {
+  createMediaHandleUrl?: (
+    session: ProviderSessionRecord,
+    handle: MediaHandle,
+    nextPath: string,
+    basePath: string,
+  ) => string;
+}
+
 interface CachedProxyMediaResponse {
   status: number;
   headers: [string, string][];
@@ -399,9 +408,14 @@ function rewritePlaylistUri(
   session: ProviderSessionRecord,
   handle: MediaHandle,
   basePath: string,
-  uri: string
+  uri: string,
+  options: ProxyMediaResponseOptions = {},
 ) {
   const nextPath = resolvePlaylistUri(basePath, uri);
+  if (options.createMediaHandleUrl) {
+    return options.createMediaHandleUrl(session, handle, nextPath, playlistBasePath(nextPath));
+  }
+
   return createProviderMediaHandle(session, {
     providerId: handle.providerId,
     sourceId: handle.sourceId,
@@ -416,7 +430,8 @@ function rewritePlaylistUri(
 async function rewriteHlsPlaylist(
   session: ProviderSessionRecord,
   handle: MediaHandle,
-  upstream: globalThis.Response
+  upstream: globalThis.Response,
+  options: ProxyMediaResponseOptions = {},
 ) {
   const body = await upstream.text();
   const basePath = handle.basePath ?? playlistBasePath(handle.path);
@@ -439,12 +454,12 @@ async function rewriteHlsPlaylist(
 
         return [line.replace(/URI="([^"]+)"/g, (_match, uri: string) => {
           rewrittenUriCount += 1;
-          return `URI="${rewritePlaylistUri(session, handle, basePath, uri)}"`;
+          return `URI="${rewritePlaylistUri(session, handle, basePath, uri, options)}"`;
         })];
       }
 
       rewrittenUriCount += 1;
-      return [rewritePlaylistUri(session, handle, basePath, trimmed)];
+      return [rewritePlaylistUri(session, handle, basePath, trimmed, options)];
     })
     .join("\n");
 
@@ -556,12 +571,13 @@ async function createCachedProxyMediaResponse(
   session: ProviderSessionRecord,
   handle: MediaHandle,
   upstream: globalThis.Response,
+  options: ProxyMediaResponseOptions = {},
 ) {
   const contentType = upstream.headers.get("content-type") ?? "";
   const headers = snapshotProxyHeaders(upstream);
 
   if (isHlsPlaylist(handle, contentType)) {
-    const playlist = await rewriteHlsPlaylist(session, handle, upstream);
+    const playlist = await rewriteHlsPlaylist(session, handle, upstream, options);
     const body = Buffer.from(playlist);
     const nextHeaders = headers
       .filter(([name]) => name !== "content-type" && name !== "content-length")
@@ -628,7 +644,8 @@ export async function proxyUpstreamMediaResponse(
   session: ProviderSessionRecord,
   handle: MediaHandle,
   upstream: globalThis.Response,
-  res: Response
+  res: Response,
+  options: ProxyMediaResponseOptions = {},
 ) {
   res.status(upstream.status);
 
@@ -643,7 +660,7 @@ export async function proxyUpstreamMediaResponse(
   });
 
   if (isHlsPlaylist(handle, contentType)) {
-    const playlist = await rewriteHlsPlaylist(session, handle, upstream);
+    const playlist = await rewriteHlsPlaylist(session, handle, upstream, options);
     copyProxyHeaders(upstream, res);
     res.setHeader("Content-Type", "application/vnd.apple.mpegurl");
     res.setHeader("Content-Length", Buffer.byteLength(playlist));
@@ -700,6 +717,7 @@ export async function proxyProviderMediaResponse(
   request: ProxyMediaRequestOptions,
   fetchUpstream: () => Promise<globalThis.Response>,
   res: Response,
+  options: ProxyMediaResponseOptions = {},
 ) {
   const cacheKey = buildProxyCacheKey(handle, request);
   if (!cacheKey) {
@@ -727,7 +745,7 @@ export async function proxyProviderMediaResponse(
   if (!inflightResponse) {
     inflightResponse = (async () => {
       const upstream = await fetchUpstream();
-      const response = await createCachedProxyMediaResponse(session, handle, upstream);
+      const response = await createCachedProxyMediaResponse(session, handle, upstream, options);
 
       if (response.body.byteLength <= HLS_PROXY_RESPONSE_CACHE_MAX_BYTES) {
         cachedProxyResponses.set(cacheKey, {

--- a/apps/server/src/routes/media.test.ts
+++ b/apps/server/src/routes/media.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import { errorHandler } from "../http/errors.js";
+import { mediaRouter } from "./media.js";
+
+async function withMediaApp<T>(callback: (baseUrl: string) => Promise<T>) {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/media", mediaRouter);
+  app.use(errorHandler);
+
+  const server = app.listen(0, "127.0.0.1");
+
+  try {
+    await new Promise((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve(undefined));
+    });
+  }
+}
+
+void test("creates and proxies local URL media handles", async () => {
+  await withMediaApp(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/media/local-url`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        url: "http://1.1.1.1/video.mp4",
+      }),
+    });
+
+    assert.equal(createResponse.status, 201);
+    const created = await createResponse.json() as { mediaUrl?: string; hls?: boolean };
+    assert.match(created.mediaUrl ?? "", /^\/api\/media\/local-url\//);
+    assert.equal(created.hls, false);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const requestUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (requestUrl.startsWith(baseUrl)) {
+        return originalFetch(input, init);
+      }
+
+      assert.equal(requestUrl, "http://1.1.1.1/video.mp4");
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("range"), "bytes=0-3");
+      assert.equal(headers.get("accept"), "video/mp4");
+
+      return new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 206,
+        headers: {
+          "accept-ranges": "bytes",
+          "content-range": "bytes 0-3/4",
+          "content-type": "video/mp4",
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const proxyResponse = await originalFetch(`${baseUrl}${created.mediaUrl}`, {
+        headers: {
+          accept: "video/mp4",
+          range: "bytes=0-3",
+        },
+      });
+      assert.equal(proxyResponse.status, 206);
+      assert.equal(proxyResponse.headers.get("content-type"), "video/mp4");
+      assert.deepEqual(new Uint8Array(await proxyResponse.arrayBuffer()), new Uint8Array([1, 2, 3, 4]));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+void test("rejects local URL media handles for internal addresses", async () => {
+  await withMediaApp(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/media/local-url`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        url: "http://127.0.0.1/video.mp4",
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    const body = await response.json() as { error?: { code?: string } };
+    assert.equal(body.error?.code, "media_proxy_unsafe_url");
+  });
+});

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -1,15 +1,42 @@
+import { randomUUID } from "crypto";
 import { Router } from "express";
 import { listMediaSources } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getServerLogger } from "../logging.js";
 import { getProvider } from "../providers/registry.js";
-import { sanitizeLoggedMediaPath } from "../providers/shared/mediaProxy.js";
-import type { CurrentlyPlayingEntry, SourcePlaybackError, ViewerPlaybackGroup } from "../providers/types.js";
+import {
+  assertAllowedMediaHandleRequestUrl,
+  fetchMediaHandleRequest,
+  mediaHandleRequestUrl,
+  proxyProviderMediaResponse,
+  sanitizeLoggedMediaPath,
+  shouldForwardMediaRange,
+} from "../providers/shared/mediaProxy.js";
+import type {
+  CurrentlyPlayingEntry,
+  MediaHandle,
+  SourcePlaybackError,
+  ViewerPlaybackGroup,
+} from "../providers/types.js";
 import { requireAccountSession, setNoStore } from "../session/request.js";
-import { pruneSessionMediaHandles } from "../session/store.js";
+import { pruneSessionMediaHandles, type ProviderSessionRecord } from "../session/store.js";
 
 export const mediaRouter = Router();
 const logger = getServerLogger(["routes", "media"]);
+const LOCAL_URL_PROVIDER_ID = "local-url";
+const LOCAL_URL_SOURCE_ID = "remote-url";
+const LOCAL_URL_MEDIA_BASE_URL = "http://cliparr.local";
+const HLS_PLAYLIST_PATTERN = /\.m3u8(?:$|[?#])/i;
+const localUrlMediaHandles = new Map<string, MediaHandle>();
+const localUrlSession: ProviderSessionRecord = {
+  id: "local-url",
+  providerId: LOCAL_URL_PROVIDER_ID,
+  providerAccountId: LOCAL_URL_SOURCE_ID,
+  userToken: "",
+  mediaHandles: localUrlMediaHandles,
+  createdAt: 0,
+  expiresAt: Number.MAX_SAFE_INTEGER,
+};
 
 function compareStrings(left: string, right: string) {
   return left.localeCompare(right, undefined, { sensitivity: "base" });
@@ -54,6 +81,168 @@ function errorMessage(err: unknown) {
 
   return "Unknown error";
 }
+
+function bodyUrl(value: unknown) {
+  const body = value && typeof value === "object" ? value as { url?: unknown } : null;
+  if (typeof body?.url !== "string") {
+    throw new ApiError(400, "local_media_url_invalid", "Media URL is required");
+  }
+
+  return body.url;
+}
+
+function parseLocalMediaUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ApiError(400, "local_media_url_invalid", "Media URL is required");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new ApiError(400, "local_media_url_invalid", "Enter a valid absolute media URL");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ApiError(400, "local_media_url_invalid", "Media URL must use HTTP or HTTPS");
+  }
+
+  return parsed;
+}
+
+function localUrlMediaPath(handleId: string) {
+  return `/api/media/local-url/${handleId}`;
+}
+
+function isHlsPlaylistUrl(url: string) {
+  return HLS_PLAYLIST_PATTERN.test(url);
+}
+
+function buildLocalUrlMediaHandle(value: string, basePath?: string): MediaHandle {
+  const url = parseLocalMediaUrl(value);
+
+  return {
+    id: randomUUID(),
+    providerId: LOCAL_URL_PROVIDER_ID,
+    sourceId: LOCAL_URL_SOURCE_ID,
+    baseUrl: LOCAL_URL_MEDIA_BASE_URL,
+    path: url.toString(),
+    token: "",
+    basePath,
+    lastAccessedAt: Date.now(),
+  };
+}
+
+function storeLocalUrlMediaHandle(handle: MediaHandle) {
+  localUrlMediaHandles.set(handle.id, handle);
+  return localUrlMediaPath(handle.id);
+}
+
+function createLocalUrlMediaHandleUrl(
+  _session: ProviderSessionRecord,
+  _handle: MediaHandle,
+  nextPath: string,
+  basePath: string,
+) {
+  return storeLocalUrlMediaHandle(buildLocalUrlMediaHandle(nextPath, basePath));
+}
+
+mediaRouter.post(
+  "/local-url",
+  asyncHandler(async (req, res) => {
+    setNoStore(res);
+    pruneSessionMediaHandles(localUrlSession);
+
+    const handle = buildLocalUrlMediaHandle(bodyUrl(req.body));
+    await assertAllowedMediaHandleRequestUrl(handle);
+    const mediaUrl = storeLocalUrlMediaHandle(handle);
+
+    logger.trace("Created local URL media handle {handleId}.", {
+      handleId: handle.id,
+      upstreamUrl: sanitizeLoggedMediaPath(handle.path),
+      hls: isHlsPlaylistUrl(handle.path),
+    });
+
+    res.status(201).json({
+      mediaUrl,
+      hls: isHlsPlaylistUrl(handle.path),
+    });
+  })
+);
+
+mediaRouter.get(
+  "/local-url/:handleId",
+  asyncHandler(async (req, res) => {
+    setNoStore(res);
+    const prunedCount = pruneSessionMediaHandles(localUrlSession);
+    const handle = localUrlMediaHandles.get(req.params.handleId as string);
+    if (!handle) {
+      throw new ApiError(404, "local_media_url_not_found", "URL media handle was not found or has expired");
+    }
+
+    handle.lastAccessedAt = Date.now();
+
+    const accept = req.header("accept") ?? undefined;
+    const requestedRange = req.header("range") ?? undefined;
+    const range = shouldForwardMediaRange(handle, requestedRange);
+    const headers = new Headers(accept ? { Accept: accept } : undefined);
+    if (range) {
+      headers.set("Range", range);
+    }
+
+    const upstreamUrl = mediaHandleRequestUrl(handle).toString();
+    logger.trace("Fetching local URL media for handle {handleId}.", {
+      handleId: handle.id,
+      upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
+      hasRange: Boolean(range),
+      accept,
+      prunedCount,
+    });
+
+    await proxyProviderMediaResponse(
+      localUrlSession,
+      handle,
+      {
+        accept,
+        range: range ?? undefined,
+      },
+      async () => {
+        try {
+          const upstream = await fetchMediaHandleRequest(handle, { headers });
+          if (!upstream.ok && upstream.status !== 206) {
+            const detail = (await upstream.text()).slice(0, 400).replace(/\s+/g, " ").trim();
+            throw new ApiError(
+              upstream.status,
+              "local_media_url_failed",
+              detail ? `URL media request failed: ${detail}` : "URL media request failed"
+            );
+          }
+
+          return upstream;
+        } catch (err) {
+          logger.warn("Local URL media request failed for handle {handleId}.", {
+            handleId: handle.id,
+            upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
+            hasRange: Boolean(range),
+            accept,
+            errorMessage: errorMessage(err),
+          });
+
+          if (err instanceof ApiError) {
+            throw err;
+          }
+
+          throw new ApiError(502, "local_media_url_failed", `URL media request failed: ${errorMessage(err)}`);
+        }
+      },
+      res,
+      {
+        createMediaHandleUrl: createLocalUrlMediaHandleUrl,
+      },
+    );
+  })
+);
 
 mediaRouter.get(
   "/currently-playing",


### PR DESCRIPTION
## Summary
- Route local video URLs through a same-origin Cliparr media proxy so browser CORS does not block preview/export.
- Reuse the shared media proxy path for range forwarding, redirect validation, HLS playlist rewriting, and unsafe internal-address blocking.
- Update local URL session creation, UI copy, and export messaging to reflect proxy-backed URL reads.

## Root Cause
Local URL media used Mediabunny UrlSource directly in the browser, so remote servers without Access-Control-Allow-Origin caused Failed to fetch before Cliparr could read the media.

## Validation
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/server lint:eslint
- pnpm --filter @cliparr/frontend lint:eslint
- Manually verified the Big Buck Bunny sample URL returns 206 Partial Content via /api/media/local-url/...