### PR TITLE
fix: support squash release title lookup

### DIFF
--- a/scripts/release/conventional.mjs
+++ b/scripts/release/conventional.mjs
@@ -218,8 +218,10 @@ export function extractReleaseTitleFromCommitMessage(message) {
 
 export function extractPullRequestNumberFromCommitMessage(message) {
   const subject = message.replace(/\r\n/g, "\n").split("\n")[0]?.trim() ?? "";
-  const match = /^Merge pull request #(?<number>\d+) /u.exec(subject);
-  return match?.groups?.number ? Number(match.groups.number) : undefined;
+  const match = /^(?:Merge pull request #(?<mergeNumber>\d+) |\S[\s\S]* \(#(?<squashNumber>\d+)\)$)/u.exec(subject);
+  const number = match?.groups?.mergeNumber ?? match?.groups?.squashNumber;
+
+  return number ? Number(number) : undefined;
 }
 
 export function parseGitLogMessages(logOutput) {

--- a/scripts/release/conventional.test.mjs
+++ b/scripts/release/conventional.test.mjs
@@ -69,3 +69,10 @@ feat: add cliparr.dev website`;
   assert.equal(extractReleaseTitleFromCommitMessage(message), "feat: add cliparr.dev website");
   assert.equal(extractPullRequestNumberFromCommitMessage(message), 82);
 });
+
+void test("extracts pull request numbers from squash commits", () => {
+  const message = `[codex] Prepare Cloudflare Worker deploy (#83)`;
+
+  assert.equal(extractReleaseTitleFromCommitMessage(message), message);
+  assert.equal(extractPullRequestNumberFromCommitMessage(message), 83);
+});


### PR DESCRIPTION
## Summary
- Teach the release planner to extract PR numbers from squash-merge subjects like `... (#83)`
- Add a regression test for squash commits blocking release planning

## Validation
- `pnpm test:release`
- `node scripts/release/plan-release.mjs --channel stable --target HEAD --image-name ghcr.io/techsquidtv/cliparr` planned `v0.6.1`