### PR TITLE
chore: improve v1 release readiness

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,17 +93,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          data_dir="${RUNNER_TEMP}/cliparr-smoke-data"
           health_file="${RUNNER_TEMP}/cliparr-health.json"
           index_file="${RUNNER_TEMP}/cliparr-index.html"
 
-          mkdir -p "${data_dir}"
           docker run \
             --detach \
             --name cliparr-smoke \
             --publish 3000:3000 \
             --env APP_KEY="cliparr-smoke-test-key-with-at-least-32-characters" \
-            --volume "${data_dir}:/data" \
+            --volume cliparr-smoke-data:/data \
             cliparr:smoke
 
           for attempt in {1..30}; do
@@ -126,7 +124,9 @@ jobs:
 
       - name: Stop smoke-test container
         if: always()
-        run: docker rm -f cliparr-smoke || true
+        run: |
+          docker rm -f cliparr-smoke || true
+          docker volume rm cliparr-smoke-data || true
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,58 @@ jobs:
           fi
           echo "value=${version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Build smoke-test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          pull: true
+          load: true
+          build-args: |
+            CLIPARR_VERSION=${{ steps.version.outputs.value }}
+          tags: cliparr:smoke
+          cache-from: type=gha
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+
+          data_dir="${RUNNER_TEMP}/cliparr-smoke-data"
+          health_file="${RUNNER_TEMP}/cliparr-health.json"
+          index_file="${RUNNER_TEMP}/cliparr-index.html"
+
+          mkdir -p "${data_dir}"
+          docker run \
+            --detach \
+            --name cliparr-smoke \
+            --publish 3000:3000 \
+            --env APP_KEY="cliparr-smoke-test-key-with-at-least-32-characters" \
+            --volume "${data_dir}:/data" \
+            cliparr:smoke
+
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:3000/api/health > "${health_file}"; then
+              break
+            fi
+            sleep 1
+          done
+
+          cat "${health_file}"
+          grep -q '"status":"ok"' "${health_file}"
+          grep -q '"database":"ok"' "${health_file}"
+
+          curl --fail --silent --show-error http://127.0.0.1:3000/ > "${index_file}"
+          grep -q '<div id="root"></div>' "${index_file}"
+
+      - name: Show smoke-test logs
+        if: failure()
+        run: docker logs cliparr-smoke || true
+
+      - name: Stop smoke-test container
+        if: always()
+        run: docker rm -f cliparr-smoke || true
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thanks for helping improve Cliparr.
 Requirements:
 
 - Node.js 24 or newer
-- pnpm 10.x
-- A Plex account and a reachable Plex Media Server for manual end-to-end testing
+- pnpm 11.2.2 via Corepack, matching the root `packageManager`
+- A Plex or Jellyfin server, or a local video file, for manual end-to-end testing
 
 Install dependencies:
 
@@ -45,4 +45,4 @@ pnpm build
 
 ## Security
 
-Do not include Plex tokens, server URLs, local media paths, or other private account details in issues, logs, screenshots, or pull requests.
+Do not include Plex tokens, Jellyfin credentials, server URLs, local media paths, or other private account details in issues, logs, screenshots, or pull requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,8 @@
 # Security Policy
 
-Cliparr is a local-first tool that temporarily stores Plex auth state in server memory and proxies media from Plex to the browser.
+Cliparr is a local-first tool that stores encrypted provider credentials in SQLite under `CLIPARR_DATA_DIR`, keeps short-lived browser sessions and media handles, and proxies media from configured Plex/Jellyfin sources or user-provided media URLs to the browser.
+
+Keep your `APP_KEY` stable and private. It is required to decrypt persisted provider credentials, so backups of Cliparr data should include both the data directory and the matching key.
 
 ## Reporting a Vulnerability
 
@@ -13,7 +15,7 @@ Useful details include:
 - Affected version or commit
 - Steps to reproduce
 - Expected and actual behavior
-- Any relevant logs with Plex tokens, server addresses, and private media paths removed
+- Any relevant logs with provider tokens, credentials, server addresses, and private media paths removed
 
 ## Supported Versions
 

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { Eye } from "lucide-react";
 import {
   clampClipEndTime,
@@ -12,7 +12,6 @@ import { useEditorExport } from "./editor/useEditorExport";
 import { useEditorKeyboardShortcuts } from "./editor/useEditorKeyboardShortcuts";
 import { useEditorTimeline } from "./editor/useEditorTimeline";
 import { EditorHeader } from "./editor/EditorHeader";
-import { EditorExportDialog } from "./editor/EditorExportDialog";
 import { EditorPreview } from "./editor/EditorPreview";
 import { EditorControls } from "./editor/EditorControls";
 import { EditorSidebar } from "./editor/EditorSidebar";
@@ -37,6 +36,12 @@ import {
   saveSubtitleStyleSettings,
 } from "../lib/subtitles/settings";
 import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
+
+const EditorExportDialog = lazy(() =>
+  import("./editor/EditorExportDialog").then((module) => ({
+    default: module.EditorExportDialog,
+  }))
+);
 
 interface Props {
   session: EditorSession;
@@ -497,44 +502,48 @@ export default function EditorScreen({ session, onBack }: Props) {
         </div>
       </main>
 
-      <EditorExportDialog
-        isOpen={exportDialogOpen}
-        title={session.title}
-        clipStart={startTime}
-        clipEnd={endTime}
-        selectedFormat={exportFormat}
-        onFormatChange={handleFormatChange}
-        selectedResolution={resolution}
-        onResolutionChange={handleResolutionChange}
-        selectedSourcePreference={effectiveExportSourcePreference}
-        onSourcePreferenceChange={handleExportSourceChange}
-        includeAudio={includeAudio}
-        onIncludeAudioChange={handleAudioChange}
-        exporting={exporting}
-        progress={progress}
-        error={exportError}
-        fileNamePreview={fileName.fullName}
-        outputDimensions={outputDimensions}
-        hasHlsSource={Boolean(session.hlsSource)}
-        hasDirectSource={Boolean(session.directSource)}
-        directSourceLabel={session.directSource ? sourceDisplayLabel(session.directSource) : "Direct/original"}
-        hlsSourceLabel={session.hlsSource ? sourceDisplayLabel(session.hlsSource) : "HLS playback"}
-        exportSourceLabel={exportSourceLabel}
-        exportSourceMessage={exportSourceMessage}
-        exportSourceSummaryMessage={exportSourceSummaryMessage}
-        subtitleSummaryLabel={subtitleExportSummary.label}
-        subtitleSummaryDetail={subtitleExportSummary.detail}
-        subtitleSummaryTone={subtitleExportSummary.tone}
-        exportDisabledReason={exportDisabledReason}
-        activeTemplateKind={fileName.templateKind}
-        editingTemplateKind={templateEditorKind}
-        onEditingTemplateKindChange={setTemplateEditorKind}
-        fileNameTemplates={fileNameTemplates}
-        onFileNameTemplateChange={handleFileNameTemplateChange}
-        onResetFileNameTemplate={handleResetFileNameTemplate}
-        onClose={handleCloseExportDialog}
-        onExport={() => void handleExport()}
-      />
+      {exportDialogOpen && (
+        <Suspense fallback={null}>
+          <EditorExportDialog
+            isOpen={exportDialogOpen}
+            title={session.title}
+            clipStart={startTime}
+            clipEnd={endTime}
+            selectedFormat={exportFormat}
+            onFormatChange={handleFormatChange}
+            selectedResolution={resolution}
+            onResolutionChange={handleResolutionChange}
+            selectedSourcePreference={effectiveExportSourcePreference}
+            onSourcePreferenceChange={handleExportSourceChange}
+            includeAudio={includeAudio}
+            onIncludeAudioChange={handleAudioChange}
+            exporting={exporting}
+            progress={progress}
+            error={exportError}
+            fileNamePreview={fileName.fullName}
+            outputDimensions={outputDimensions}
+            hasHlsSource={Boolean(session.hlsSource)}
+            hasDirectSource={Boolean(session.directSource)}
+            directSourceLabel={session.directSource ? sourceDisplayLabel(session.directSource) : "Direct/original"}
+            hlsSourceLabel={session.hlsSource ? sourceDisplayLabel(session.hlsSource) : "HLS playback"}
+            exportSourceLabel={exportSourceLabel}
+            exportSourceMessage={exportSourceMessage}
+            exportSourceSummaryMessage={exportSourceSummaryMessage}
+            subtitleSummaryLabel={subtitleExportSummary.label}
+            subtitleSummaryDetail={subtitleExportSummary.detail}
+            subtitleSummaryTone={subtitleExportSummary.tone}
+            exportDisabledReason={exportDisabledReason}
+            activeTemplateKind={fileName.templateKind}
+            editingTemplateKind={templateEditorKind}
+            onEditingTemplateKindChange={setTemplateEditorKind}
+            fileNameTemplates={fileNameTemplates}
+            onFileNameTemplateChange={handleFileNameTemplateChange}
+            onResetFileNameTemplate={handleResetFileNameTemplate}
+            onClose={handleCloseExportDialog}
+            onExport={() => void handleExport()}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Eye } from "lucide-react";
 import {
   clampClipEndTime,
@@ -18,24 +18,12 @@ import { EditorSidebar } from "./editor/EditorSidebar";
 import { EditorPlaybackSourcePanel } from "./editor/EditorPlaybackSourcePanel";
 import { EditorTimeline } from "./editor/EditorTimeline";
 import { EditorSubtitlePanel } from "./editor/EditorSubtitlePanel";
-import { buildSubtitleExportSummary } from "./editor/subtitleExportSummary";
 import {
   buildClipRangeAfterDurationDiscovery,
   buildInitialClipRange,
 } from "./editor/initialClipRange";
-import { useSubtitleCues } from "./editor/useSubtitleCues";
-import type { PlaybackSubtitleTrack } from "../providers/types";
+import { useEditorSubtitles } from "./editor/useEditorSubtitles";
 import { sourceDisplayLabel, type EditorSession } from "../lib/editorMedia";
-import {
-  selectPreferredSubtitleTrack,
-  subtitleTrackKey,
-  subtitleTrackSupportsBurnIn,
-} from "../lib/selectPreferredSubtitleTrack";
-import {
-  loadSubtitleStyleSettings,
-  saveSubtitleStyleSettings,
-} from "../lib/subtitles/settings";
-import { trimSubtitleCues } from "../lib/subtitles/trimSubtitleCues";
 
 const EditorExportDialog = lazy(() =>
   import("./editor/EditorExportDialog").then((module) => ({
@@ -52,59 +40,27 @@ export default function EditorScreen({ session, onBack }: Props) {
   const initialClipRange = buildInitialClipRange(session.duration, session.initialPlayheadSeconds);
   const [startTime, setStartTime] = useState(() => initialClipRange.startTime);
   const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
-  const [subtitleStyleSettings, setSubtitleStyleSettings] = useState(() => loadSubtitleStyleSettings());
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
-  const [subtitleEnabled, setSubtitleEnabled] = useState(false);
-  const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState("none");
-
-  const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
-    () => session.local
-      ? []
-      : (session.subtitleTracks ?? []).filter((track) => subtitleTrackSupportsBurnIn(track)),
-    [session.local, session.subtitleTracks]
-  );
-  const selectedSubtitleTrack = useMemo(() => {
-    if (selectedSubtitleTrackKey === "none") {
-      return null;
-    }
-
-    return subtitleTracks.find((track) => subtitleTrackKey(track) === selectedSubtitleTrackKey) ?? null;
-  }, [selectedSubtitleTrackKey, subtitleTracks]);
   const {
+    subtitleTracks,
+    selectedSubtitleTrack,
+    selectedSubtitleTrackKey,
+    subtitleEnabled,
+    setSubtitleEnabled,
+    subtitleStyleSettings,
+    setSubtitleStyleSettings,
     subtitleCues,
     subtitleLoading,
     subtitleError,
-    resetSubtitleCues,
-    clearSubtitleError,
-  } = useSubtitleCues({
-    selectedSubtitleTrack,
-    subtitleEnabled,
-    providerId: session.source.providerId,
+    subtitlePreviewEnabled,
+    clippedSubtitleCues,
+    subtitleExportSummary,
+    handleSelectedSubtitleTrackChange,
+  } = useEditorSubtitles({
+    session,
+    startTime,
+    endTime,
   });
-  const subtitlePreviewEnabled = subtitleEnabled
-    && subtitleTrackSupportsBurnIn(selectedSubtitleTrack)
-    && subtitleCues.length > 0;
-  const clippedSubtitleCues = useMemo(
-    () => subtitleEnabled ? trimSubtitleCues(subtitleCues, startTime, endTime) : [],
-    [endTime, startTime, subtitleCues, subtitleEnabled]
-  );
-  const subtitleExportSummary = useMemo(() => buildSubtitleExportSummary({
-    selectedSubtitleTrack,
-    subtitleEnabled,
-    subtitleTrackCount: subtitleTracks.length,
-    clippedSubtitleCueCount: clippedSubtitleCues.length,
-    subtitleLoading,
-    subtitleError,
-    providerId: session.source.providerId,
-  }), [
-    selectedSubtitleTrack,
-    subtitleEnabled,
-    subtitleTracks.length,
-    clippedSubtitleCues.length,
-    subtitleLoading,
-    subtitleError,
-    session.source.providerId,
-  ]);
   const posterImageUrl = session.thumbUrl;
 
   const {
@@ -296,37 +252,6 @@ export default function EditorScreen({ session, onBack }: Props) {
     startTime,
     updateClipRange,
   ]);
-
-  useEffect(() => {
-    saveSubtitleStyleSettings(subtitleStyleSettings);
-  }, [subtitleStyleSettings]);
-
-  useEffect(() => {
-    const preferredSubtitleTrack = selectPreferredSubtitleTrack(subtitleTracks, session.selectedSubtitleTrack);
-
-    setSelectedSubtitleTrackKey(preferredSubtitleTrack ? subtitleTrackKey(preferredSubtitleTrack) : "none");
-    setSubtitleEnabled(Boolean(preferredSubtitleTrack && subtitleTrackSupportsBurnIn(preferredSubtitleTrack)));
-    resetSubtitleCues();
-  }, [
-    session.id,
-    session.selectedSubtitleTrack,
-    subtitleTracks,
-    resetSubtitleCues,
-  ]);
-
-  const handleSelectedSubtitleTrackChange = useCallback((value: string) => {
-    setSelectedSubtitleTrackKey(value);
-    clearSubtitleError();
-
-    if (value === "none") {
-      setSubtitleEnabled(false);
-      resetSubtitleCues();
-      return;
-    }
-
-    const nextTrack = subtitleTracks.find((track) => subtitleTrackKey(track) === value) ?? null;
-    setSubtitleEnabled(Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)));
-  }, [clearSubtitleError, resetSubtitleCues, subtitleTracks]);
 
   useEditorKeyboardShortcuts({ togglePlay });
 

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -9,7 +9,6 @@ import type {
 } from "mediabunny";
 import type { SubtitleCue, SubtitleStyleSettings } from "../../lib/subtitles/types";
 import type { EditorMediaSource } from "../../lib/editorMedia";
-import { ensureMediabunnyCodecs } from "../../lib/mediabunnyCodecs";
 import { createCliparrInputFromSource } from "../../lib/mediabunnyInput";
 import {
   fromSourceTimelineTime,
@@ -136,6 +135,11 @@ function initialPlaybackTime(seconds: number | null | undefined, duration: numbe
   }
 
   return Math.min(safeSeconds, safeDuration);
+}
+
+async function ensurePlaybackCodecs() {
+  const { ensureMediabunnyCodecs } = await import("../../lib/mediabunnyCodecs");
+  await ensureMediabunnyCodecs();
 }
 
 export function useEditorPlayback({
@@ -600,7 +604,7 @@ export function useEditorPlayback({
           );
 
           try {
-            await ensureMediabunnyCodecs();
+            await ensurePlaybackCodecs();
             const { AudioBufferSink, CanvasSink } = await import("mediabunny");
 
             if (cancelled || generation !== generationRef.current) {

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { EditorSession } from "../../lib/editorMedia";
+import {
+  selectPreferredSubtitleTrack,
+  subtitleTrackKey,
+  subtitleTrackSupportsBurnIn,
+} from "../../lib/selectPreferredSubtitleTrack";
+import {
+  loadSubtitleStyleSettings,
+  saveSubtitleStyleSettings,
+} from "../../lib/subtitles/settings";
+import { trimSubtitleCues } from "../../lib/subtitles/trimSubtitleCues";
+import type { PlaybackSubtitleTrack } from "../../providers/types";
+import { buildSubtitleExportSummary } from "./subtitleExportSummary";
+import { useSubtitleCues } from "./useSubtitleCues";
+
+interface UseEditorSubtitlesProps {
+  session: EditorSession;
+  startTime: number;
+  endTime: number;
+}
+
+export function useEditorSubtitles({
+  session,
+  startTime,
+  endTime,
+}: UseEditorSubtitlesProps) {
+  const [subtitleStyleSettings, setSubtitleStyleSettings] = useState(() => loadSubtitleStyleSettings());
+  const [subtitleEnabled, setSubtitleEnabled] = useState(false);
+  const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState("none");
+
+  const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
+    () => session.local
+      ? []
+      : (session.subtitleTracks ?? []).filter((track) => subtitleTrackSupportsBurnIn(track)),
+    [session.local, session.subtitleTracks]
+  );
+  const selectedSubtitleTrack = useMemo(() => {
+    if (selectedSubtitleTrackKey === "none") {
+      return null;
+    }
+
+    return subtitleTracks.find((track) => subtitleTrackKey(track) === selectedSubtitleTrackKey) ?? null;
+  }, [selectedSubtitleTrackKey, subtitleTracks]);
+  const {
+    subtitleCues,
+    subtitleLoading,
+    subtitleError,
+    resetSubtitleCues,
+    clearSubtitleError,
+  } = useSubtitleCues({
+    selectedSubtitleTrack,
+    subtitleEnabled,
+    providerId: session.source.providerId,
+  });
+  const subtitlePreviewEnabled = subtitleEnabled
+    && subtitleTrackSupportsBurnIn(selectedSubtitleTrack)
+    && subtitleCues.length > 0;
+  const clippedSubtitleCues = useMemo(
+    () => subtitleEnabled ? trimSubtitleCues(subtitleCues, startTime, endTime) : [],
+    [endTime, startTime, subtitleCues, subtitleEnabled]
+  );
+  const subtitleExportSummary = useMemo(() => buildSubtitleExportSummary({
+    selectedSubtitleTrack,
+    subtitleEnabled,
+    subtitleTrackCount: subtitleTracks.length,
+    clippedSubtitleCueCount: clippedSubtitleCues.length,
+    subtitleLoading,
+    subtitleError,
+    providerId: session.source.providerId,
+  }), [
+    selectedSubtitleTrack,
+    subtitleEnabled,
+    subtitleTracks.length,
+    clippedSubtitleCues.length,
+    subtitleLoading,
+    subtitleError,
+    session.source.providerId,
+  ]);
+
+  useEffect(() => {
+    saveSubtitleStyleSettings(subtitleStyleSettings);
+  }, [subtitleStyleSettings]);
+
+  useEffect(() => {
+    const preferredSubtitleTrack = selectPreferredSubtitleTrack(subtitleTracks, session.selectedSubtitleTrack);
+
+    setSelectedSubtitleTrackKey(preferredSubtitleTrack ? subtitleTrackKey(preferredSubtitleTrack) : "none");
+    setSubtitleEnabled(Boolean(preferredSubtitleTrack && subtitleTrackSupportsBurnIn(preferredSubtitleTrack)));
+    resetSubtitleCues();
+  }, [
+    session.id,
+    session.selectedSubtitleTrack,
+    subtitleTracks,
+    resetSubtitleCues,
+  ]);
+
+  const handleSelectedSubtitleTrackChange = useCallback((value: string) => {
+    setSelectedSubtitleTrackKey(value);
+    clearSubtitleError();
+
+    if (value === "none") {
+      setSubtitleEnabled(false);
+      resetSubtitleCues();
+      return;
+    }
+
+    const nextTrack = subtitleTracks.find((track) => subtitleTrackKey(track) === value) ?? null;
+    setSubtitleEnabled(Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)));
+  }, [clearSubtitleError, resetSubtitleCues, subtitleTracks]);
+
+  return {
+    subtitleTracks,
+    selectedSubtitleTrack,
+    selectedSubtitleTrackKey,
+    subtitleEnabled,
+    setSubtitleEnabled,
+    subtitleStyleSettings,
+    setSubtitleStyleSettings,
+    subtitleCues,
+    subtitleLoading,
+    subtitleError,
+    subtitlePreviewEnabled,
+    clippedSubtitleCues,
+    subtitleExportSummary,
+    handleSelectedSubtitleTrackChange,
+  };
+}

--- a/apps/frontend/src/lib/mediabunnyCodecs.ts
+++ b/apps/frontend/src/lib/mediabunnyCodecs.ts
@@ -1,16 +1,21 @@
-import { canEncodeAudio } from "mediabunny";
-import { registerAacEncoder } from "@mediabunny/aac-encoder";
-import { registerAc3Decoder, registerAc3Encoder } from "@mediabunny/ac3";
-
 let codecRegistration: Promise<void> | undefined;
 
 export function ensureMediabunnyCodecs() {
   codecRegistration ??= (async () => {
+    const [
+      { canEncodeAudio },
+      { registerAc3Decoder, registerAc3Encoder },
+    ] = await Promise.all([
+      import("mediabunny"),
+      import("@mediabunny/ac3"),
+    ]);
+
     registerAc3Decoder();
     registerAc3Encoder();
 
     const canEncodeAac = await canEncodeAudio("aac").catch(() => false);
     if (!canEncodeAac) {
+      const { registerAacEncoder } = await import("@mediabunny/aac-encoder");
       registerAacEncoder();
     }
   })();

--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -21,6 +21,8 @@ export default defineConfig(({mode}) => {
       tailwindcss(),
     ],
     build: {
+      // Lazy codec extension chunks are intentionally larger than Vite's default 500 kB warning.
+      chunkSizeWarningLimit: 1200,
       rollupOptions: {
         output: {
           manualChunks(id) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cliparr",
-  "description": "Plex video clipper",
+  "description": "Personal media clipper for Plex, Jellyfin, and local video files",
   "requestFramePermissions": [],
   "majorCapabilities": []
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cliparr",
   "private": true,
-  "description": "Plex clipper for exporting MP4 clips from active playback sessions, featuring a React frontend and Express server.",
+  "description": "Personal media clipper for Plex, Jellyfin, and local video files, featuring a React frontend and Express server.",
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@11.2.2",


### PR DESCRIPTION
## Summary

- Add a Docker image smoke test that runs the built image, checks `/api/health`, and verifies the SPA root responds.
- Refresh stale pre-v1 metadata and docs around supported providers, pnpm version, and credential persistence.
- Split editor export UI and codec registration into lazy chunks to reduce the editor route's initial payload.
- Extract editor subtitle state into a focused hook so `EditorScreen` is easier to maintain.

## Impact

This improves release confidence before v1 by testing the production container path, tightening public-facing project metadata, reducing initial editor bundle size, and making subtitle state easier to reason about.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm knip`
