### PR TITLE
ci: improve Docker image publishes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/techsquidtv/cliparr
+  IMAGE_DESCRIPTION: Instant media clipper for Plex and Jellyfin servers.
 
 jobs:
   build:
@@ -24,6 +25,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -52,6 +56,14 @@ jobs:
             type=raw,value=rc,enable=${{ github.ref_type == 'tag' && contains(github.ref_name, '-rc.') }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Cliparr
+            org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
+          annotations: |
+            org.opencontainers.image.title=Cliparr
+            org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
       - name: Resolve app version
         id: version
@@ -70,10 +82,12 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          pull: true
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           build-args: |
             CLIPARR_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ startsWith(github.ref, 'refs/tags/v') && steps.meta.outputs.annotations || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ FROM node:24-slim AS runner
 
 ARG CLIPARR_VERSION
 
+LABEL org.opencontainers.image.title="Cliparr" \
+  org.opencontainers.image.description="Instant media clipper for Plex and Jellyfin servers." \
+  org.opencontainers.image.source="https://github.com/techsquidtv/cliparr" \
+  org.opencontainers.image.licenses="MIT"
+
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV CLIPARR_DATA_DIR=/data


### PR DESCRIPTION
## Summary

- add OCI labels and multi-arch annotations so GHCR package pages get title/description metadata
- make QEMU setup explicit for linux/amd64 + linux/arm64 tag publishes
- pull fresh base images during Docker build-push runs
- add fallback OCI labels to the runtime Dockerfile for local/manual image builds

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker.yml"); puts "YAML OK"'`
- `git diff --check`
- `git diff --cached --check`
- attempted `docker build --build-arg CLIPARR_VERSION=codex-docker-publish-check -t cliparr:codex-docker-publish-check .`, but Docker daemon was not running at `~/.colima/default/docker.sock`
