### PR TITLE
ci: Authenticate GitHub release build fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,6 @@ jobs:
         run: pnpm docs:check
 
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Build
         env:
           CLIPARR_VERSION: ${{ steps.plan.outputs.tag }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: pnpm build
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary

- Pass the built-in GitHub Actions token into the CI docs/app build.
- Pass the same token into the release workflow build step.

## Root Cause

The Astro docs site mirrors GitHub Releases during `pnpm build`. The loader already supports `GITHUB_TOKEN`/`GH_TOKEN`, but the CI build step did not expose a token, so the GitHub Releases API request could hit the unauthenticated rate limit before any Cloudflare step ran.

## Validation

- `git diff --check`
- Parsed `.github/workflows/ci.yml` and `.github/workflows/release.yml` as YAML
- Confirmed an authenticated GitHub Releases API call returns release data
