### PR TITLE
fix: allow dry-run release without image digest

### DIFF
--- a/scripts/release/create-github-release.mjs
+++ b/scripts/release/create-github-release.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { appendFileSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = {
     dryRun: false,
     prerelease: false,
@@ -27,7 +28,7 @@ function parseArgs(argv) {
     ) {
       const value = argv[index + 1];
 
-      if (!value) {
+      if (value === undefined) {
         throw new Error(`${arg} requires a value.`);
       }
 
@@ -75,7 +76,7 @@ function readDockerTags(filePath) {
     .filter(Boolean);
 }
 
-function composeReleaseBody({ generatedBody, imageName, imageDigest, dockerTags }) {
+export function composeReleaseBody({ generatedBody, imageName, imageDigest, dockerTags }) {
   const pullTag = dockerTags.find((tag) => !tag.endsWith(":latest") && !/:sha-[a-f0-9]+$/u.test(tag)) ?? dockerTags[0];
   const dockerLines = [
     "## Docker image",
@@ -107,8 +108,8 @@ function writeGithubOutput(outputs) {
   appendFileSync(outputFile, `${Object.entries(outputs).map(([key, value]) => `${key}=${value}`).join("\n")}\n`);
 }
 
-try {
-  const args = parseArgs(process.argv.slice(2));
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
   const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
 
   if (!token) {
@@ -155,7 +156,13 @@ try {
 
   console.log(`Created release ${release.html_url}`);
   writeGithubOutput({ html_url: release.html_url });
-} catch (error) {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
 }

--- a/scripts/release/create-github-release.test.mjs
+++ b/scripts/release/create-github-release.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { composeReleaseBody, parseArgs } from "./create-github-release.mjs";
+
+const requiredArgs = [
+  "--repository",
+  "TechSquidTV/Cliparr",
+  "--tag",
+  "v0.6.1",
+  "--target",
+  "HEAD",
+  "--previous-tag",
+  "v0.6.0",
+  "--name",
+  "v0.6.1",
+  "--image-name",
+  "ghcr.io/techsquidtv/cliparr",
+  "--docker-tags-file",
+  "/tmp/docker-tags.txt",
+];
+
+void test("accepts an empty image digest for dry-run releases", () => {
+  const args = parseArgs([...requiredArgs, "--image-digest", "", "--dry-run"]);
+
+  assert.equal(args.imageDigest, "");
+  assert.equal(args.dryRun, true);
+});
+
+void test("rejects release arguments with missing values", () => {
+  assert.throws(
+    () => parseArgs([...requiredArgs, "--image-digest"]),
+    /--image-digest requires a value\./u,
+  );
+});
+
+void test("omits the digest line when no image digest exists", () => {
+  const body = composeReleaseBody({
+    generatedBody: "## What's Changed\n\n- fix release dry runs",
+    imageName: "ghcr.io/techsquidtv/cliparr",
+    imageDigest: "",
+    dockerTags: ["ghcr.io/techsquidtv/cliparr:0.6.1", "ghcr.io/techsquidtv/cliparr:latest"],
+  });
+
+  assert.match(body, /docker pull ghcr\.io\/techsquidtv\/cliparr:0\.6\.1/u);
+  assert.doesNotMatch(body, /Digest:/u);
+});


### PR DESCRIPTION
## Summary
- Allow `--image-digest ""` so release dry runs can generate notes before an image digest exists
- Make the GitHub release helper import-safe for focused unit coverage
- Add regression coverage for dry-run digest handling and release body output

## Validation
- `pnpm test:release`
- `pnpm lint:eslint`