### PR TITLE
fix: improve timeline seeking and media retries

### DIFF
--- a/apps/frontend/src/components/EditorScreen.tsx
+++ b/apps/frontend/src/components/EditorScreen.tsx
@@ -69,7 +69,9 @@ export default function EditorScreen({ session, onBack }: Props) {
     duration,
     playing,
     loadingPreview,
+    loadingPreviewFrame,
     previewStatus,
+    previewFrameStatus,
     error,
     activeSourceLabel,
     exportFallbackSource,
@@ -200,7 +202,6 @@ export default function EditorScreen({ session, onBack }: Props) {
     activeTimelineScale,
     timelineScaleCount,
     handleTimelineScroll,
-    handleTimelineWheel,
     handleTimelineZoomIn,
     handleTimelineZoomOut,
     canZoomIn,
@@ -305,7 +306,9 @@ export default function EditorScreen({ session, onBack }: Props) {
                 videoDimensions={previewVideoDimensions}
                 playing={playing}
                 loadingPreview={loadingPreview}
+                loadingPreviewFrame={loadingPreviewFrame}
                 previewStatus={previewStatus}
+                previewFrameStatus={previewFrameStatus}
                 togglePlay={togglePlay}
               />
             </section>
@@ -354,7 +357,6 @@ export default function EditorScreen({ session, onBack }: Props) {
                     handleTimelineChange={handleTimelineChange}
                     handleTimelineActionMoveEnd={handleTimelineActionMoveEnd}
                     handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
-                    handleTimelineWheel={handleTimelineWheel}
                     isValidTimelineRange={isValidTimelineRange}
                     seekToTime={seekToTime}
                     onCursorDragStart={() => {

--- a/apps/frontend/src/components/editor/EditorPreview.tsx
+++ b/apps/frontend/src/components/editor/EditorPreview.tsx
@@ -1,4 +1,4 @@
-import { Play } from "lucide-react";
+import { LoaderCircle, Play } from "lucide-react";
 import type { RefObject } from "react";
 
 interface EditorPreviewProps {
@@ -9,7 +9,9 @@ interface EditorPreviewProps {
   } | null;
   playing: boolean;
   loadingPreview: boolean;
+  loadingPreviewFrame: boolean;
   previewStatus: string;
+  previewFrameStatus: string;
   togglePlay: () => void;
 }
 
@@ -18,12 +20,16 @@ export function EditorPreview({
   videoDimensions,
   playing,
   loadingPreview,
+  loadingPreviewFrame,
   previewStatus,
+  previewFrameStatus,
   togglePlay,
 }: EditorPreviewProps) {
   const aspectRatio = videoDimensions && videoDimensions.width > 0 && videoDimensions.height > 0
     ? `${videoDimensions.width} / ${videoDimensions.height}`
     : undefined;
+  const showLoadingOverlay = loadingPreview || loadingPreviewFrame;
+  const loadingStatus = loadingPreviewFrame ? previewFrameStatus : previewStatus;
 
   return (
     <div
@@ -35,24 +41,27 @@ export function EditorPreview({
         className="h-full w-full object-contain"
         onClick={togglePlay}
       />
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-        <button
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation();
-            togglePlay();
-          }}
-          aria-label={playing ? "Pause playback" : "Play playback"}
-          className={`pointer-events-auto flex h-11 w-11 items-center justify-center border border-[var(--editor-preview-overlay-border)] bg-card/92 text-foreground transition-all ${
-            playing ? "scale-95 opacity-0" : "scale-100 opacity-100 group-hover:bg-card"
-          }`}
-        >
-          <Play className="ml-0.5 h-5 w-5" />
-        </button>
-      </div>
-      {loadingPreview && (
-        <div className="absolute inset-0 flex items-center justify-center bg-[var(--editor-preview-overlay)] text-sm text-[var(--editor-preview-overlay-foreground)]">
-          {previewStatus}
+      {!showLoadingOverlay && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              togglePlay();
+            }}
+            aria-label={playing ? "Pause playback" : "Play playback"}
+            className={`pointer-events-auto flex h-11 w-11 items-center justify-center border border-[var(--editor-preview-overlay-border)] bg-card/92 text-foreground transition-all ${
+              playing ? "scale-95 opacity-0" : "scale-100 opacity-100 group-hover:bg-card"
+            }`}
+          >
+            <Play className="ml-0.5 h-5 w-5" />
+          </button>
+        </div>
+      )}
+      {showLoadingOverlay && (
+        <div className="absolute inset-0 flex items-center justify-center gap-2 bg-[var(--editor-preview-overlay)] text-sm text-[var(--editor-preview-overlay-foreground)]">
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+          <span>{loadingStatus}</span>
         </div>
       )}
     </div>

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -1,9 +1,10 @@
 import { useCallback } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
-import type { CSSProperties, RefObject, WheelEvent as ReactWheelEvent } from "react";
+import type { CSSProperties, RefObject } from "react";
 import { Scissors } from "lucide-react";
 import type { PlaybackReadyRange } from "./useEditorPlayback";
+import { isPlaybackReadyRangeVisible } from "./editorPlaybackWarmupRange";
 import { 
   formatTime,
   getTimelineFillPercentages,
@@ -28,7 +29,6 @@ interface EditorTimelineProps {
   handleTimelineChange: (data: ClipTimelineData) => void;
   handleTimelineActionMoveEnd: (params: { action: { id: string }; start: number; end: number }) => void;
   handleTimelineActionResizeEnd: (params: { action: { id: string }; start: number; end: number }) => void;
-  handleTimelineWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
   isValidTimelineRange: (start: number, end: number) => boolean;
   seekToTime: (time: number) => Promise<void> | void;
   onCursorDragStart: () => void;
@@ -49,14 +49,17 @@ export function EditorTimeline({
   handleTimelineChange,
   handleTimelineActionMoveEnd,
   handleTimelineActionResizeEnd,
-  handleTimelineWheel,
   isValidTimelineRange,
   seekToTime,
   onCursorDragStart,
   onCursorDrag,
 }: EditorTimelineProps) {
   const getReadyFillStyle = useCallback((action: ClipTimelineAction): CSSProperties | null => {
-    if (action.effectId !== "clip" || !playbackReadyRange) {
+    if (
+      action.effectId !== "clip"
+      || !playbackReadyRange
+      || !isPlaybackReadyRangeVisible(playbackReadyRange)
+    ) {
       return null;
     }
 
@@ -102,7 +105,6 @@ export function EditorTimeline({
     <div
       ref={timelineWheelRegionRef}
       className="cliparr-timeline"
-      onWheelCapture={handleTimelineWheel}
     >
       <Timeline
         ref={timelineRef}

--- a/apps/frontend/src/components/editor/editorPlaybackPlan.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackPlan.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolvePreviewPlaybackPlan } from "./editorPlaybackPlan";
+
+void test("snaps to the selection start when the playhead is close", () => {
+  assert.deepEqual(resolvePreviewPlaybackPlan({
+    currentTime: 9.2,
+    clipStart: 10,
+    clipEnd: 20,
+    duration: 60,
+  }), {
+    mode: "selection",
+    startTime: 10,
+    stopTime: 20,
+    resetTime: 10,
+  });
+});
+
+void test("plays from inside the selection without snapping", () => {
+  assert.deepEqual(resolvePreviewPlaybackPlan({
+    currentTime: 14,
+    clipStart: 10,
+    clipEnd: 20,
+    duration: 60,
+  }), {
+    mode: "selection",
+    startTime: 14,
+    stopTime: 20,
+    resetTime: 10,
+  });
+});
+
+void test("plays source preview from a playhead outside the selection", () => {
+  assert.deepEqual(resolvePreviewPlaybackPlan({
+    currentTime: 35,
+    clipStart: 10,
+    clipEnd: 20,
+    duration: 60,
+  }), {
+    mode: "source",
+    startTime: 35,
+    stopTime: 60,
+    resetTime: null,
+  });
+});
+
+void test("keeps distant pre-selection preview at the playhead", () => {
+  assert.deepEqual(resolvePreviewPlaybackPlan({
+    currentTime: 2,
+    clipStart: 10,
+    clipEnd: 20,
+    duration: 60,
+  }), {
+    mode: "source",
+    startTime: 2,
+    stopTime: 60,
+    resetTime: null,
+  });
+});

--- a/apps/frontend/src/components/editor/editorPlaybackPlan.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackPlan.ts
@@ -1,0 +1,59 @@
+type PreviewPlaybackMode = "selection" | "source";
+
+export interface PreviewPlaybackPlan {
+  mode: PreviewPlaybackMode;
+  startTime: number;
+  stopTime: number;
+  resetTime: number | null;
+}
+
+interface PreviewPlaybackPlanOptions {
+  currentTime: number;
+  clipStart: number;
+  clipEnd: number;
+  duration: number;
+}
+
+const CLIP_START_PLAY_SNAP_SECONDS = 1;
+
+function finiteNonNegative(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function resolvePreviewPlaybackPlan({
+  currentTime,
+  clipStart,
+  clipEnd,
+  duration,
+}: PreviewPlaybackPlanOptions): PreviewPlaybackPlan {
+  const safeDuration = finiteNonNegative(duration);
+  const safeClipStart = clamp(finiteNonNegative(clipStart), 0, safeDuration);
+  const safeClipEnd = clamp(finiteNonNegative(clipEnd || safeDuration), safeClipStart, safeDuration);
+  const safeCurrentTime = clamp(finiteNonNegative(currentTime), 0, safeDuration);
+  const hasSelection = safeClipEnd > safeClipStart;
+  const nearSelectionStart = hasSelection
+    && Math.abs(safeCurrentTime - safeClipStart) <= CLIP_START_PLAY_SNAP_SECONDS;
+  const insideSelection = hasSelection
+    && safeCurrentTime >= safeClipStart
+    && safeCurrentTime < safeClipEnd;
+
+  if (hasSelection && (nearSelectionStart || insideSelection)) {
+    return {
+      mode: "selection",
+      startTime: nearSelectionStart ? safeClipStart : safeCurrentTime,
+      stopTime: safeClipEnd,
+      resetTime: safeClipStart,
+    };
+  }
+
+  return {
+    mode: "source",
+    startTime: safeCurrentTime,
+    stopTime: safeDuration,
+    resetTime: null,
+  };
+}

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupRange.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupRange.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createIdlePlaybackReadyRange,
+  isPlaybackReadyRangeVisible,
+  markPlaybackReadyRangeFresh,
+  PLAYBACK_READY_RANGE_FRESH_MS,
+  resetPlaybackReadyRangeWarmState,
+} from "./editorPlaybackWarmupRange";
+
+void test("does not show idle selection readiness", () => {
+  const range = createIdlePlaybackReadyRange(10, 20);
+
+  assert.equal(isPlaybackReadyRangeVisible(range), false);
+});
+
+void test("shows active warmup even before progress advances", () => {
+  const range = markPlaybackReadyRangeFresh({
+    startTime: 10,
+    endTime: 20,
+    readyUntilTime: 10,
+    status: "warming",
+  }, 1_000);
+
+  assert.equal(isPlaybackReadyRangeVisible(range, 1_000), true);
+});
+
+void test("hides readiness after the freshness window expires", () => {
+  const range = markPlaybackReadyRangeFresh({
+    startTime: 10,
+    endTime: 20,
+    readyUntilTime: 20,
+    status: "ready",
+  }, 1_000);
+
+  assert.equal(isPlaybackReadyRangeVisible(range, 1_000 + PLAYBACK_READY_RANGE_FRESH_MS - 1), true);
+  assert.equal(isPlaybackReadyRangeVisible(range, 1_000 + PLAYBACK_READY_RANGE_FRESH_MS), false);
+});
+
+void test("resetting warm state removes prior progress", () => {
+  const range = resetPlaybackReadyRangeWarmState({
+    startTime: 10,
+    endTime: 20,
+    readyUntilTime: 20,
+    status: "ready",
+    updatedAtMs: 1_000,
+    expiresAtMs: 31_000,
+  });
+
+  assert.deepEqual(range, {
+    startTime: 10,
+    endTime: 20,
+    readyUntilTime: 10,
+    status: "idle",
+  });
+});

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupRange.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupRange.ts
@@ -1,0 +1,74 @@
+import type { PlaybackReadyRange } from "./editorPlaybackWarmupTypes";
+
+export const PLAYBACK_READY_RANGE_FRESH_MS = 30_000;
+
+const READY_RANGE_EPSILON = 1e-6;
+
+export function createIdlePlaybackReadyRange(
+  startTime: number,
+  endTime: number,
+): PlaybackReadyRange {
+  return {
+    startTime,
+    endTime,
+    readyUntilTime: startTime,
+    status: "idle",
+  };
+}
+
+export function markPlaybackReadyRangeFresh(
+  range: PlaybackReadyRange,
+  nowMs = Date.now(),
+): PlaybackReadyRange {
+  if (range.status === "idle") {
+    return {
+      startTime: range.startTime,
+      endTime: range.endTime,
+      readyUntilTime: range.readyUntilTime,
+      status: range.status,
+    };
+  }
+
+  return {
+    ...range,
+    updatedAtMs: nowMs,
+    expiresAtMs: nowMs + PLAYBACK_READY_RANGE_FRESH_MS,
+  };
+}
+
+export function resetPlaybackReadyRangeWarmState(
+  range: PlaybackReadyRange,
+): PlaybackReadyRange {
+  return createIdlePlaybackReadyRange(range.startTime, range.endTime);
+}
+
+export function isPlaybackReadyRangeVisible(
+  range: PlaybackReadyRange,
+  nowMs = Date.now(),
+) {
+  if (range.status === "idle") {
+    return false;
+  }
+
+  if (range.expiresAtMs !== undefined && range.expiresAtMs <= nowMs) {
+    return false;
+  }
+
+  if (range.status === "warming") {
+    return true;
+  }
+
+  return range.readyUntilTime - range.startTime > READY_RANGE_EPSILON;
+}
+
+export function samePlaybackReadyRange(
+  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
+  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
+) {
+  return (
+    left !== null
+    && left !== undefined
+    && Math.abs(left.startTime - right.startTime) < READY_RANGE_EPSILON
+    && Math.abs(left.endTime - right.endTime) < READY_RANGE_EPSILON
+  );
+}

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupTypes.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupTypes.ts
@@ -7,6 +7,8 @@ export interface PlaybackReadyRange {
   endTime: number;
   readyUntilTime: number;
   status: "idle" | "warming" | "ready";
+  updatedAtMs?: number;
+  expiresAtMs?: number;
 }
 
 export interface WarmClipSelectionOptions {

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -53,6 +53,8 @@ import {
   useEditorPlaybackWarmup,
   type PlaybackReadyRange,
 } from "./useEditorPlaybackWarmup";
+import { resolvePreviewPlaybackPlan } from "./editorPlaybackPlan";
+import { resetPlaybackReadyRangeWarmState } from "./editorPlaybackWarmupRange";
 
 export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
 export type { PlaybackReadyRange } from "./useEditorPlaybackWarmup";
@@ -161,6 +163,8 @@ export function useEditorPlayback({
   const [playing, setPlaying] = useState(false);
   const [loadingPreview, setLoadingPreview] = useState(true);
   const [previewStatus, setPreviewStatus] = useState("Loading stream...");
+  const [loadingPreviewFrame, setLoadingPreviewFrame] = useState(false);
+  const [previewFrameStatus, setPreviewFrameStatus] = useState("Loading preview frame...");
   const [volume, setVolume] = useState(0.8);
   const [muted, setMuted] = useState(false);
   const [error, setError] = useState("");
@@ -190,6 +194,9 @@ export function useEditorPlayback({
   const warmupGenerationRef = useRef(0);
   const warmupPromiseRef = useRef<Promise<void> | null>(null);
   const warmupTargetTimeRef = useRef<number | null>(null);
+  const previewFrameLoadGenerationRef = useRef(0);
+  const previewFrameLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const previewFrameLoadTargetTimeRef = useRef<number | null>(null);
   const selectionWarmupGenerationRef = useRef(0);
   const selectionWarmupPromiseRef = useRef<Promise<void> | null>(null);
   const selectionWarmupVideoIteratorRef = useRef<AsyncGenerator<WrappedCanvas, void, unknown> | null>(null);
@@ -200,6 +207,8 @@ export function useEditorPlayback({
   const playingRef = useRef(false);
   const audioContextStartTimeRef = useRef<number | null>(null);
   const playbackTimeAtStartRef = useRef(initialPlaybackTime(initialCurrentTime, initialDuration));
+  const playbackStopTimeRef = useRef<number | null>(null);
+  const playbackResetTimeRef = useRef<number | null>(null);
   const sourceTimelineOffsetRef = useRef(0);
   const skipLiveWaitRef = useRef(false);
   const activeSourceLabelRef = useRef(activeSourceLabel);
@@ -232,6 +241,51 @@ export function useEditorPlayback({
 
   useEffect(() => {
     playbackReadyRangeRef.current = playbackReadyRange;
+  }, [playbackReadyRange]);
+
+  const clearSelectionWarmState = useCallback(() => {
+    setPlaybackReadyRange((current) => {
+      if (!current) {
+        playbackReadyRangeRef.current = null;
+        return current;
+      }
+
+      const next = resetPlaybackReadyRangeWarmState(current);
+      playbackReadyRangeRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const setPlaybackError = useCallback((message: string) => {
+    clearSelectionWarmState();
+    setError(message);
+  }, [clearSelectionWarmState]);
+
+  useEffect(() => {
+    if (
+      !playbackReadyRange
+      || playbackReadyRange.status === "idle"
+      || playbackReadyRange.expiresAtMs === undefined
+    ) {
+      return;
+    }
+
+    const expiresAtMs = playbackReadyRange.expiresAtMs;
+    const timeoutId = window.setTimeout(() => {
+      setPlaybackReadyRange((current) => {
+        if (!current || current.expiresAtMs !== expiresAtMs) {
+          return current;
+        }
+
+        const next = resetPlaybackReadyRangeWarmState(current);
+        playbackReadyRangeRef.current = next;
+        return next;
+      });
+    }, Math.max(0, expiresAtMs - Date.now()));
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
   }, [playbackReadyRange]);
 
   useEffect(() => {
@@ -312,10 +366,11 @@ export function useEditorPlayback({
     generationRef,
     playingRef,
     playbackTimeAtStartRef,
+    playbackStopTimeRef,
+    playbackResetTimeRef,
     sourceTimelineOffsetRef,
     skipLiveWaitRef,
     durationRef,
-    startTimeRef,
     endTimeRef,
     subtitleCuesRef,
     subtitlesEnabledRef,
@@ -324,7 +379,7 @@ export function useEditorPlayback({
     clampTime,
     pausePlayback,
     setCurrentTime,
-    setError,
+    setError: setPlaybackError,
   });
 
   const {
@@ -364,6 +419,46 @@ export function useEditorPlayback({
     setPlaybackReadyRange,
   });
 
+  const clearPreviewFrameLoad = useCallback(() => {
+    previewFrameLoadGenerationRef.current++;
+    previewFrameLoadPromiseRef.current = null;
+    previewFrameLoadTargetTimeRef.current = null;
+    setLoadingPreviewFrame(false);
+  }, []);
+
+  const loadPreviewFrameAtPlaybackTime = useCallback(async (
+    status = "Loading preview frame...",
+  ) => {
+    const targetTime = Number(clampTime(playbackTimeAtStartRef.current).toFixed(6));
+    const pendingLoad = previewFrameLoadPromiseRef.current;
+    const pendingTargetTime = previewFrameLoadTargetTimeRef.current;
+    if (
+      pendingLoad
+      && pendingTargetTime !== null
+      && Math.abs(pendingTargetTime - targetTime) < 1e-6
+    ) {
+      return pendingLoad;
+    }
+
+    const frameLoadGeneration = ++previewFrameLoadGenerationRef.current;
+    setPreviewFrameStatus(status);
+    setLoadingPreviewFrame(true);
+
+    const frameLoadPromise = startVideoIterator();
+    previewFrameLoadPromiseRef.current = frameLoadPromise;
+    previewFrameLoadTargetTimeRef.current = targetTime;
+
+    try {
+      await frameLoadPromise;
+    } finally {
+      if (frameLoadGeneration === previewFrameLoadGenerationRef.current) {
+        previewFrameLoadPromiseRef.current = null;
+        previewFrameLoadTargetTimeRef.current = null;
+        setLoadingPreviewFrame(false);
+      }
+    }
+  }, [clampTime, startVideoIterator]);
+
   const resetPreview = useCallback((advanceGeneration = false, clearActiveSource = false) => {
     if (advanceGeneration) {
       generationRef.current++;
@@ -386,8 +481,11 @@ export function useEditorPlayback({
     staticVideoFrameRef.current = null;
     sourceTimelineOffsetRef.current = 0;
     skipLiveWaitRef.current = false;
+    playbackStopTimeRef.current = null;
+    playbackResetTimeRef.current = null;
     warmupPromiseRef.current = null;
     warmupTargetTimeRef.current = null;
+    clearPreviewFrameLoad();
     displayedFrameRef.current = null;
     displayedStaticFrameRef.current = null;
     disposePlaybackSinkResources({
@@ -398,7 +496,7 @@ export function useEditorPlayback({
       gainNodeRef,
     });
     setPlaybackReadyRange(null);
-  }, [cancelSelectionWarmup, pausePlayback, stopRenderLoop]);
+  }, [cancelSelectionWarmup, clearPreviewFrameLoad, pausePlayback, stopRenderLoop]);
 
   useEffect(() => {
     const displayedFrame = displayedFrameRef.current;
@@ -431,11 +529,11 @@ export function useEditorPlayback({
       sourceTimelineOffsetRef,
       getPlaybackTime,
       onError: (err) => {
-        setError(errorMessage(err));
+        setPlaybackError(errorMessage(err));
         pausePlayback();
       },
     });
-  }, [getPlaybackTime, pausePlayback]);
+  }, [getPlaybackTime, pausePlayback, setPlaybackError]);
 
   const playPreview = useCallback(async () => {
     if (!inputRef.current || loadingPreview) {
@@ -445,11 +543,16 @@ export function useEditorPlayback({
     const clipStart = clampTime(startTimeRef.current);
     const clipEnd = Math.min(endTimeRef.current || durationRef.current, durationRef.current);
     const playbackTime = getPlaybackTime();
-    const playbackStartTarget = (
-      playbackTime < clipStart || playbackTime >= clipEnd
-        ? clipStart
-        : clampTime(playbackTime)
-    );
+    const playbackPlan = resolvePreviewPlaybackPlan({
+      currentTime: playbackTime,
+      clipStart,
+      clipEnd,
+      duration: durationRef.current,
+    });
+    if (playbackPlan.mode === "source") {
+      clearSelectionWarmState();
+    }
+    const playbackStartTarget = clampTime(playbackPlan.startTime);
     const pendingWarmup = warmupPromiseRef.current;
     const warmupTargetTime = warmupTargetTimeRef.current;
     if (
@@ -463,12 +566,32 @@ export function useEditorPlayback({
       }
     }
 
+    const pendingFrameLoad = previewFrameLoadPromiseRef.current;
+    const pendingFrameTargetTime = previewFrameLoadTargetTimeRef.current;
+    if (
+      pendingFrameLoad
+      && pendingFrameTargetTime !== null
+      && Math.abs(pendingFrameTargetTime - playbackStartTarget) < 1e-6
+    ) {
+      await pendingFrameLoad;
+      if (!inputRef.current || loadingPreview) {
+        return;
+      }
+    }
+
     cancelSelectionWarmup();
 
-    if (playbackTime < clipStart || playbackTime >= clipEnd) {
-      playbackTimeAtStartRef.current = clipStart;
+    playbackStopTimeRef.current = playbackPlan.stopTime;
+    playbackResetTimeRef.current = playbackPlan.resetTime;
+
+    if (Math.abs(playbackTime - playbackStartTarget) > 1e-6) {
+      playbackTimeAtStartRef.current = playbackStartTarget;
       setCurrentTime(playbackTimeAtStartRef.current);
-      await startVideoIterator();
+      await loadPreviewFrameAtPlaybackTime();
+    }
+
+    if (playingRef.current) {
+      return;
     }
 
     let audioContext = audioContextRef.current;
@@ -499,7 +622,15 @@ export function useEditorPlayback({
       );
       void runAudioIterator(generationRef.current);
     }
-  }, [cancelSelectionWarmup, clampTime, getPlaybackTime, loadingPreview, runAudioIterator, startVideoIterator]);
+  }, [
+    cancelSelectionWarmup,
+    clampTime,
+    clearSelectionWarmState,
+    getPlaybackTime,
+    loadPreviewFrameAtPlaybackTime,
+    loadingPreview,
+    runAudioIterator,
+  ]);
 
   const togglePlay = useCallback(() => {
     if (playingRef.current) {
@@ -510,22 +641,39 @@ export function useEditorPlayback({
     void playPreview().catch((err) => {
       setPlaying(false);
       playingRef.current = false;
-      setError(errorMessage(err));
+      setPlaybackError(errorMessage(err));
     });
-  }, [pausePlayback, playPreview]);
+  }, [pausePlayback, playPreview, setPlaybackError]);
 
   const seekToTime = useCallback(async (seconds: number) => {
     const nextTime = clampTime(seconds);
     const wasPlaying = playingRef.current;
     const currentReadyRange = playbackReadyRangeRef.current;
+    const seekPlaybackPlan = resolvePreviewPlaybackPlan({
+      currentTime: nextTime,
+      clipStart: startTimeRef.current,
+      clipEnd: endTimeRef.current,
+      duration: durationRef.current,
+    });
 
     if (wasPlaying) {
       pausePlayback();
     }
 
+    if (seekPlaybackPlan.mode === "source") {
+      clearSelectionWarmState();
+    }
+
+    playbackStopTimeRef.current = null;
+    playbackResetTimeRef.current = null;
     playbackTimeAtStartRef.current = nextTime;
     setCurrentTime(nextTime);
-    await startVideoIterator();
+    try {
+      await loadPreviewFrameAtPlaybackTime();
+    } catch (err) {
+      setPlaybackError(errorMessage(err));
+      return;
+    }
 
     if (
       !wasPlaying
@@ -537,22 +685,28 @@ export function useEditorPlayback({
       )
     ) {
       void warmClipStart(nextTime);
-      void warmClipSelection(startTimeRef.current, endTimeRef.current, {
-        extendToSelectionEnd: false,
-      });
-      scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
+      if (seekPlaybackPlan.mode === "selection") {
+        void warmClipSelection(startTimeRef.current, endTimeRef.current, {
+          extendToSelectionEnd: false,
+        });
+        scheduleSelectionWarmupExtension(startTimeRef.current, endTimeRef.current);
+      } else {
+        cancelSelectionWarmup();
+      }
     }
 
-    if (wasPlaying && nextTime < endTimeRef.current) {
+    if (wasPlaying && nextTime < durationRef.current && !playingRef.current) {
       void playPreview();
     }
   }, [
+    cancelSelectionWarmup,
     clampTime,
-    endTimeRef,
+    clearSelectionWarmState,
+    loadPreviewFrameAtPlaybackTime,
     pausePlayback,
     playPreview,
     scheduleSelectionWarmupExtension,
-    startVideoIterator,
+    setPlaybackError,
     warmClipStart,
     warmClipSelection,
   ]);
@@ -589,6 +743,8 @@ export function useEditorPlayback({
       playbackTimeAtStartRef.current = resetCurrentTime;
       sourceTimelineOffsetRef.current = 0;
       skipLiveWaitRef.current = false;
+      playbackStopTimeRef.current = null;
+      playbackResetTimeRef.current = null;
 
       try {
         const failures: PlaybackLoadFailure[] = [];
@@ -841,7 +997,7 @@ export function useEditorPlayback({
         }
 
         if (!cancelled) {
-          setError(buildPlaybackLoadError(failures));
+          setPlaybackError(buildPlaybackLoadError(failures));
           setHlsFallbackInfo(nextHlsFallbackInfo);
           setSourceVideoDimensions(null);
           setPreviewVideoDimensions(null);
@@ -869,6 +1025,7 @@ export function useEditorPlayback({
     sessionId,
     disposePreview,
     resetPreview,
+    setPlaybackError,
     startRenderLoop,
     startVideoIterator,
   ]);
@@ -879,7 +1036,9 @@ export function useEditorPlayback({
     duration,
     playing,
     loadingPreview,
+    loadingPreviewFrame,
     previewStatus,
+    previewFrameStatus,
     error,
     activeSourceLabel,
     exportFallbackSource,

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -29,10 +29,11 @@ interface UseEditorPlaybackRenderLoopOptions {
   generationRef: RefValue<number>;
   playingRef: RefValue<boolean>;
   playbackTimeAtStartRef: RefValue<number>;
+  playbackStopTimeRef: RefValue<number | null>;
+  playbackResetTimeRef: RefValue<number | null>;
   sourceTimelineOffsetRef: RefValue<number>;
   skipLiveWaitRef: RefValue<boolean>;
   durationRef: RefValue<number>;
-  startTimeRef: RefValue<number>;
   endTimeRef: RefValue<number>;
   subtitleCuesRef: RefValue<readonly SubtitleCue[]>;
   subtitlesEnabledRef: RefValue<boolean>;
@@ -58,10 +59,11 @@ export function useEditorPlaybackRenderLoop({
   generationRef,
   playingRef,
   playbackTimeAtStartRef,
+  playbackStopTimeRef,
+  playbackResetTimeRef,
   sourceTimelineOffsetRef,
   skipLiveWaitRef,
   durationRef,
-  startTimeRef,
   endTimeRef,
   subtitleCuesRef,
   subtitlesEnabledRef,
@@ -250,14 +252,20 @@ export function useEditorPlaybackRenderLoop({
     }
 
     const playbackTime = getPlaybackTime();
-    const clipEnd = Math.min(endTimeRef.current || durationRef.current, durationRef.current);
+    const duration = durationRef.current;
+    const stopTime = playbackStopTimeRef.current
+      ?? Math.min(endTimeRef.current || duration, duration);
 
-    if (playingRef.current && playbackTime >= clipEnd) {
+    if (playingRef.current && playbackTime >= stopTime) {
       pausePlayback(false);
-      const nextTime = clampTime(startTimeRef.current);
+      const nextTime = clampTime(playbackResetTimeRef.current ?? stopTime);
       playbackTimeAtStartRef.current = nextTime;
       setCurrentTime(nextTime);
-      void startVideoIterator();
+      playbackStopTimeRef.current = null;
+      playbackResetTimeRef.current = null;
+      if (nextTime < duration) {
+        void startVideoIterator();
+      }
       return;
     }
 
@@ -282,11 +290,12 @@ export function useEditorPlaybackRenderLoop({
     inputRef,
     nextFrameRef,
     pausePlayback,
+    playbackResetTimeRef,
+    playbackStopTimeRef,
     playbackTimeAtStartRef,
     playingRef,
     setCurrentTime,
     sourceTimelineOffsetRef,
-    startTimeRef,
     startVideoIterator,
     updateNextFrame,
   ]);

--- a/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
@@ -9,6 +9,12 @@ import {
   fromSourceTimelineTime,
   toSourceTimelineTime,
 } from "../../lib/mediabunnyTrackAccess";
+import {
+  createIdlePlaybackReadyRange,
+  isPlaybackReadyRangeVisible,
+  markPlaybackReadyRangeFresh,
+  samePlaybackReadyRange,
+} from "./editorPlaybackWarmupRange";
 import { isPresent } from "./editorPlaybackSources";
 import type {
   PlaybackReadyRange,
@@ -125,27 +131,28 @@ export function useEditorPlaybackSelectionWarmup({
       return;
     }
 
-    const nextRange: PlaybackReadyRange = {
+    const nextRange = markPlaybackReadyRangeFresh({
       startTime: normalizedStart,
       endTime: normalizedEnd,
       readyUntilTime: normalizedStart,
       status: "warming",
-    };
+    });
     const currentReadyRange = playbackReadyRangeRef.current;
     if (
-      samePlaybackRange(currentReadyRange, nextRange)
+      samePlaybackReadyRange(currentReadyRange, nextRange)
       && currentReadyRange?.status === "ready"
       && currentReadyRange.readyUntilTime >= normalizedEnd
+      && isPlaybackReadyRangeVisible(currentReadyRange)
     ) {
       return;
     }
 
     setPlaybackReadyRange((current) => {
-      if (samePlaybackRange(current, nextRange) && current) {
-        return {
+      if (samePlaybackReadyRange(current, nextRange) && current) {
+        return markPlaybackReadyRangeFresh({
           ...current,
           status: current.status === "ready" ? "ready" : "warming",
-        };
+        });
       }
 
       return nextRange;
@@ -201,7 +208,7 @@ export function useEditorPlaybackSelectionWarmup({
 
       lastPublishedReadyUntil = Math.max(lastPublishedReadyUntil, clampedReadyUntil);
       setPlaybackReadyRange((current) => {
-        const baseRange: PlaybackReadyRange = samePlaybackRange(current, nextRange) && current
+        const baseRange: PlaybackReadyRange = samePlaybackReadyRange(current, nextRange) && current
           ? current
           : {
               ...nextRange,
@@ -216,12 +223,12 @@ export function useEditorPlaybackSelectionWarmup({
           return current ?? baseRange;
         }
 
-        return {
+        return markPlaybackReadyRangeFresh({
           startTime: normalizedStart,
           endTime: normalizedEnd,
           readyUntilTime,
           status,
-        };
+        });
       });
     };
 
@@ -447,15 +454,10 @@ export function useEditorPlaybackSelectionWarmup({
       return;
     }
 
-    const nextRange: PlaybackReadyRange = {
-      startTime: normalizedStart,
-      endTime: normalizedEnd,
-      readyUntilTime: normalizedStart,
-      status: "idle",
-    };
+    const nextRange = createIdlePlaybackReadyRange(normalizedStart, normalizedEnd);
 
     setPlaybackReadyRange((current) => (
-      samePlaybackRange(current, nextRange) ? current : nextRange
+      samePlaybackReadyRange(current, nextRange) ? current : nextRange
     ));
 
     const warmupSessionKey = `${sessionId}:hls:${normalizedStart}:${normalizedEnd}`;
@@ -524,13 +526,17 @@ export function useEditorPlaybackSelectionWarmup({
 
     const normalizedCurrent = Number(clampTime(currentTime).toFixed(6));
     setPlaybackReadyRange((current) => {
-      if (!current) {
+      if (
+        !current
+        || normalizedCurrent < current.startTime
+        || normalizedCurrent > current.endTime
+      ) {
         return current;
       }
 
       const readyUntilTime = Math.max(
         current.readyUntilTime,
-        Math.min(current.endTime, normalizedCurrent),
+        normalizedCurrent,
       );
       const status = readyUntilTime >= current.endTime ? "ready" : "warming";
 
@@ -541,11 +547,11 @@ export function useEditorPlaybackSelectionWarmup({
         return current;
       }
 
-      return {
+      return markPlaybackReadyRangeFresh({
         ...current,
         readyUntilTime,
         status,
-      };
+      });
     });
   }, [activeSourceLabel, clampTime, currentTime, playing, setPlaybackReadyRange]);
 
@@ -554,16 +560,4 @@ export function useEditorPlaybackSelectionWarmup({
     warmClipSelection,
     scheduleSelectionWarmupExtension,
   };
-}
-
-function samePlaybackRange(
-  left: Pick<PlaybackReadyRange, "startTime" | "endTime"> | null | undefined,
-  right: Pick<PlaybackReadyRange, "startTime" | "endTime">,
-) {
-  return (
-    left !== null
-    && left !== undefined
-    && Math.abs(left.startTime - right.startTime) < 1e-6
-    && Math.abs(left.endTime - right.endTime) < 1e-6
-  );
 }

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, startTransition, type WheelEvent as ReactWheelEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, startTransition } from "react";
 import type { TimelineState } from "@xzdarcy/react-timeline-editor";
 import { 
   getTimelineZoomLevels, 
@@ -348,7 +348,7 @@ export function useEditorTimeline({
     updateTimelineZoom(1, { anchorTime: getTimelineZoomAnchorTime() });
   }, [getTimelineZoomAnchorTime, updateTimelineZoom]);
 
-  const handleTimelineWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+  const handleTimelineWheel = useCallback((event: WheelEvent) => {
     if (!hasDuration) return;
 
     const timelineWheelRegion = timelineWheelRegionRef.current;
@@ -395,6 +395,17 @@ export function useEditorTimeline({
     if (zoomDelta === 0) return;
     updateTimelineZoom(zoomDelta, { anchorClientX: event.clientX });
   }, [hasDuration, duration, activeTimelineScale, availableTimelineZoomLevels, updateTimelineZoom]);
+
+  useEffect(() => {
+    const timelineWheelRegion = timelineWheelRegionRef.current;
+    if (!timelineWheelRegion) return;
+
+    timelineWheelRegion.addEventListener("wheel", handleTimelineWheel, { passive: false });
+
+    return () => {
+      timelineWheelRegion.removeEventListener("wheel", handleTimelineWheel);
+    };
+  }, [handleTimelineWheel]);
 
   const handleTimelineChange = useCallback((nextData: ClipTimelineData) => {
     const nextAction = nextData
@@ -451,7 +462,6 @@ export function useEditorTimeline({
     timelineScrollLeft,
     timelineViewportWidth,
     handleTimelineScroll,
-    handleTimelineWheel,
     handleTimelineZoomIn,
     handleTimelineZoomOut,
     canZoomIn: hasDuration && timelineZoomIndex > 0,

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -786,7 +786,7 @@ export async function proxyMedia(
       try {
         const upstream = await fetchMediaHandleRequest(handle, {
           headers,
-          signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
+          timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
         });
 
         if (!upstream.ok && upstream.status !== 206) {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -402,6 +402,118 @@ void test("strips provider auth headers from cross-origin media redirects", asyn
   }
 });
 
+void test("retries transient media fetch failures", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+    if (fetchCount === 1) {
+      throw new TypeError("fetch failed");
+    }
+
+    return new Response("ok", {
+      status: 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(createMediaHandle({
+      path: "/library/parts/1/file.mp4",
+    }), {
+      retryBaseDelayMs: 0,
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+    assert.equal(fetchCount, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("retries retryable upstream media responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+
+    return new Response(fetchCount === 1 ? "busy" : "ok", {
+      status: fetchCount === 1 ? 503 : 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(createMediaHandle({
+      path: "/library/parts/1/file.mp4",
+    }), {
+      retryBaseDelayMs: 0,
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+    assert.equal(fetchCount, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("does not retry non-transient upstream media responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+
+    return new Response("missing", {
+      status: 404,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(createMediaHandle({
+      path: "/library/parts/1/file.mp4",
+    }), {
+      retryBaseDelayMs: 0,
+    });
+
+    assert.equal(response.status, 404);
+    assert.equal(await response.text(), "missing");
+    assert.equal(fetchCount, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("retries not-yet-generated HLS-derived media responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+
+    return new Response(fetchCount < 3 ? "missing" : "ok", {
+      status: fetchCount < 3 ? 404 : 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(createMediaHandle({
+      path: "/hls/segment0.ts",
+      basePath: "/hls/",
+    }), {
+      retryBaseDelayMs: 0,
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+    assert.equal(fetchCount, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 void test("sanitizes logged media paths by stripping query strings", () => {
   assert.equal(
     sanitizeLoggedMediaPath("https://cdn.example.com/hls/segment0.ts?sig=secret#frag"),

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import type { Request, Response } from "express";
 import { updateMediaSource, type MediaSource } from "../../db/mediaSourcesRepository.js";
 import { ApiError } from "../../http/errors.js";
@@ -56,6 +56,7 @@ import {
 
 const logger = getServerLogger(["providers", "plex"]);
 const HD_ARTWORK_SIZE = 1920;
+const PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH = 16;
 
 function createMediaHandle(
   session: ProviderSessionRecord,
@@ -242,7 +243,7 @@ function resolveSelectedPart(item: any, selection?: PlexMediaSelection) {
 
 export function createPreviewPath(
   item: any,
-  playbackSessionId: string,
+  transcodeSessionId: string,
   selection?: PlexMediaSelection
 ) {
   if (String(item?.type ?? "").toLowerCase() === "track") {
@@ -257,7 +258,7 @@ export function createPreviewPath(
   const resolvedSelection = resolveSelectedPart(item, selection);
   const params = new URLSearchParams({
     path,
-    transcodeSessionId: playbackSessionId,
+    transcodeSessionId,
     protocol: "hls",
     directPlay: "0",
     directStream: "0",
@@ -275,6 +276,19 @@ export function createPreviewPath(
   });
 
   return `/video/:/transcode/universal/start.m3u8?${params.toString()}`;
+}
+
+export function createCliparrPlexTranscodeSessionId(sourceId: string, playbackSessionId: string) {
+  const safeSourceId = sourceId
+    .replace(/[^a-z0-9_-]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH) || "source";
+  const digest = createHash("sha256")
+    .update(`${sourceId}:${playbackSessionId}`)
+    .digest("hex")
+    .slice(0, 16);
+
+  return `cliparr-${safeSourceId}-${digest}`;
 }
 
 function transcodeSessionId(path: string) {
@@ -866,14 +880,15 @@ async function normalizeCurrentPlayback(
 
   return Promise.all(uniqueMetadata.map(async (item) => {
     const sessionId = playbackSessionIdentity(item);
+    const transcodeSessionId = createCliparrPlexTranscodeSessionId(source.id, sessionId);
     const mediaSelection = deriveMediaSelection(item);
     const enrichedItem = await enrichMetadataItem(context, item);
     const mediaPath = await resolveMediaPath(context, item, enrichedItem, mediaSelection);
-    const previewPath = createPreviewPath(enrichedItem, sessionId, mediaSelection);
+    const previewPath = createPreviewPath(enrichedItem, transcodeSessionId, mediaSelection);
     const thumbPath = metadataImagePath(enrichedItem);
     const selectedAudioTrack = deriveSelectedAudioTrack(enrichedItem, mediaSelection);
     const selectedSubtitleTrack = deriveSelectedSubtitleTrack(enrichedItem, mediaSelection);
-    const subtitleTracks = deriveSubtitleTracks(session, context, enrichedItem, sessionId, mediaSelection)
+    const subtitleTracks = deriveSubtitleTracks(session, context, enrichedItem, transcodeSessionId, mediaSelection)
       .filter((track) => subtitleTrackSupportsBurnIn(track));
     const selectedPart = resolveSelectedPart(enrichedItem, mediaSelection)?.part;
     const audioStreams = selectedPart ? streamEntries(selectedPart).filter((stream) => isAudioStream(stream)) : [];
@@ -892,6 +907,7 @@ async function normalizeCurrentPlayback(
       sourceId: source.id,
       providerAccountId: session.providerAccountId,
       playbackSessionId: sessionId,
+      transcodeSessionId,
       currentlyPlayingItem: {
         id: `${source.id}:${sessionId}`,
         title: String(enrichedItem.title ?? "Untitled"),

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ProviderSessionRecord } from "../session/store.js";
 import {
+  createCliparrPlexTranscodeSessionId,
   createPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
@@ -57,6 +58,18 @@ void test("uses a stable Plex transcode session id for repeated playback polls",
   assert.notEqual(firstPath, differentSessionPath);
   assert.match(firstPath ?? "", /transcodeSessionId=plex-session-1/);
   assert.match(firstPath ?? "", /subtitles=none/);
+});
+
+void test("creates a Cliparr-owned Plex transcode session id", () => {
+  const firstId = createCliparrPlexTranscodeSessionId("source-1", "plex-session-1");
+  const secondId = createCliparrPlexTranscodeSessionId("source-1", "plex-session-1");
+  const differentPlaybackId = createCliparrPlexTranscodeSessionId("source-1", "plex-session-2");
+  const differentSourceId = createCliparrPlexTranscodeSessionId("source-2", "plex-session-1");
+
+  assert.equal(firstId, secondId);
+  assert.notEqual(firstId, differentPlaybackId);
+  assert.notEqual(firstId, differentSourceId);
+  assert.match(firstId, /^cliparr-source-1-[a-f0-9]{16}$/);
 });
 
 void test("does not create Plex HLS preview paths for audio tracks", () => {

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -36,6 +36,12 @@ interface ProxyMediaResponseOptions {
   ) => string;
 }
 
+interface FetchMediaHandleRequestInit extends RequestInit {
+  retryAttempts?: number;
+  retryBaseDelayMs?: number;
+  timeoutMs?: number;
+}
+
 interface CachedProxyMediaResponse {
   status: number;
   headers: [string, string][];
@@ -61,11 +67,24 @@ const PROXY_HEADER_ALLOWLIST = [
 const HLS_PROXY_RESPONSE_CACHE_TTL_MS = 4_000;
 const HLS_PROXY_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const MEDIA_PROXY_MAX_REDIRECTS = 5;
+const MEDIA_PROXY_FETCH_ATTEMPTS = 3;
+const HLS_MEDIA_PROXY_FETCH_ATTEMPTS = 5;
+const MEDIA_PROXY_FETCH_RETRY_BASE_DELAY_MS = 150;
+const MEDIA_PROXY_FETCH_RETRY_MAX_DELAY_MS = 1_000;
 const DNS_VALIDATION_CACHE_TTL_MS = 60_000;
 const DISALLOWED_MEDIA_HOSTNAMES = new Set([
   "metadata",
   "metadata.azure.internal",
   "metadata.google.internal",
+]);
+const RETRYABLE_MEDIA_STATUS_CODES = new Set([
+  408,
+  425,
+  429,
+  500,
+  502,
+  503,
+  504,
 ]);
 const logger = getServerLogger(["providers", "media-proxy"]);
 const cachedProxyResponses = new Map<string, {
@@ -277,7 +296,102 @@ function removeSensitiveRedirectHeaders(init: RequestInit) {
   };
 }
 
-export async function fetchMediaHandleRequest(handle: MediaHandle, init: RequestInit = {}) {
+function retryDelayMs(attemptIndex: number, baseDelayMs: number) {
+  return Math.min(
+    MEDIA_PROXY_FETCH_RETRY_MAX_DELAY_MS,
+    Math.max(0, baseDelayMs) * (2 ** attemptIndex),
+  );
+}
+
+function delay(ms: number) {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  const signalWithReason = signal as AbortSignal & { reason?: unknown };
+  return signalWithReason.reason;
+}
+
+function createAttemptRequestInit(
+  init: RequestInit,
+  timeoutMs: number | undefined,
+) {
+  if (!timeoutMs && !init.signal) {
+    return {
+      init,
+      cleanup: () => undefined,
+    };
+  }
+
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const abortFromSource = () => {
+    controller.abort(init.signal ? abortReason(init.signal) : undefined);
+  };
+
+  if (init.signal?.aborted) {
+    abortFromSource();
+  } else {
+    init.signal?.addEventListener("abort", abortFromSource, { once: true });
+  }
+
+  if (timeoutMs && timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      controller.abort(new DOMException("Media proxy request timed out", "TimeoutError"));
+    }, timeoutMs);
+  }
+
+  return {
+    init: {
+      ...init,
+      signal: controller.signal,
+    },
+    cleanup: () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      init.signal?.removeEventListener("abort", abortFromSource);
+    },
+  };
+}
+
+function isAbortLikeError(err: unknown) {
+  return err instanceof DOMException
+    && (err.name === "AbortError" || err.name === "TimeoutError");
+}
+
+function isRetryableMediaFetchError(err: unknown, sourceSignal: AbortSignal | null | undefined) {
+  if (sourceSignal?.aborted) {
+    return false;
+  }
+
+  if (err instanceof ApiError) {
+    return false;
+  }
+
+  return err instanceof Error || isAbortLikeError(err);
+}
+
+function isRetryableMediaResponse(handle: MediaHandle, response: globalThis.Response) {
+  return RETRYABLE_MEDIA_STATUS_CODES.has(response.status)
+    || (response.status === 404 && isHlsDerivedHandle(handle));
+}
+
+async function closeRetryableResponse(response: globalThis.Response) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The response body is discarded before retrying; cleanup failure is non-fatal.
+  }
+}
+
+async function fetchMediaHandleRequestOnce(handle: MediaHandle, init: RequestInit = {}) {
   let requestUrl = mediaHandleRequestUrl(handle);
   let requestInit = init;
 
@@ -305,6 +419,65 @@ export async function fetchMediaHandleRequest(handle: MediaHandle, init: Request
     "media_proxy_redirect_limit",
     "Media URL redirected too many times"
   );
+}
+
+export async function fetchMediaHandleRequest(handle: MediaHandle, init: FetchMediaHandleRequestInit = {}) {
+  const {
+    retryAttempts = MEDIA_PROXY_FETCH_ATTEMPTS,
+    retryBaseDelayMs = MEDIA_PROXY_FETCH_RETRY_BASE_DELAY_MS,
+    timeoutMs,
+    ...requestInit
+  } = init;
+  const totalAttempts = Math.max(
+    1,
+    Math.floor(retryAttempts),
+    isHlsDerivedHandle(handle) ? HLS_MEDIA_PROXY_FETCH_ATTEMPTS : 1,
+  );
+  let lastError: unknown;
+
+  for (let attemptIndex = 0; attemptIndex < totalAttempts; attemptIndex += 1) {
+    const attemptNumber = attemptIndex + 1;
+    const isFinalAttempt = attemptNumber >= totalAttempts;
+    const { init: attemptInit, cleanup } = createAttemptRequestInit(requestInit, timeoutMs);
+
+    try {
+      const response = await fetchMediaHandleRequestOnce(handle, attemptInit).finally(cleanup);
+      if (!isRetryableMediaResponse(handle, response) || isFinalAttempt) {
+        return response;
+      }
+
+      await closeRetryableResponse(response);
+      logger.trace("Retrying media request after retryable upstream status for handle {handleId}.", {
+        handleId: handle.id,
+        providerId: handle.providerId,
+        sourceId: handle.sourceId,
+        path: sanitizeLoggedMediaPath(handle.path),
+        statusCode: response.status,
+        attempt: attemptNumber,
+        maxAttempts: totalAttempts,
+      });
+    } catch (err) {
+      cleanup();
+      lastError = err;
+      if (isFinalAttempt || !isRetryableMediaFetchError(err, requestInit.signal)) {
+        throw err;
+      }
+
+      logger.trace("Retrying media request after fetch failure for handle {handleId}.", {
+        handleId: handle.id,
+        providerId: handle.providerId,
+        sourceId: handle.sourceId,
+        path: sanitizeLoggedMediaPath(handle.path),
+        attempt: attemptNumber,
+        maxAttempts: totalAttempts,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    await delay(retryDelayMs(attemptIndex, retryBaseDelayMs));
+  }
+
+  throw lastError;
 }
 
 export function sanitizeLoggedMediaPath(value: string | undefined) {


### PR DESCRIPTION
## Summary
- let timeline playback preview from the current playhead when it is clearly outside the selected clip
- keep near-selection play behavior by snapping only when close to the clip start
- add media proxy retries for transient HLS/media fetch failures across Plex, Jellyfin, and direct URLs

## Why
Seeking away from the selected clip could jump playback back to the selection start, making it hard to preview other sections. Transient upstream media failures could also fail playback immediately during HLS playlist or segment fetches.

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/frontend lint:eslint
- pnpm --filter @cliparr/server test
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/server lint:eslint