### PR TITLE
test: Add critical test coverage

### DIFF
--- a/apps/frontend/src/api/cliparrClient.test.ts
+++ b/apps/frontend/src/api/cliparrClient.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { cliparrClient, subscribeToAuthFailure } from "./cliparrClient";
+
+function jsonResponse(value: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(value), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+}
+
+async function withMockedFetch<T>(
+  handler: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>,
+  action: () => Promise<T>
+) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+void test("handles 204 responses without trying to parse JSON", async () => {
+  await withMockedFetch(async (input, init) => {
+    assert.equal(input, "/api/session");
+    assert.equal(init?.method, "DELETE");
+    return new Response(null, { status: 204 });
+  }, async () => {
+    await cliparrClient.logout();
+  });
+});
+
+void test("reports app-page responses as API configuration errors", async () => {
+  await withMockedFetch(async () => {
+    return new Response("<!doctype html><title>Cliparr</title>", {
+      status: 200,
+      headers: {
+        "content-type": "text/html",
+      },
+    });
+  }, async () => {
+    await assert.rejects(
+      () => cliparrClient.getHealth(),
+      /Cliparr API returned the app page instead of JSON/
+    );
+  });
+});
+
+void test("surfaces JSON API errors and coalesces auth failure notifications", async () => {
+  await withMockedFetch(async () => {
+    return jsonResponse({
+      error: {
+        code: "not_authenticated",
+        message: "Sign in with a provider first",
+      },
+    }, {
+      status: 401,
+      statusText: "Unauthorized",
+    });
+  }, async () => {
+    let authFailureCount = 0;
+    const unsubscribe = subscribeToAuthFailure(() => {
+      authFailureCount += 1;
+    });
+
+    try {
+      const results = await Promise.allSettled([
+        cliparrClient.getSession(),
+        cliparrClient.listSources(),
+      ]);
+
+      assert.equal(results[0]?.status, "rejected");
+      assert.equal(results[1]?.status, "rejected");
+      const error = results[0]?.status === "rejected" ? results[0].reason as Error & { status?: number; code?: string } : undefined;
+      assert.equal(error?.name, "CliparrRequestError");
+      assert.equal(error?.message, "Sign in with a provider first");
+      assert.equal(error?.status, 401);
+      assert.equal(error?.code, "not_authenticated");
+
+      await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+      assert.equal(authFailureCount, 1);
+    } finally {
+      unsubscribe();
+    }
+  });
+});
+
+void test("follows app auth redirects with the current browser location", async () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  let assignedUrl = "";
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        origin: "http://cliparr.test",
+        pathname: "/dashboard",
+        search: "?tab=sources",
+        hash: "#top",
+        assign(url: string) {
+          assignedUrl = url;
+        },
+      },
+    },
+  });
+
+  try {
+    await withMockedFetch(async () => {
+      return {
+        redirected: true,
+        url: "http://cliparr.test/api/auth/plex?state=abc",
+      } as Response;
+    }, async () => {
+      void cliparrClient.getHealth();
+      await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+      assert.equal(
+        assignedUrl,
+        "http://cliparr.test/api/auth/plex?state=abc&redirectUrl=%2Fdashboard%3Ftab%3Dsources%23top"
+      );
+    });
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  }
+});

--- a/apps/frontend/src/components/SourcesModalSections.tsx
+++ b/apps/frontend/src/components/SourcesModalSections.tsx
@@ -75,11 +75,7 @@ const secondarySurfaceClasses =
 const elevatedGlassClasses =
   "border-[color:color-mix(in_oklch,var(--foreground)_10%,transparent)] bg-[color:color-mix(in_oklch,var(--card)_72%,transparent)]";
 
-export function compareStrings(left: string, right: string) {
-  return left.localeCompare(right, undefined, { sensitivity: "base" });
-}
-
-export function stringValue(value: unknown) {
+function stringValue(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
@@ -129,14 +125,6 @@ function sourceStatus(source: MediaSource) {
     className: secondarySurfaceClasses,
     icon: Globe,
   };
-}
-
-export function sortSources(sources: MediaSource[]) {
-  return [...sources].sort((left, right) =>
-    compareStrings(formatProviderName(left.providerId), formatProviderName(right.providerId))
-    || compareStrings(left.name, right.name)
-    || compareStrings(left.id, right.id)
-  );
 }
 
 interface SourcesModalHeaderProps {

--- a/apps/frontend/src/components/editor/useEditorExport.test.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.test.ts
@@ -3,7 +3,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createProviderUrlSource, type EditorMediaSource } from "../../lib/editorMedia";
-import { resolveExportSource } from "./useEditorExport";
+import {
+  buildExportSourceLabel,
+  buildExportSourceMessage,
+  buildExportSourceSummaryMessage,
+  getEditorExportReadiness,
+  getOutputDimensions,
+  resolveExportSource,
+} from "./useEditorExport";
 
 const localFileSource = {
   kind: "file",
@@ -66,4 +73,173 @@ void test("uses export fallback source when auto-selected", () => {
     source: localFileSource,
     kind: "direct",
   });
+});
+
+void test("reports editor export readiness and subtitle blockers", () => {
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+  const readySource = { source: hlsSource, kind: "hls" as const };
+  const textSubtitleTrack = {
+    streamId: "subtitle-1",
+    isText: true,
+    contentUrl: "/subtitles/1.srt",
+    contentFormat: "srt",
+  };
+  const imageSubtitleTrack = {
+    streamId: "subtitle-2",
+    isText: false,
+    codec: "pgs",
+  };
+  const subtitleCues = [{
+    startTime: 1,
+    endTime: 2,
+    text: "Hello",
+    lines: ["Hello"],
+  }];
+
+  assert.deepEqual(getEditorExportReadiness({
+    exportSource: { source: null, kind: "none" },
+    exporting: false,
+    startTime: 0,
+    endTime: 10,
+    subtitleEnabled: false,
+    selectedSubtitleTrack: null,
+    clippedSubtitleCues: [],
+    subtitleLoading: false,
+  }), {
+    state: "idle",
+    shouldBurnSubtitles: false,
+  });
+
+  assert.deepEqual(getEditorExportReadiness({
+    exportSource: readySource,
+    exporting: false,
+    startTime: 10,
+    endTime: 10,
+    subtitleEnabled: false,
+    selectedSubtitleTrack: null,
+    clippedSubtitleCues: [],
+    subtitleLoading: false,
+  }), {
+    state: "blocked",
+    message: "Waiting for media duration.",
+    shouldBurnSubtitles: false,
+  });
+
+  assert.deepEqual(getEditorExportReadiness({
+    exportSource: readySource,
+    exporting: false,
+    startTime: 0,
+    endTime: 10,
+    subtitleEnabled: true,
+    selectedSubtitleTrack: textSubtitleTrack,
+    clippedSubtitleCues: subtitleCues,
+    subtitleLoading: true,
+  }), {
+    state: "blocked",
+    message: "Subtitles are still loading.",
+    shouldBurnSubtitles: true,
+  });
+
+  assert.deepEqual(getEditorExportReadiness({
+    exportSource: readySource,
+    exporting: false,
+    startTime: 0,
+    endTime: 10,
+    subtitleEnabled: true,
+    selectedSubtitleTrack: imageSubtitleTrack,
+    clippedSubtitleCues: subtitleCues,
+    subtitleLoading: false,
+  }), {
+    state: "blocked",
+    message: "This subtitle track is not supported.",
+    shouldBurnSubtitles: true,
+  });
+
+  assert.deepEqual(getEditorExportReadiness({
+    exportSource: readySource,
+    exporting: false,
+    startTime: 0,
+    endTime: 10,
+    subtitleEnabled: true,
+    selectedSubtitleTrack: textSubtitleTrack,
+    clippedSubtitleCues: subtitleCues,
+    subtitleLoading: false,
+  }), {
+    state: "ready",
+    source: hlsSource,
+    sourceKind: "hls",
+    shouldBurnSubtitles: true,
+  });
+});
+
+void test("builds export dimensions and source messaging", () => {
+  const hlsSource = createProviderUrlSource("/playback/master.m3u8", "hls");
+  const directSource = createProviderUrlSource("/media/movie.mp4", "direct");
+  const directUrlSource = {
+    kind: "url",
+    role: "direct-url",
+    label: "URL",
+    url: "/api/media/local-url/handle",
+  } satisfies EditorMediaSource;
+
+  assert.deepEqual(getOutputDimensions({ width: 1920, height: 1080 }, "720"), {
+    width: 1280,
+    height: 720,
+  });
+  assert.deepEqual(getOutputDimensions({ width: 1920, height: 1080 }, "original"), {
+    width: 1920,
+    height: 1080,
+  });
+  assert.equal(getOutputDimensions({ width: 0, height: 1080 }, "720"), null);
+
+  assert.equal(buildExportSourceLabel({
+    preference: "auto",
+    resolvedSourceKind: "direct",
+    resolvedSource: directSource,
+    exportFallbackSource: directSource,
+  }), "Auto: Direct/original fallback");
+
+  assert.equal(buildExportSourceLabel({
+    preference: "hls",
+    resolvedSourceKind: "none",
+    resolvedSource: null,
+  }), "Unavailable");
+
+  assert.equal(buildExportSourceMessage({
+    preference: "auto",
+    resolvedSourceKind: "direct",
+    resolvedSource: directSource,
+    hlsSource,
+    directSource,
+    hlsFallbackInfo: {
+      category: "shared-export-blocking",
+      message: "browser cannot read the stream",
+    },
+  }), "Export switched to direct media: browser cannot read the stream");
+
+  assert.equal(buildExportSourceMessage({
+    preference: "auto",
+    resolvedSourceKind: "hls",
+    resolvedSource: hlsSource,
+    hlsSource,
+    directSource,
+    hlsFallbackInfo: {
+      category: "shared-export-blocking",
+      message: "browser cannot read the stream",
+    },
+  }), "Export cannot use this HLS stream: browser cannot read the stream");
+
+  assert.equal(buildExportSourceMessage({
+    preference: "auto",
+    resolvedSourceKind: "direct",
+    resolvedSource: directUrlSource,
+    hlsFallbackInfo: null,
+  }), "Export reads this media URL through Cliparr.");
+
+  assert.equal(buildExportSourceSummaryMessage({
+    preference: "direct",
+    resolvedSourceKind: "direct",
+    resolvedSource: directSource,
+    hlsSource,
+  }), "Using direct media.");
 });

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -32,6 +32,17 @@ interface ResolvedExportSource {
   kind: ResolvedExportSourceKind;
 }
 
+interface ExportReadinessInput {
+  exportSource: ResolvedExportSource;
+  exporting: boolean;
+  startTime: number;
+  endTime: number;
+  subtitleEnabled: boolean;
+  selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  clippedSubtitleCues: readonly SubtitleCue[];
+  subtitleLoading: boolean;
+}
+
 interface UseEditorExportProps {
   session: EditorSession;
   startTime: number;
@@ -214,26 +225,27 @@ export function useEditorExport({
   }, []);
 
   const handleExport = useCallback(async () => {
-    if (!exportSource.source) return;
-    if (exporting) return;
-    if (endTime <= startTime) {
-      setExportError("Waiting for media duration.");
+    const readiness = getEditorExportReadiness({
+      exportSource,
+      exporting,
+      startTime,
+      endTime,
+      subtitleEnabled,
+      selectedSubtitleTrack,
+      clippedSubtitleCues,
+      subtitleLoading,
+    });
+
+    if (readiness.state === "idle") {
       return;
     }
 
-    const shouldBurnSubtitles = subtitleEnabled
-      && selectedSubtitleTrack !== null
-      && clippedSubtitleCues.length > 0;
-
-    if (shouldBurnSubtitles && subtitleLoading) {
-      setExportError("Subtitles are still loading.");
+    if (readiness.state === "blocked") {
+      setExportError(readiness.message);
       return;
     }
 
-    if (shouldBurnSubtitles && !subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
-      setExportError("This subtitle track is not supported.");
-      return;
-    }
+    const shouldBurnSubtitles = readiness.shouldBurnSubtitles;
 
     setExportError(null);
     setExporting(true);
@@ -242,8 +254,8 @@ export function useEditorExport({
     try {
       const { exportClip } = await import("../../lib/exportClip");
       const blob = await exportClip({
-        mediaSource: exportSource.source,
-        hls: exportSource.kind === "hls",
+        mediaSource: readiness.source,
+        hls: readiness.sourceKind === "hls",
         startTime,
         endTime,
         format: exportFormat,
@@ -276,8 +288,7 @@ export function useEditorExport({
     clippedSubtitleCues,
     endTime,
     exportFormat,
-    exportSource.kind,
-    exportSource.source,
+    exportSource,
     exporting,
     fileName.fullName,
     includeAudio,
@@ -322,7 +333,7 @@ export function useEditorExport({
   };
 }
 
-function getOutputDimensions(
+export function getOutputDimensions(
   sourceVideoDimensions: VideoDimensions | null,
   resolution: ExportResolution
 ) {
@@ -342,6 +353,59 @@ function getOutputDimensions(
   const width = Math.max(1, Math.round((sourceVideoDimensions.width / sourceVideoDimensions.height) * height));
 
   return { width, height };
+}
+
+export function getEditorExportReadiness({
+  exportSource,
+  exporting,
+  startTime,
+  endTime,
+  subtitleEnabled,
+  selectedSubtitleTrack,
+  clippedSubtitleCues,
+  subtitleLoading,
+}: ExportReadinessInput) {
+  if (!exportSource.source || exporting) {
+    return {
+      state: "idle" as const,
+      shouldBurnSubtitles: false,
+    };
+  }
+
+  if (endTime <= startTime) {
+    return {
+      state: "blocked" as const,
+      message: "Waiting for media duration.",
+      shouldBurnSubtitles: false,
+    };
+  }
+
+  const shouldBurnSubtitles = subtitleEnabled
+    && selectedSubtitleTrack !== null
+    && clippedSubtitleCues.length > 0;
+
+  if (shouldBurnSubtitles && subtitleLoading) {
+    return {
+      state: "blocked" as const,
+      message: "Subtitles are still loading.",
+      shouldBurnSubtitles,
+    };
+  }
+
+  if (shouldBurnSubtitles && !subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
+    return {
+      state: "blocked" as const,
+      message: "This subtitle track is not supported.",
+      shouldBurnSubtitles,
+    };
+  }
+
+  return {
+    state: "ready" as const,
+    source: exportSource.source,
+    sourceKind: exportSource.kind,
+    shouldBurnSubtitles,
+  };
 }
 
 export function resolveExportSource({
@@ -382,7 +446,7 @@ export function resolveExportSource({
   return { source: null, kind: "none" };
 }
 
-function buildExportSourceLabel({
+export function buildExportSourceLabel({
   preference,
   resolvedSourceKind,
   resolvedSource,
@@ -406,7 +470,7 @@ function buildExportSourceLabel({
   return preference === "auto" ? `Auto: ${label}` : label;
 }
 
-function buildExportSourceMessage({
+export function buildExportSourceMessage({
   preference,
   resolvedSourceKind,
   resolvedSource,
@@ -461,7 +525,7 @@ function buildExportSourceMessage({
   return `${prefix}: ${hlsFallbackInfo.message}`;
 }
 
-function buildExportSourceSummaryMessage({
+export function buildExportSourceSummaryMessage({
   preference,
   resolvedSourceKind,
   resolvedSource,

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import AuthCompleteScreen from "./AuthCompleteScreen";
+import { LocalVideoOpenModal } from "./LocalVideoOpenModal";
+
+void test("renders the provider auth completion screen", () => {
+  const markup = renderToStaticMarkup(createElement(AuthCompleteScreen));
+
+  assert.match(markup, /Plex sign-in finished/);
+  assert.match(markup, /Close this tab/);
+});
+
+void test("renders local video modal file picker workflow", () => {
+  const markup = renderToStaticMarkup(createElement(LocalVideoOpenModal, {
+    isOpen: true,
+    onClose: () => undefined,
+    onOpened: () => undefined,
+  }));
+
+  assert.match(markup, /Open Video/);
+  assert.match(markup, /Local files stay in your browser/);
+  assert.match(markup, /Choose File/);
+});

--- a/apps/frontend/src/components/sourcesModalStateUtils.ts
+++ b/apps/frontend/src/components/sourcesModalStateUtils.ts
@@ -1,0 +1,158 @@
+import type { MediaSource, MediaSourceCheckResult } from "../providers/types";
+import type { Feedback, SourceFilter } from "./SourcesModalSections";
+
+export function compareStrings(left: string, right: string) {
+  return left.localeCompare(right, undefined, { sensitivity: "base" });
+}
+
+export function stringValue(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function formatProviderNameForSort(providerId: string) {
+  return providerId
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function sortSources(sources: MediaSource[]) {
+  return [...sources].sort((left, right) =>
+    compareStrings(formatProviderNameForSort(left.providerId), formatProviderNameForSort(right.providerId))
+    || compareStrings(left.name, right.name)
+    || compareStrings(left.id, right.id)
+  );
+}
+
+export function draftBaseUrlsFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.baseUrl]));
+}
+
+export function draftNamesFor(sources: readonly MediaSource[]) {
+  return Object.fromEntries(sources.map((source) => [source.id, source.name]));
+}
+
+export function buildSourceEditInput(
+  source: MediaSource,
+  draftNames: Record<string, string>,
+  draftBaseUrls: Record<string, string>
+) {
+  const nextName = (draftNames[source.id] ?? source.name).trim();
+  const nextBaseUrl = (draftBaseUrls[source.id] ?? source.baseUrl).trim();
+  const hasNameChange = Boolean(nextName) && nextName !== source.name;
+  const hasBaseUrlChange = Boolean(nextBaseUrl) && nextBaseUrl !== source.baseUrl;
+
+  return {
+    ...(hasNameChange ? { name: nextName } : {}),
+    ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
+  };
+}
+
+export function sourceCounts(sources: readonly MediaSource[]) {
+  return {
+    all: sources.length,
+    enabled: sources.filter((source) => source.enabled).length,
+    disabled: sources.filter((source) => !source.enabled).length,
+    attention: sources.filter((source) => Boolean(source.lastError)).length,
+  };
+}
+
+export function sourceProviderOptions(sources: readonly MediaSource[]) {
+  const providers = [...new Set(sources.map((source) => source.providerId))];
+  return providers.sort(compareStrings);
+}
+
+export function filterSources({
+  sources,
+  providerFilter,
+  statusFilter,
+  query,
+}: {
+  sources: readonly MediaSource[];
+  providerFilter: string;
+  statusFilter: SourceFilter;
+  query: string;
+}) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return sources.filter((source) => {
+    if (providerFilter !== "all" && source.providerId !== providerFilter) {
+      return false;
+    }
+
+    if (statusFilter === "enabled" && !source.enabled) {
+      return false;
+    }
+
+    if (statusFilter === "disabled" && source.enabled) {
+      return false;
+    }
+
+    if (statusFilter === "attention" && !source.lastError) {
+      return false;
+    }
+
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    const haystack = [
+      source.name,
+      source.baseUrl,
+      source.providerId,
+      stringValue(source.metadata.product),
+      stringValue(source.metadata.platform),
+    ].filter(Boolean).join(" ").toLowerCase();
+
+    return haystack.includes(normalizedQuery);
+  });
+}
+
+export function mergeRefreshAllSourceResults(
+  sources: readonly MediaSource[],
+  results: readonly PromiseSettledResult<{
+    source: MediaSource;
+    result: MediaSourceCheckResult;
+  }>[]
+) {
+  const nextSources = new Map(sources.map((source) => [source.id, source]));
+  let healthyCount = 0;
+  let attentionCount = 0;
+  let failedCount = 0;
+
+  results.forEach((entry, index) => {
+    const currentSource = sources[index];
+    if (!currentSource) {
+      return;
+    }
+
+    if (entry.status === "fulfilled") {
+      nextSources.set(entry.value.result.source.id, entry.value.result.source);
+      if (entry.value.result.ok) {
+        healthyCount += 1;
+      } else {
+        attentionCount += 1;
+      }
+      return;
+    }
+
+    failedCount += 1;
+  });
+
+  const summaryParts = [
+    `${healthyCount} healthy`,
+    `${attentionCount} need attention`,
+  ];
+  if (failedCount > 0) {
+    summaryParts.push(`${failedCount} failed`);
+  }
+
+  return {
+    sources: sortSources([...nextSources.values()]),
+    feedback: {
+      tone: attentionCount > 0 || failedCount > 0 ? "warning" : "success",
+      message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}. ${summaryParts.join(", ")}.`,
+    } satisfies Feedback,
+  };
+}

--- a/apps/frontend/src/components/sourcesModalStateUtils.ts
+++ b/apps/frontend/src/components/sourcesModalStateUtils.ts
@@ -1,11 +1,11 @@
 import type { MediaSource, MediaSourceCheckResult } from "../providers/types";
 import type { Feedback, SourceFilter } from "./SourcesModalSections";
 
-export function compareStrings(left: string, right: string) {
+function compareStrings(left: string, right: string) {
   return left.localeCompare(right, undefined, { sensitivity: "base" });
 }
 
-export function stringValue(value: unknown) {
+function stringValue(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 

--- a/apps/frontend/src/components/useSourcesModalState.test.ts
+++ b/apps/frontend/src/components/useSourcesModalState.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { MediaSource, MediaSourceCheckResult } from "../providers/types";
+import {
+  buildSourceEditInput,
+  draftBaseUrlsFor,
+  draftNamesFor,
+  filterSources,
+  mergeRefreshAllSourceResults,
+  sourceCounts,
+  sourceProviderOptions,
+} from "./sourcesModalStateUtils";
+
+function source(overrides: Partial<MediaSource> & Pick<MediaSource, "id" | "name" | "providerId">): MediaSource {
+  return {
+    enabled: true,
+    baseUrl: `https://${overrides.id}.example.test`,
+    metadata: {},
+    lastCheckedAt: null,
+    lastError: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const alpha = source({
+  id: "alpha",
+  providerId: "demo",
+  name: "Alpha",
+  metadata: {
+    product: "Example Server",
+    platform: "macOS",
+  },
+  lastCheckedAt: "2026-01-01T00:00:00.000Z",
+});
+const beta = source({
+  id: "beta",
+  providerId: "other",
+  name: "Beta",
+  enabled: false,
+});
+const gamma = source({
+  id: "gamma",
+  providerId: "demo",
+  name: "Gamma",
+  lastError: "Offline",
+});
+const sources = [gamma, beta, alpha];
+
+void test("builds source drafts, counts, and provider options", () => {
+  assert.deepEqual(draftBaseUrlsFor(sources), {
+    alpha: alpha.baseUrl,
+    beta: beta.baseUrl,
+    gamma: gamma.baseUrl,
+  });
+  assert.deepEqual(draftNamesFor(sources), {
+    alpha: "Alpha",
+    beta: "Beta",
+    gamma: "Gamma",
+  });
+  assert.deepEqual(sourceCounts(sources), {
+    all: 3,
+    enabled: 2,
+    disabled: 1,
+    attention: 1,
+  });
+  assert.deepEqual(sourceProviderOptions(sources), ["demo", "other"]);
+});
+
+void test("filters sources by provider, status, and query metadata", () => {
+  assert.deepEqual(filterSources({
+    sources,
+    providerFilter: "demo",
+    statusFilter: "all",
+    query: "",
+  }).map((item) => item.id), ["gamma", "alpha"]);
+
+  assert.deepEqual(filterSources({
+    sources,
+    providerFilter: "all",
+    statusFilter: "disabled",
+    query: "",
+  }).map((item) => item.id), ["beta"]);
+
+  assert.deepEqual(filterSources({
+    sources,
+    providerFilter: "all",
+    statusFilter: "attention",
+    query: "",
+  }).map((item) => item.id), ["gamma"]);
+
+  assert.deepEqual(filterSources({
+    sources,
+    providerFilter: "all",
+    statusFilter: "enabled",
+    query: "macos",
+  }).map((item) => item.id), ["alpha"]);
+});
+
+void test("builds trimmed source edit payloads only for changed fields", () => {
+  assert.deepEqual(buildSourceEditInput(alpha, {
+    alpha: " Alpha ",
+  }, {
+    alpha: `${alpha.baseUrl}   `,
+  }), {});
+
+  assert.deepEqual(buildSourceEditInput(alpha, {
+    alpha: "  Alpha Renamed  ",
+  }, {
+    alpha: " https://alpha-new.example.test ",
+  }), {
+    name: "Alpha Renamed",
+    baseUrl: "https://alpha-new.example.test",
+  });
+
+  assert.deepEqual(buildSourceEditInput(alpha, {
+    alpha: "   ",
+  }, {
+    alpha: "   ",
+  }), {});
+});
+
+void test("merges refresh-all results and summarizes partial failures", () => {
+  const alphaHealthy = {
+    ...alpha,
+    name: "Alpha Healthy",
+    lastError: null,
+    lastCheckedAt: "2026-01-02T00:00:00.000Z",
+  };
+  const gammaAttention = {
+    ...gamma,
+    lastError: "Still offline",
+    lastCheckedAt: "2026-01-02T00:00:00.000Z",
+  };
+  const results: Array<PromiseSettledResult<{ source: MediaSource; result: MediaSourceCheckResult }>> = [
+    {
+      status: "fulfilled",
+      value: {
+        source: gamma,
+        result: {
+          ok: false,
+          source: gammaAttention,
+          error: {
+            message: "Still offline",
+          },
+        },
+      },
+    },
+    {
+      status: "rejected",
+      reason: new Error("Network failed"),
+    },
+    {
+      status: "fulfilled",
+      value: {
+        source: alpha,
+        result: {
+          ok: true,
+          source: alphaHealthy,
+        },
+      },
+    },
+  ];
+
+  const merged = mergeRefreshAllSourceResults(sources, results);
+
+  assert.deepEqual(merged.sources.map((item) => item.name), [
+    "Alpha Healthy",
+    "Gamma",
+    "Beta",
+  ]);
+  assert.deepEqual(merged.feedback, {
+    tone: "warning",
+    message: "Refreshed 3 sources. 1 healthy, 1 need attention, 1 failed.",
+  });
+});

--- a/apps/frontend/src/components/useSourcesModalState.ts
+++ b/apps/frontend/src/components/useSourcesModalState.ts
@@ -4,10 +4,15 @@ import { useAuth } from "../auth";
 import type { MediaSource, ProviderSession } from "../providers/types";
 import type { Feedback, SourceFilter } from "./SourcesModalSections";
 import {
-  compareStrings,
+  buildSourceEditInput,
+  draftBaseUrlsFor,
+  draftNamesFor,
+  filterSources,
+  mergeRefreshAllSourceResults,
+  sourceCounts,
+  sourceProviderOptions,
   sortSources,
-  stringValue,
-} from "./SourcesModalSections";
+} from "./sourcesModalStateUtils";
 
 interface UseSourcesModalStateOptions {
   isOpen: boolean;
@@ -18,14 +23,6 @@ interface SourceActionResult {
   feedback: Feedback;
   source?: MediaSource;
   removeSourceId?: string;
-}
-
-function draftBaseUrlsFor(sources: readonly MediaSource[]) {
-  return Object.fromEntries(sources.map((source) => [source.id, source.baseUrl]));
-}
-
-function draftNamesFor(sources: readonly MediaSource[]) {
-  return Object.fromEntries(sources.map((source) => [source.id, source.name]));
 }
 
 export function useSourcesModalState({
@@ -186,20 +183,14 @@ export function useSourcesModalState({
   }
 
   async function saveSourceEdits(source: MediaSource) {
-    const nextName = (draftNames[source.id] ?? source.name).trim();
-    const nextBaseUrl = (draftBaseUrls[source.id] ?? source.baseUrl).trim();
-    const hasNameChange = Boolean(nextName) && nextName !== source.name;
-    const hasBaseUrlChange = Boolean(nextBaseUrl) && nextBaseUrl !== source.baseUrl;
+    const input = buildSourceEditInput(source, draftNames, draftBaseUrls);
 
-    if (!hasNameChange && !hasBaseUrlChange) {
+    if (Object.keys(input).length === 0) {
       return;
     }
 
     await runSourceAction(source, "Saving...", "Could not update source.", async () => {
-      const updatedSource = await cliparrClient.updateSource(source.id, {
-        ...(hasNameChange ? { name: nextName } : {}),
-        ...(hasBaseUrlChange ? { baseUrl: nextBaseUrl } : {}),
-      });
+      const updatedSource = await cliparrClient.updateSource(source.id, input);
 
       return {
         source: updatedSource,
@@ -285,45 +276,10 @@ export function useSourcesModalState({
         })
       );
 
-      const nextSources = new Map(sources.map((source) => [source.id, source]));
-      let healthyCount = 0;
-      let attentionCount = 0;
-      let failedCount = 0;
+      const merged = mergeRefreshAllSourceResults(sources, results);
+      replaceSources(merged.sources);
 
-      results.forEach((entry, index) => {
-        const currentSource = sources[index];
-        if (!currentSource) {
-          return;
-        }
-
-        if (entry.status === "fulfilled") {
-          nextSources.set(entry.value.result.source.id, entry.value.result.source);
-          if (entry.value.result.ok) {
-            healthyCount += 1;
-          } else {
-            attentionCount += 1;
-          }
-          return;
-        }
-
-        failedCount += 1;
-      });
-
-      const mergedSources = sortSources([...nextSources.values()]);
-      replaceSources(mergedSources);
-
-      const summaryParts = [
-        `${healthyCount} healthy`,
-        `${attentionCount} need attention`,
-      ];
-      if (failedCount > 0) {
-        summaryParts.push(`${failedCount} failed`);
-      }
-
-      setFeedback({
-        tone: attentionCount > 0 || failedCount > 0 ? "warning" : "success",
-        message: `Refreshed ${sources.length} source${sources.length === 1 ? "" : "s"}. ${summaryParts.join(", ")}.`,
-      });
+      setFeedback(merged.feedback);
       await refreshPlaybackView();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Could not refresh sources.";
@@ -361,10 +317,7 @@ export function useSourcesModalState({
     }
   }, [isOpen, loading, sources.length]);
 
-  const providerOptions = useMemo(() => {
-    const providers = [...new Set(sources.map((source) => source.providerId))];
-    return providers.sort(compareStrings);
-  }, [sources]);
+  const providerOptions = useMemo(() => sourceProviderOptions(sources), [sources]);
 
   useEffect(() => {
     if (providerFilter === "all" || providerOptions.includes(providerFilter)) {
@@ -374,48 +327,14 @@ export function useSourcesModalState({
     setProviderFilter("all");
   }, [providerFilter, providerOptions]);
 
-  const counts = useMemo(() => ({
-    all: sources.length,
-    enabled: sources.filter((source) => source.enabled).length,
-    disabled: sources.filter((source) => !source.enabled).length,
-    attention: sources.filter((source) => Boolean(source.lastError)).length,
-  }), [sources]);
+  const counts = useMemo(() => sourceCounts(sources), [sources]);
 
-  const filteredSources = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-
-    return sources.filter((source) => {
-      if (providerFilter !== "all" && source.providerId !== providerFilter) {
-        return false;
-      }
-
-      if (statusFilter === "enabled" && !source.enabled) {
-        return false;
-      }
-
-      if (statusFilter === "disabled" && source.enabled) {
-        return false;
-      }
-
-      if (statusFilter === "attention" && !source.lastError) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      const haystack = [
-        source.name,
-        source.baseUrl,
-        source.providerId,
-        stringValue(source.metadata.product),
-        stringValue(source.metadata.platform),
-      ].filter(Boolean).join(" ").toLowerCase();
-
-      return haystack.includes(normalizedQuery);
-    });
-  }, [providerFilter, query, sources, statusFilter]);
+  const filteredSources = useMemo(() => filterSources({
+    sources,
+    providerFilter,
+    statusFilter,
+    query,
+  }), [providerFilter, query, sources, statusFilter]);
 
   const updateDraftName = useCallback((sourceId: string, value: string) => {
     setDraftNames((current) => ({

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -1,0 +1,309 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ConversionOptions } from "mediabunny";
+import { exportClipWithRuntime } from "./exportClip";
+import type { EditorMediaSource } from "./editorMedia";
+import type { SubtitleStyleSettings } from "./subtitles/types";
+
+type ExportRuntime = Parameters<typeof exportClipWithRuntime>[1];
+type CliparrInput = Awaited<ReturnType<ExportRuntime["createCliparrInputFromSource"]>>;
+type ConversionResult = Awaited<ReturnType<ExportRuntime["initConversion"]>>;
+type OutputFormat = ReturnType<ExportRuntime["createOutputFormat"]>;
+type BufferTargetResult = ReturnType<ExportRuntime["createBufferTarget"]>;
+type OutputResult = ReturnType<ExportRuntime["createOutput"]>;
+type SubtitleProcessor = ReturnType<ExportRuntime["buildSubtitleBurnInProcessor"]>;
+
+const mediaSource = {
+  kind: "url",
+  role: "direct",
+  label: "Direct",
+  url: "/api/media/handle-1",
+} satisfies EditorMediaSource;
+
+const subtitleStyle = {
+  fontFamily: "Arial",
+  fontSize: 40,
+  fontColor: "#ffffff",
+  shadowColor: "#000000",
+  shadowBlur: 2,
+  shadowOffsetY: 2,
+  strokeColor: "#000000",
+  strokeWidth: 2,
+  bottomMargin: 48,
+  lineHeight: 1.2,
+} satisfies SubtitleStyleSettings;
+
+function createRuntime(overrides: Partial<ExportRuntime> = {}) {
+  const target = { buffer: undefined as ArrayBuffer | undefined };
+  const videoTrack = {
+    id: "video-1",
+    hasOnlyKeyPackets: async () => false,
+  };
+  const audioTrack = {
+    id: "audio-1",
+  };
+  let disposed = false;
+
+  const input = {
+    async getPrimaryVideoTrack({ filter }: { filter: (track: typeof videoTrack) => Promise<boolean> }) {
+      assert.equal(await filter(videoTrack), true);
+      return videoTrack;
+    },
+    async getAudioTracks() {
+      return [audioTrack];
+    },
+    dispose() {
+      disposed = true;
+    },
+  } as unknown as CliparrInput;
+
+  const runtime = {
+    ensureMediabunnyCodecs: async () => undefined,
+    createCliparrInputFromSource: async () => input,
+    selectPreferredPairableAudioTrack: async (_videoTrack, audioTracks) => audioTracks[0] ?? null,
+    getTrackTimelineOffsetSeconds: async () => 5,
+    getVideoTrackDimensions: async () => ({ width: 1920, height: 1080 }),
+    buildMetadataTags: async () => ({ title: "Clip" }),
+    describeDiscardedTracks: async () => "",
+    patchMp4MetadataBoxes: () => undefined,
+    createOutputFormat: () => ({ mimeType: "video/mp4" }) as unknown as OutputFormat,
+    createBufferTarget: () => target as unknown as BufferTargetResult,
+    createOutput: (options) => ({ options }) as unknown as OutputResult,
+    initConversion: async () => createConversion({
+      target,
+      bytes: [1, 2, 3],
+      utilizedAudio: true,
+      progress: 0.5,
+    }),
+    buildSubtitleBurnInProcessor: () => (() => ({})) as unknown as SubtitleProcessor,
+    ...overrides,
+  } satisfies ExportRuntime;
+
+  return {
+    runtime,
+    target,
+    input,
+    videoTrack,
+    audioTrack,
+    get disposed() {
+      return disposed;
+    },
+  };
+}
+
+function createConversion({
+  target,
+  bytes,
+  utilizedAudio,
+  progress,
+}: {
+  target: { buffer: ArrayBuffer | undefined };
+  bytes?: number[];
+  utilizedAudio: boolean;
+  progress?: number;
+}) {
+  let onProgress: ((progress: number) => void) | undefined;
+
+  return {
+    isValid: true,
+    utilizedTracks: utilizedAudio ? [{ isAudioTrack: () => true }] : [],
+    discardedTracks: [],
+    get onProgress() {
+      return onProgress;
+    },
+    set onProgress(next: ((progress: number) => void) | undefined) {
+      onProgress = next;
+    },
+    async execute() {
+      if (progress !== undefined) {
+        onProgress?.(progress);
+      }
+      if (bytes) {
+        target.buffer = new Uint8Array(bytes).buffer;
+      }
+    },
+  } as unknown as ConversionResult;
+}
+
+void test("builds and executes a trimmed conversion with selected audio and metadata", async () => {
+  let capturedHls: boolean | undefined;
+  let capturedOptions: ConversionOptions | undefined;
+  let patchedBytes: number[] = [];
+  const progress: number[] = [];
+  const context = createRuntime();
+  context.runtime.createCliparrInputFromSource = async (_source, options) => {
+    capturedHls = options?.hls;
+    return context.input;
+  };
+  context.runtime.initConversion = async (options) => {
+    capturedOptions = options;
+    return createConversion({
+      target: context.target,
+      bytes: [1, 2, 3],
+      utilizedAudio: true,
+      progress: 0.5,
+    });
+  };
+  context.runtime.patchMp4MetadataBoxes = (bytes) => {
+    patchedBytes = [...bytes];
+  };
+
+  const blob = await exportClipWithRuntime({
+    mediaSource,
+    hls: true,
+    startTime: 10,
+    endTime: 15,
+    format: "mp4",
+    resolution: "720",
+    includeAudio: true,
+    metadata: {
+      providerId: "plex",
+      itemType: "movie",
+      title: "Movie",
+    },
+    onProgress: (value) => progress.push(value),
+  }, context.runtime);
+
+  assert.equal(capturedHls, true);
+  assert.equal(capturedOptions?.trim?.start, 15);
+  assert.equal(capturedOptions?.trim?.end, 20);
+  assert.equal(blob.type, "video/mp4");
+  assert.equal(blob.size, 3);
+  assert.deepEqual(progress, [0.5]);
+  assert.deepEqual(patchedBytes, [1, 2, 3]);
+  assert.equal(context.disposed, true);
+
+  const audioOptionsForTrack = capturedOptions?.audio;
+  assert.equal(typeof audioOptionsForTrack, "function");
+  if (typeof audioOptionsForTrack !== "function") {
+    throw new Error("Expected audio conversion options to be a function");
+  }
+  const selectedAudioOptions = audioOptionsForTrack(
+    { id: "audio-1" } as unknown as Parameters<typeof audioOptionsForTrack>[0],
+    1
+  ) as { discard: boolean };
+  const otherAudioOptions = audioOptionsForTrack(
+    { id: "audio-2" } as unknown as Parameters<typeof audioOptionsForTrack>[0],
+    2
+  ) as { discard: boolean };
+  assert.equal(selectedAudioOptions.discard, false);
+  assert.equal(otherAudioOptions.discard, true);
+
+  const videoOptionsForTrack = capturedOptions?.video;
+  assert.equal(typeof videoOptionsForTrack, "function");
+  if (typeof videoOptionsForTrack !== "function") {
+    throw new Error("Expected video conversion options to be a function");
+  }
+  const selectedVideoOptions = videoOptionsForTrack(
+    { id: "video-1" } as unknown as Parameters<typeof videoOptionsForTrack>[0],
+    1
+  ) as { discard: boolean; height?: number };
+  const otherVideoOptions = videoOptionsForTrack(
+    { id: "video-2" } as unknown as Parameters<typeof videoOptionsForTrack>[0],
+    2
+  ) as { discard: boolean; height?: number };
+  assert.equal(selectedVideoOptions.discard, false);
+  assert.equal(selectedVideoOptions.height, 720);
+  assert.equal(otherVideoOptions.discard, true);
+});
+
+void test("fails before execution when conversion would drop source audio", async () => {
+  const context = createRuntime({
+    describeDiscardedTracks: async () => "Codec unsupported.",
+    initConversion: async () => ({
+      isValid: true,
+      utilizedTracks: [],
+      discardedTracks: [{}],
+      execute: async () => {
+        throw new Error("execute should not run");
+      },
+    }) as unknown as ConversionResult,
+  });
+
+  await assert.rejects(
+    () => exportClipWithRuntime({
+      mediaSource,
+      startTime: 0,
+      endTime: 10,
+      format: "webm",
+      resolution: "original",
+      includeAudio: true,
+      onProgress: () => undefined,
+    }, context.runtime),
+    /Export would drop the source audio track\. Codec unsupported\./
+  );
+  assert.equal(context.disposed, true);
+});
+
+void test("validates subtitle burn-in inputs and wires the burn-in processor", async () => {
+  const processor = (() => ({})) as unknown as SubtitleProcessor;
+  let capturedOptions: ConversionOptions | undefined;
+  let processorCueCount = 0;
+  const context = createRuntime({
+    buildSubtitleBurnInProcessor: (cues) => {
+      processorCueCount = cues.length;
+      return processor;
+    },
+    initConversion: async (options) => {
+      capturedOptions = options;
+      return createConversion({
+        target: context.target,
+        bytes: [1],
+        utilizedAudio: true,
+      });
+    },
+  });
+
+  await assert.rejects(
+    () => exportClipWithRuntime({
+      mediaSource,
+      startTime: 0,
+      endTime: 10,
+      format: "mp4",
+      resolution: "original",
+      includeAudio: true,
+      includeBurnedSubtitles: true,
+      subtitleCues: [{
+        startTime: 1,
+        endTime: 2,
+        text: "Hello",
+        lines: ["Hello"],
+      }],
+      onProgress: () => undefined,
+    }, context.runtime),
+    /Subtitle burn-in was requested without style settings/
+  );
+
+  const blob = await exportClipWithRuntime({
+    mediaSource,
+    startTime: 0,
+    endTime: 10,
+    format: "mp4",
+    resolution: "original",
+    includeAudio: true,
+    includeBurnedSubtitles: true,
+    subtitleStyleSettings: subtitleStyle,
+    subtitleCues: [{
+      startTime: 1,
+      endTime: 2,
+      text: "Hello",
+      lines: ["Hello"],
+    }],
+    onProgress: () => undefined,
+  }, context.runtime);
+
+  assert.equal(blob.size, 1);
+  const videoOptionsForTrack = capturedOptions?.video;
+  assert.equal(typeof videoOptionsForTrack, "function");
+  if (typeof videoOptionsForTrack !== "function") {
+    throw new Error("Expected video conversion options to be a function");
+  }
+  const videoOptions = videoOptionsForTrack(
+    { id: "video-1" } as unknown as Parameters<typeof videoOptionsForTrack>[0],
+    1
+  ) as { process?: unknown };
+  assert.equal(processorCueCount, 1);
+  assert.equal(videoOptions.process, processor);
+});

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -7,7 +7,7 @@ import {
   Output,
   WebMOutputFormat,
 } from "mediabunny";
-import type { ConversionOptions, DiscardedTrack, VideoSample } from "mediabunny";
+import type { ConversionOptions, VideoSample } from "mediabunny";
 import type { EditorMediaSource } from "./editorMedia";
 import { createCliparrInputFromSource } from "./mediabunnyInput";
 import { ensureMediabunnyCodecs } from "./mediabunnyCodecs";
@@ -48,11 +48,20 @@ interface ExportClipOptions {
   onProgress: (progress: number) => void;
 }
 
-async function buildAudioDroppedError(discardedTracks: readonly DiscardedTrack[]) {
-  const discardedDetails = await describeDiscardedTracks(discardedTracks);
-  const suffix = discardedDetails ? ` ${discardedDetails}` : " Mediabunny did not report a discarded-track reason.";
-
-  return new Error(`Export would drop the source audio track.${suffix}`);
+interface ExportClipRuntime {
+  ensureMediabunnyCodecs: typeof ensureMediabunnyCodecs;
+  createCliparrInputFromSource: typeof createCliparrInputFromSource;
+  selectPreferredPairableAudioTrack: typeof selectPreferredPairableAudioTrack;
+  getTrackTimelineOffsetSeconds: typeof getTrackTimelineOffsetSeconds;
+  getVideoTrackDimensions: typeof getVideoTrackDimensions;
+  buildMetadataTags: typeof buildMetadataTags;
+  describeDiscardedTracks: typeof describeDiscardedTracks;
+  patchMp4MetadataBoxes: typeof patchMp4MetadataBoxes;
+  createOutputFormat: typeof createOutputFormat;
+  createBufferTarget: () => BufferTarget;
+  createOutput: (options: ConstructorParameters<typeof Output>[0]) => Output;
+  initConversion: typeof Conversion.init;
+  buildSubtitleBurnInProcessor: typeof buildSubtitleBurnInProcessor;
 }
 
 function createOutputFormat(format: ExportFormat) {
@@ -114,23 +123,71 @@ export async function exportClip({
   subtitleStyleSettings,
   onProgress,
 }: ExportClipOptions) {
-  await ensureMediabunnyCodecs();
+  return exportClipWithRuntime({
+    mediaSource,
+    hls,
+    startTime,
+    endTime,
+    format,
+    resolution,
+    includeAudio,
+    selectedAudioTrack,
+    metadata,
+    includeBurnedSubtitles,
+    subtitleCues,
+    subtitleStyleSettings,
+    onProgress,
+  }, defaultExportClipRuntime);
+}
 
-  const input = await createCliparrInputFromSource(mediaSource, { hls });
+const defaultExportClipRuntime: ExportClipRuntime = {
+  ensureMediabunnyCodecs,
+  createCliparrInputFromSource,
+  selectPreferredPairableAudioTrack,
+  getTrackTimelineOffsetSeconds,
+  getVideoTrackDimensions,
+  buildMetadataTags,
+  describeDiscardedTracks,
+  patchMp4MetadataBoxes,
+  createOutputFormat,
+  createBufferTarget: () => new BufferTarget(),
+  createOutput: (options) => new Output(options),
+  initConversion: (options) => Conversion.init(options),
+  buildSubtitleBurnInProcessor,
+};
+
+export async function exportClipWithRuntime({
+  mediaSource,
+  hls,
+  startTime,
+  endTime,
+  format,
+  resolution,
+  includeAudio,
+  selectedAudioTrack,
+  metadata,
+  includeBurnedSubtitles = false,
+  subtitleCues = [],
+  subtitleStyleSettings,
+  onProgress,
+}: ExportClipOptions, runtime: ExportClipRuntime) {
+  await runtime.ensureMediabunnyCodecs();
+
+  const input = await runtime.createCliparrInputFromSource(mediaSource, { hls });
 
   try {
     const sourceVideoTrack = await input.getPrimaryVideoTrack({
       filter: async (track) => !(await track.hasOnlyKeyPackets()),
     });
     const sourceAudioTracks = await input.getAudioTracks();
-    const preferredAudioTrack = await selectPreferredPairableAudioTrack(
+    const preferredAudioTrack = await runtime.selectPreferredPairableAudioTrack(
       sourceVideoTrack,
       sourceAudioTracks,
       selectedAudioTrack
     );
     const sourceHasAudio = sourceAudioTracks.length > 0;
 
-    const timelineOffsetSeconds = await getTrackTimelineOffsetSeconds([
+    const timelineOffsetSeconds = await runtime.getTrackTimelineOffsetSeconds([
       sourceVideoTrack,
       includeAudio ? preferredAudioTrack : undefined,
     ]);
@@ -138,7 +195,7 @@ export async function exportClip({
     const trimEnd = toSourceTimelineTime(endTime, timelineOffsetSeconds);
 
     const sourceVideoDimensions = sourceVideoTrack
-      ? await getVideoTrackDimensions(sourceVideoTrack)
+      ? await runtime.getVideoTrackDimensions(sourceVideoTrack)
       : null;
     const outputHeight = resolution === "original" ? sourceVideoDimensions?.height : parseInt(resolution, 10);
     const clippedSubtitleCues = includeBurnedSubtitles && subtitleCues.length > 0
@@ -154,10 +211,10 @@ export async function exportClip({
       throw new Error("Subtitle burn-in requires a video track.");
     }
 
-    const outputFormat = createOutputFormat(format);
-    const target = new BufferTarget();
-    const metadataTags = await buildMetadataTags(metadata, startTime, endTime, outputHeight, format);
-    const output = new Output({
+    const outputFormat = runtime.createOutputFormat(format);
+    const target = runtime.createBufferTarget();
+    const metadataTags = await runtime.buildMetadataTags(metadata, startTime, endTime, outputHeight, format);
+    const output = runtime.createOutput({
       format: outputFormat,
       target,
     });
@@ -206,7 +263,7 @@ export async function exportClip({
         ...(shouldBurnSubtitles && subtitleStyleSettings
           ? {
               forceTranscode: true,
-              process: buildSubtitleBurnInProcessor(clippedSubtitleCues, subtitleStyleSettings),
+              process: runtime.buildSubtitleBurnInProcessor(clippedSubtitleCues, subtitleStyleSettings),
             }
           : {}),
       });
@@ -217,17 +274,19 @@ export async function exportClip({
       };
     }
 
-    const conversion = await Conversion.init(conversionOptions);
+    const conversion = await runtime.initConversion(conversionOptions);
     const utilizedAudioTracks = conversion.utilizedTracks.filter((track) => track.isAudioTrack());
 
     if (!conversion.isValid) {
-      const discardedDetails = await describeDiscardedTracks(conversion.discardedTracks);
+      const discardedDetails = await runtime.describeDiscardedTracks(conversion.discardedTracks);
       const suffix = discardedDetails ? ` ${discardedDetails}` : "";
       throw new Error(`Conversion is invalid.${suffix}`);
     }
 
     if (includeAudio && sourceHasAudio && utilizedAudioTracks.length === 0) {
-      throw await buildAudioDroppedError(conversion.discardedTracks);
+      const discardedDetails = await runtime.describeDiscardedTracks(conversion.discardedTracks);
+      const suffix = discardedDetails ? ` ${discardedDetails}` : " Mediabunny did not report a discarded-track reason.";
+      throw new Error(`Export would drop the source audio track.${suffix}`);
     }
 
     conversion.onProgress = onProgress;
@@ -239,7 +298,7 @@ export async function exportClip({
     }
 
     if (isIsobmffExportFormat(format)) {
-      patchMp4MetadataBoxes(new Uint8Array(target.buffer));
+      runtime.patchMp4MetadataBoxes(new Uint8Array(target.buffer));
     }
 
     // Conversion.init already proved that at least one audio track made it into the

--- a/apps/frontend/src/lib/exportFileName.test.ts
+++ b/apps/frontend/src/lib/exportFileName.test.ts
@@ -1,0 +1,155 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildExportFileName,
+  defaultExportFileNameTemplates,
+  getExportFileNameTemplateTokens,
+  loadExportFileNameTemplates,
+  saveExportFileNameTemplates,
+  type ExportFileNameTemplateSettings,
+} from "./exportFileName";
+
+const legacyMovieTemplate = "{source_title} ({year}) - clip {clip_start} to {clip_end}";
+const legacyEpisodeTemplate = "{show_title} - {episode_code} - {title} - clip {clip_start} to {clip_end}";
+
+function withWindowStorage<T>(
+  initialValue: string | null,
+  callback: (storage: Map<string, string>) => T
+) {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const storage = new Map<string, string>();
+  if (initialValue !== null) {
+    storage.set("cliparr.export.filename-templates.v1", initialValue);
+  }
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem(key: string) {
+          return storage.get(key) ?? null;
+        },
+        setItem(key: string, value: string) {
+          storage.set(key, value);
+        },
+      },
+    },
+  });
+
+  try {
+    return callback(storage);
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  }
+}
+
+void test("builds sanitized movie filenames from metadata templates", () => {
+  const fileName = buildExportFileName({
+    title: "Fallback: Title",
+    sessionType: "movie",
+    metadata: {
+      providerId: "local",
+      itemType: "movie",
+      sourceTitle: "Movie / With: Bad * Characters?",
+      year: 1999,
+    },
+    startTime: 61.2,
+    endTime: 3661.6,
+    format: "mp4",
+    templates: defaultExportFileNameTemplates(),
+  });
+
+  assert.deepEqual(fileName, {
+    baseName: "Movie With Bad Characters (1999) [01m01s-01h01m02s]",
+    fullName: "Movie With Bad Characters (1999) [01m01s-01h01m02s].mp4",
+    templateKind: "movie",
+  });
+});
+
+void test("builds episode filenames and falls back when episode numbers are absent", () => {
+  const templates = {
+    movie: "{source_title}",
+    episode: "{show_title} - {episode_code} - {title} - {provider} - {format} - {unknown}",
+  } satisfies ExportFileNameTemplateSettings;
+
+  assert.deepEqual(buildExportFileName({
+    title: "Pilot",
+    sessionType: "episode",
+    metadata: {
+      providerId: "demo",
+      itemType: "episode",
+      title: "Pilot",
+      showTitle: "Example Show",
+      seasonNumber: 1,
+      episodeNumber: 2,
+    },
+    startTime: 0,
+    endTime: 10,
+    format: "webm",
+    templates,
+  }), {
+    baseName: "Example Show - S01E02 - Pilot - demo - webm -",
+    fullName: "Example Show - S01E02 - Pilot - demo - webm -.webm",
+    templateKind: "episode",
+  });
+
+  assert.deepEqual(buildExportFileName({
+    title: "Standalone",
+    sessionType: "episode",
+    metadata: {
+      providerId: "demo",
+      itemType: "episode",
+      title: "Standalone",
+      showTitle: "Example Show",
+    },
+    startTime: 0,
+    endTime: 10,
+    format: "mkv",
+    templates,
+  }), {
+    baseName: "Example Show - Standalone - demo - mkv -",
+    fullName: "Example Show - Standalone - demo - mkv -.mkv",
+    templateKind: "episode",
+  });
+});
+
+void test("loads, migrates, and saves filename templates through local storage", () => {
+  withWindowStorage(JSON.stringify({
+    movie: legacyMovieTemplate,
+    episode: legacyEpisodeTemplate,
+  }), (storage) => {
+    assert.deepEqual(loadExportFileNameTemplates(), defaultExportFileNameTemplates());
+
+    const templates = {
+      movie: "{title} custom",
+      episode: "{show_title} custom",
+    } satisfies ExportFileNameTemplateSettings;
+    saveExportFileNameTemplates(templates);
+
+    assert.deepEqual(
+      JSON.parse(storage.get("cliparr.export.filename-templates.v1") ?? ""),
+      templates
+    );
+  });
+});
+
+void test("exposes expected template tokens by media kind", () => {
+  assert.deepEqual(getExportFileNameTemplateTokens("movie"), [
+    "title",
+    "source_title",
+    "year",
+    "clip_start",
+    "clip_end",
+    "clip_range",
+    "provider",
+    "item_type",
+    "format",
+  ]);
+  assert(getExportFileNameTemplateTokens("episode").includes("episode_code"));
+});

--- a/apps/frontend/src/lib/exportMetadata.test.ts
+++ b/apps/frontend/src/lib/exportMetadata.test.ts
@@ -1,0 +1,235 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { MetadataTags } from "mediabunny";
+import {
+  buildMetadataTags,
+  patchMp4MetadataBoxes,
+} from "./exportMetadata";
+
+function bytes(...values: number[]) {
+  return new Uint8Array(values);
+}
+
+function textBytes(value: string) {
+  return new TextEncoder().encode(value);
+}
+
+function uint32(value: number) {
+  return bytes(
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff
+  );
+}
+
+function concatBytes(...chunks: Uint8Array[]) {
+  const size = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const result = new Uint8Array(size);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}
+
+function box(type: string, content: Uint8Array) {
+  return concatBytes(uint32(content.length + 8), textBytes(type), content);
+}
+
+function readUint32(bytes: Uint8Array, offset: number) {
+  return (
+    bytes[offset] * 2 ** 24
+    + bytes[offset + 1] * 2 ** 16
+    + bytes[offset + 2] * 2 ** 8
+    + bytes[offset + 3]
+  );
+}
+
+async function withMockedFetch<T>(
+  handler: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>,
+  action: () => Promise<T>
+) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function withWindowLocation<T>(href: string, callback: () => Promise<T>) {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        href,
+      },
+    },
+  });
+
+  try {
+    return await callback();
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  }
+}
+
+function findText(bytes: Uint8Array, text: string, start = 0) {
+  const needle = textBytes(text);
+
+  for (let index = start; index <= bytes.length - needle.length; index += 1) {
+    if (needle.every((value, offset) => bytes[index + offset] === value)) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+void test("builds MP4 metadata tags for movie clips", async () => {
+  const tags = await buildMetadataTags({
+    providerId: "demo",
+    itemType: "movie",
+    title: "Movie Clip",
+    sourceTitle: "Original Movie",
+    year: 2001,
+    description: "A useful scene",
+    genres: ["Action", "Drama"],
+    contentRating: "PG-13",
+  }, 65.125, 130.75, 1080, "mp4");
+
+  assert(tags);
+  assert.equal(tags.title, "Movie Clip");
+  assert.equal(tags.description, "A useful scene");
+  assert.equal(tags.genre, "Action, Drama");
+  assert.equal(tags.date instanceof Date, true);
+  assert.equal((tags.date as Date).getUTCFullYear(), 2001);
+  assert.equal(tags.comment, "Clip from Original Movie, 1:05 to 2:11. Content rating: PG-13.");
+
+  const raw = tags.raw as NonNullable<MetadataTags["raw"]>;
+  assert.deepEqual(raw.stik, bytes(9));
+  assert.deepEqual(raw.hdvd, bytes(1));
+  assert.equal(raw["©TIM"], "00:01:05.125");
+  assert.equal(raw.csta, "65.125");
+  assert.equal(raw.cend, "130.750");
+  assert.equal(raw.cdur, "65.625");
+  assert.deepEqual(JSON.parse(raw.clpr as string), {
+    sourceStartSeconds: 65.125,
+    sourceEndSeconds: 130.75,
+    sourceDurationSeconds: 65.625,
+  });
+});
+
+void test("builds episode metadata and embeds fetched artwork", async () => {
+  await withMockedFetch(async (input) => {
+    assert.equal(input, "/artwork/cover");
+    return new Response(bytes(1, 2, 3), {
+      status: 200,
+      headers: {
+        "content-type": "image/png; charset=binary",
+      },
+    });
+  }, async () => {
+    const tags = await buildMetadataTags({
+      providerId: "demo",
+      itemType: "episode",
+      title: "Episode Title",
+      showTitle: "Great Show",
+      seasonNumber: 3,
+      episodeNumber: 7,
+      network: "Example Network",
+      directors: ["A Director", "B Director"],
+      tagline: "A tiny line",
+      imageUrl: "/artwork/cover",
+    }, 0, 10, 480, "mov");
+
+    assert(tags);
+    assert.equal(tags.title, "Episode Title");
+    assert.equal(tags.description, "A tiny line");
+    assert.equal(tags.images?.[0]?.mimeType, "image/png");
+    assert.deepEqual(tags.images?.[0]?.data, bytes(1, 2, 3));
+
+    const raw = tags.raw as NonNullable<MetadataTags["raw"]>;
+    assert.deepEqual(raw.stik, bytes(10));
+    assert.deepEqual(raw.hdvd, bytes(0));
+    assert.equal(raw.tvsh, "Great Show");
+    assert.deepEqual(raw.tvsn, uint32(3));
+    assert.deepEqual(raw.tves, uint32(7));
+    assert.equal(raw.tven, "S03E07");
+    assert.equal(raw.tvnn, "Example Network");
+    assert.equal(raw["©dir"], "A Director, B Director");
+  });
+});
+
+void test("omits raw ISOBMFF metadata for non-MP4-like formats", async () => {
+  const tags = await buildMetadataTags({
+    providerId: "demo",
+    itemType: "movie",
+    title: "Movie Clip",
+  }, 0, 10, 1080, "webm");
+
+  assert(tags);
+  assert.equal(tags.raw, undefined);
+});
+
+void test("infers artwork mime type and ignores failed artwork fetches", async () => {
+  await withWindowLocation("http://cliparr.test/dashboard", async () => {
+    await withMockedFetch(async (input) => {
+      if (input === "https://cdn.example.test/poster.webp") {
+        return new Response(bytes(4, 5), { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    }, async () => {
+      const withArtwork = await buildMetadataTags({
+        providerId: "demo",
+        itemType: "movie",
+        title: "Movie Clip",
+        imageUrl: "https://cdn.example.test/poster.webp",
+      }, 0, 10, 1080, "mp4");
+      assert.equal(withArtwork?.images?.[0]?.mimeType, "image/webp");
+
+      const withoutArtwork = await buildMetadataTags({
+        providerId: "demo",
+        itemType: "movie",
+        title: "Movie Clip",
+        imageUrl: "https://cdn.example.test/missing.jpg",
+      }, 0, 10, 1080, "mp4");
+      assert.equal(withoutArtwork?.images, undefined);
+    });
+  });
+});
+
+void test("patches MP4 ilst integer metadata data types", () => {
+  const stikData = box("data", concatBytes(uint32(0), bytes(0, 0, 0, 0, 10)));
+  const tvsnData = box("data", concatBytes(uint32(0), bytes(0, 0, 0, 0, 0, 0, 0, 3)));
+  const ilst = box("ilst", concatBytes(box("stik", stikData), box("tvsn", tvsnData)));
+  const meta = box("meta", concatBytes(bytes(0, 0, 0, 0), ilst));
+  const file = box("moov", box("udta", meta));
+
+  patchMp4MetadataBoxes(file);
+
+  const stikTypeOffset = findText(file, "stik");
+  const stikDataTypeOffset = findText(file, "data", stikTypeOffset) + 4;
+  const tvsnTypeOffset = findText(file, "tvsn");
+  const tvsnDataTypeOffset = findText(file, "data", tvsnTypeOffset) + 4;
+
+  assert(stikTypeOffset >= 0);
+  assert(tvsnTypeOffset >= 0);
+  assert.equal(readUint32(file, stikDataTypeOffset), 0x15);
+  assert.equal(readUint32(file, tvsnDataTypeOffset), 0x16);
+});

--- a/apps/server/src/db/providerPersistence.test.ts
+++ b/apps/server/src/db/providerPersistence.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { closeDatabase, initializeDatabase } from "./database.js";
+import {
+  getMediaSourceByProviderExternalId,
+  listMediaSources,
+  updateMediaSource,
+} from "./mediaSourcesRepository.js";
+import { persistProviderAuth } from "./providerPersistence.js";
+import { PLEX_BASE_URL_MODE_MANUAL } from "../providers/plex/connectionState.js";
+
+const TEST_APP_KEY = "provider-persistence-test-key-with-32-characters";
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function withDatabase<T>(callback: () => T) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-provider-persistence-"));
+  const previousAppKey = process.env.APP_KEY;
+  const previousDataDir = process.env.CLIPARR_DATA_DIR;
+
+  process.env.APP_KEY = TEST_APP_KEY;
+  process.env.CLIPARR_DATA_DIR = dataDir;
+
+  try {
+    initializeDatabase();
+    return callback();
+  } finally {
+    closeDatabase();
+    restoreEnv("APP_KEY", previousAppKey);
+    restoreEnv("CLIPARR_DATA_DIR", previousDataDir);
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+void test("preserves manual Plex source URLs and disables stale resources", () => {
+  withDatabase(() => {
+    const provider = {
+      id: "plex",
+      name: "Plex",
+      auth: "pin" as const,
+    };
+
+    const account = persistProviderAuth({
+      provider,
+      userToken: "user-token",
+      resources: [
+        {
+          id: "kept-server",
+          name: "Kept Server",
+          accessToken: "server-token-before",
+          connections: [{
+            id: "auto-connection",
+            uri: "http://auto-before.example:32400",
+            local: true,
+            relay: false,
+          }],
+        },
+        {
+          id: "stale-server",
+          name: "Stale Server",
+          accessToken: "stale-token",
+          connections: [{
+            id: "stale-connection",
+            uri: "http://stale.example:32400",
+            local: true,
+            relay: false,
+          }],
+        },
+      ],
+    });
+
+    const keptBefore = getMediaSourceByProviderExternalId("plex", account.id, "kept-server");
+    assert(keptBefore);
+    updateMediaSource(keptBefore.id, {
+      baseUrl: "http://manual.example:32400",
+      connection: {
+        ...keptBefore.connection,
+        baseUrlMode: PLEX_BASE_URL_MODE_MANUAL,
+      },
+    });
+
+    persistProviderAuth({
+      provider,
+      userToken: "user-token",
+      resources: [{
+        id: "kept-server",
+        name: "Kept Server Renamed",
+        accessToken: "server-token-after",
+        connections: [{
+          id: "auto-connection-after",
+          uri: "http://auto-after.example:32400",
+          local: false,
+          relay: false,
+        }],
+      }],
+    });
+
+    const keptAfter = getMediaSourceByProviderExternalId("plex", account.id, "kept-server");
+    const staleAfter = getMediaSourceByProviderExternalId("plex", account.id, "stale-server");
+    assert(keptAfter);
+    assert(staleAfter);
+
+    assert.equal(keptAfter.name, "Kept Server Renamed");
+    assert.equal(keptAfter.enabled, true);
+    assert.equal(keptAfter.baseUrl, "http://manual.example:32400");
+    assert.equal(keptAfter.connection.baseUrlMode, PLEX_BASE_URL_MODE_MANUAL);
+    assert.equal(keptAfter.credentials.accessToken, "server-token-after");
+    assert.equal(staleAfter.enabled, false);
+    assert.equal(listMediaSources({ providerAccountId: account.id }).length, 2);
+  });
+});

--- a/apps/server/src/routes/mediaCurrentPlaying.test.ts
+++ b/apps/server/src/routes/mediaCurrentPlaying.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { closeDatabase } from "../db/database.js";
+import { upsertMediaSource, type MediaSource } from "../db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
+import { createApp } from "../app.js";
+import { plexProvider } from "../providers/plex/provider.js";
+import type { CurrentlyPlayingEntry } from "../providers/types.js";
+import {
+  createProviderSession,
+  getSessionCookieName,
+} from "../session/store.js";
+
+const TEST_APP_KEY = "media-currently-playing-test-key-with-32-chars";
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+async function withTestApp<T>(callback: (baseUrl: string) => Promise<T>) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-media-currently-playing-"));
+  const previousAppKey = process.env.APP_KEY;
+  const previousDataDir = process.env.CLIPARR_DATA_DIR;
+
+  process.env.APP_KEY = TEST_APP_KEY;
+  process.env.CLIPARR_DATA_DIR = dataDir;
+
+  const { app } = await createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  try {
+    await new Promise((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve(undefined));
+    });
+    closeDatabase();
+    restoreEnv("APP_KEY", previousAppKey);
+    restoreEnv("CLIPARR_DATA_DIR", previousDataDir);
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+function createSource(providerAccountId: string, name: string, providerId = "plex", enabled = true) {
+  const source = upsertMediaSource({
+    providerId,
+    providerAccountId,
+    externalId: `${providerId}-${name.toLowerCase().replace(/\s+/g, "-")}`,
+    name,
+    enabled,
+    baseUrl: `http://${name.toLowerCase().replace(/\s+/g, "-")}.example`,
+  });
+  assert(source);
+  return source;
+}
+
+function playbackEntry(source: MediaSource, viewer: { id: string; name: string }, itemId: string): CurrentlyPlayingEntry {
+  return {
+    viewer: {
+      id: viewer.id,
+      providerId: source.providerId,
+      name: viewer.name,
+    },
+    item: {
+      id: itemId,
+      source: {
+        id: source.id,
+        name: source.name,
+        providerId: source.providerId,
+      },
+      title: `${source.name} Movie`,
+      type: "movie",
+      duration: 120,
+      playerTitle: `${viewer.name} Player`,
+      playerState: "playing",
+      mediaUrl: `/api/media/${itemId}`,
+    },
+  };
+}
+
+void test("aggregates currently playing results across enabled sources with partial failures", async () => {
+  await withTestApp(async (baseUrl) => {
+    const account = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "user-token",
+    });
+    assert(account);
+
+    const alpha = createSource(account.id, "Alpha");
+    const zeta = createSource(account.id, "Zeta");
+    createSource(account.id, "Failure");
+    createSource(account.id, "Ghost", "missing-provider");
+    createSource(account.id, "Unsupported");
+    createSource(account.id, "Disabled", "plex", false);
+
+    const session = createProviderSession({
+      providerId: "plex",
+      providerAccountId: account.id,
+      userToken: "user-token",
+    });
+
+    const originalListCurrentlyPlaying = plexProvider.listCurrentlyPlaying.bind(plexProvider);
+    const originalSupportsCurrentlyPlayingSource = plexProvider.supportsCurrentlyPlayingSource?.bind(plexProvider);
+    const calls: string[] = [];
+
+    plexProvider.supportsCurrentlyPlayingSource = (source) => source.name !== "Unsupported";
+    plexProvider.listCurrentlyPlaying = async (_session, source) => {
+      calls.push(source.name);
+      if (source.name === "Failure") {
+        throw new Error("Source is offline");
+      }
+
+      if (source.id === alpha.id) {
+        return [playbackEntry(source, { id: "viewer-alice", name: "Alice" }, "alpha-item")];
+      }
+
+      if (source.id === zeta.id) {
+        return [
+          playbackEntry(source, { id: "viewer-bob", name: "Bob" }, "zeta-bob-item"),
+          playbackEntry(source, { id: "viewer-alice", name: "Alice" }, "zeta-alice-item"),
+        ];
+      }
+
+      return [];
+    };
+
+    try {
+      const response = await fetch(`${baseUrl}/api/media/currently-playing`, {
+        headers: {
+          cookie: `${getSessionCookieName()}=${session.id}`,
+        },
+      });
+
+      assert.equal(response.status, 200);
+      const body = await response.json() as {
+        viewers?: Array<{ viewer: { name: string }; items: Array<{ source: { name: string } }> }>;
+        sourceErrors?: Array<{ sourceName: string; providerId: string; message: string }>;
+      };
+
+      assert.deepEqual(calls, ["Alpha", "Failure", "Zeta"]);
+      assert.deepEqual(body.viewers?.map((group) => group.viewer.name), ["Alice", "Bob"]);
+      assert.deepEqual(body.viewers?.[0]?.items.map((item) => item.source.name), ["Alpha", "Zeta"]);
+      assert.deepEqual(
+        body.sourceErrors?.map((error) => ({
+          sourceName: error.sourceName,
+          providerId: error.providerId,
+          message: error.message,
+        })).sort((left, right) => left.sourceName.localeCompare(right.sourceName)),
+        [
+          {
+            sourceName: "Failure",
+            providerId: "plex",
+            message: "Source is offline",
+          },
+          {
+            sourceName: "Ghost",
+            providerId: "missing-provider",
+            message: "Source provider is not registered",
+          },
+        ]
+      );
+    } finally {
+      plexProvider.listCurrentlyPlaying = originalListCurrentlyPlaying;
+      plexProvider.supportsCurrentlyPlayingSource = originalSupportsCurrentlyPlayingSource;
+    }
+  });
+});

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -1,0 +1,440 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { closeDatabase } from "../db/database.js";
+import {
+  getMediaSourceByProviderExternalId,
+  getMediaSourceForAccount,
+  listMediaSources,
+  upsertMediaSource,
+} from "../db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
+import { createApp } from "../app.js";
+import {
+  createProviderSession,
+  getSessionCookieName,
+} from "../session/store.js";
+import { PLEX_BASE_URL_MODE_MANUAL } from "../providers/plex/connectionState.js";
+
+const TEST_APP_KEY = "provider-routes-test-key-with-at-least-32-characters";
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function jsonResponse(value: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(value), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+}
+
+function cookieHeader(response: Response) {
+  return response.headers
+    .getSetCookie()
+    .map((cookie) => cookie.split(";")[0])
+    .join("; ");
+}
+
+async function withTestApp<T>(callback: (baseUrl: string, fetchLocal: typeof fetch) => Promise<T>) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-provider-routes-"));
+  const previousAppKey = process.env.APP_KEY;
+  const previousDataDir = process.env.CLIPARR_DATA_DIR;
+
+  process.env.APP_KEY = TEST_APP_KEY;
+  process.env.CLIPARR_DATA_DIR = dataDir;
+
+  const { app } = await createApp();
+  const server = app.listen(0, "127.0.0.1");
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await new Promise((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`, originalFetch);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve(undefined));
+    });
+    globalThis.fetch = originalFetch;
+    closeDatabase();
+    restoreEnv("APP_KEY", previousAppKey);
+    restoreEnv("CLIPARR_DATA_DIR", previousDataDir);
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+async function withMockedFetch<T>(
+  handler: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>,
+  action: () => Promise<T>
+) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+void test("completes Plex PIN auth through route cookies and persists sources", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    await withMockedFetch(async (input) => {
+      const requestUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (requestUrl === "https://plex.tv/api/v2/pins?strong=true") {
+        return jsonResponse({
+          id: 321,
+          code: "WXYZ",
+          expiresIn: 60,
+        });
+      }
+
+      if (requestUrl === "https://plex.tv/api/v2/pins/321") {
+        return jsonResponse({
+          authToken: "plex-user-token",
+        });
+      }
+
+      if (requestUrl === "https://clients.plex.tv/api/v2/resources?includeHttps=1&includeRelay=1&includeIPv6=1") {
+        return jsonResponse([{
+          name: "Living Room Plex",
+          product: "Plex Media Server",
+          platform: "macOS",
+          provides: "server",
+          owned: true,
+          accessToken: "plex-server-token",
+          clientIdentifier: "plex-server-1",
+          connections: [
+            {
+              uri: "http://192.0.2.10:32400",
+              local: true,
+              relay: false,
+            },
+            {
+              uri: "https://relay.example.test",
+              local: false,
+              relay: true,
+            },
+          ],
+        }]);
+      }
+
+      throw new Error(`Unexpected fetch: ${requestUrl}`);
+    }, async () => {
+      const startResponse = await fetchLocal(`${baseUrl}/api/providers/plex/auth/start`, {
+        method: "POST",
+      });
+      assert.equal(startResponse.status, 200);
+      const startBody = await startResponse.json() as { authId?: string; authUrl?: string };
+      assert.equal(typeof startBody.authId, "string");
+      assert.match(startBody.authUrl ?? "", /^https:\/\/app\.plex\.tv\/auth#/);
+      const authCookie = cookieHeader(startResponse);
+      assert.match(authCookie, /cliparr_provider_auth=/);
+
+      const rejectedPollResponse = await fetchLocal(`${baseUrl}/api/providers/plex/auth/${startBody.authId}`);
+      assert.equal(rejectedPollResponse.status, 401);
+      const rejectedBody = await rejectedPollResponse.json() as { error?: { code?: string } };
+      assert.equal(rejectedBody.error?.code, "invalid_provider_auth_session");
+
+      const completeResponse = await fetchLocal(`${baseUrl}/api/providers/plex/auth/${startBody.authId}`, {
+        headers: {
+          cookie: authCookie,
+        },
+      });
+      assert.equal(completeResponse.status, 200);
+      assert.deepEqual(await completeResponse.json(), { status: "complete" });
+      const setCookies = completeResponse.headers.getSetCookie();
+      assert(setCookies.some((cookie) => cookie.startsWith("cliparr_provider_auth=") && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")));
+      assert(setCookies.some((cookie) => cookie.startsWith("cliparr_session=")));
+      assert(setCookies.some((cookie) => cookie.startsWith("cliparr_remember=")));
+
+      const sources = listMediaSources({ providerId: "plex" });
+      assert.equal(sources.length, 1);
+      assert.equal(sources[0]?.name, "Living Room Plex");
+      assert.equal(sources[0]?.baseUrl, "http://192.0.2.10:32400");
+      assert.equal(sources[0]?.credentials.accessToken, "plex-server-token");
+      assert.equal(sources[0]?.metadata.product, "Plex Media Server");
+    });
+  });
+});
+
+void test("logs into Jellyfin with credentials and stores a remembered provider session", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const upstreamRequests: Array<{ url: string; body?: string }> = [];
+
+    await withMockedFetch(async (input, init) => {
+      const requestUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      upstreamRequests.push({
+        url: requestUrl,
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+
+      if (requestUrl === "http://1.1.1.1:8096/jellyfin/System/Info/Public") {
+        return jsonResponse({
+          Id: "jellyfin-server-1",
+          ServerName: "Jelly Lab",
+          ProductName: "Jellyfin",
+          Version: "10.9.0",
+        });
+      }
+
+      if (requestUrl === "http://1.1.1.1:8096/jellyfin/Users/AuthenticateByName") {
+        return jsonResponse({
+          AccessToken: "jellyfin-user-token",
+          ServerId: "jellyfin-server-1",
+          User: {
+            Id: "admin-user",
+            Name: "Admin",
+            Policy: {
+              IsAdministrator: true,
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${requestUrl}`);
+    }, async () => {
+      const response = await fetchLocal(`${baseUrl}/api/providers/jellyfin/auth/login`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          serverUrl: "http://1.1.1.1:8096/jellyfin/?discard=true#fragment",
+          username: "admin",
+          password: "secret",
+        }),
+      });
+
+      assert.equal(response.status, 200);
+      const body = await response.json() as { session?: { providerId?: string } };
+      assert.equal(body.session?.providerId, "jellyfin");
+      const setCookies = response.headers.getSetCookie();
+      assert(setCookies.some((cookie) => cookie.startsWith("cliparr_session=")));
+      assert(setCookies.some((cookie) => cookie.startsWith("cliparr_remember=")));
+
+      const authRequest = upstreamRequests.find((request) => request.url.endsWith("/Users/AuthenticateByName"));
+      assert(authRequest?.body);
+      assert.deepEqual(JSON.parse(authRequest.body), {
+        Username: "admin",
+        Pw: "secret",
+      });
+
+      const sources = listMediaSources({ providerId: "jellyfin" });
+      assert.equal(sources.length, 1);
+      assert.equal(sources[0]?.name, "Jelly Lab");
+      assert.equal(sources[0]?.baseUrl, "http://1.1.1.1:8096/jellyfin");
+      assert.equal(sources[0]?.credentials.accessToken, "jellyfin-user-token");
+      assert.equal(sources[0]?.credentials.userId, "admin-user");
+      assert.equal(sources[0]?.metadata.username, "Admin");
+    });
+  });
+});
+
+void test("updates sources with account isolation and preserves Plex manual URL mode", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const account = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "user-token",
+    });
+    const otherAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Other Plex Account",
+      accessToken: "other-token",
+    });
+    assert(account);
+    assert(otherAccount);
+
+    const source = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: account.id,
+      externalId: "server-1",
+      name: "Main Plex",
+      baseUrl: "http://auto.example:32400",
+      connection: {
+        connections: [],
+        selectedConnectionId: "auto",
+      },
+      credentials: {
+        accessToken: "server-token",
+      },
+    });
+    const otherSource = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: otherAccount.id,
+      externalId: "server-2",
+      name: "Other Plex",
+      baseUrl: "http://other.example:32400",
+    });
+    assert(source);
+    assert(otherSource);
+
+    const session = createProviderSession({
+      providerId: "plex",
+      providerAccountId: account.id,
+      userToken: "user-token",
+    });
+    const sessionCookie = `${getSessionCookieName()}=${session.id}`;
+
+    const isolatedResponse = await fetchLocal(`${baseUrl}/api/sources/${otherSource.id}`, {
+      headers: {
+        cookie: sessionCookie,
+      },
+    });
+    assert.equal(isolatedResponse.status, 404);
+
+    const rejectedPatchResponse = await fetchLocal(`${baseUrl}/api/sources/${source.id}`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        cookie: sessionCookie,
+      },
+      body: JSON.stringify({
+        credentials: {},
+      }),
+    });
+    assert.equal(rejectedPatchResponse.status, 400);
+    const rejectedPatch = await rejectedPatchResponse.json() as { error?: { code?: string } };
+    assert.equal(rejectedPatch.error?.code, "source_field_not_editable");
+
+    const response = await fetchLocal(`${baseUrl}/api/sources/${source.id}`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        cookie: sessionCookie,
+      },
+      body: JSON.stringify({
+        name: " Main Plex Manual ",
+        baseUrl: "https://manual.example/plex/?token=secret#section",
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json() as { source?: { name?: string; baseUrl?: string } };
+    assert.equal(body.source?.name, "Main Plex Manual");
+    assert.equal(body.source?.baseUrl, "https://manual.example/plex");
+
+    const updatedSource = getMediaSourceForAccount(source.id, account.id);
+    assert(updatedSource);
+    assert.equal(updatedSource.connection.baseUrlMode, PLEX_BASE_URL_MODE_MANUAL);
+    assert.equal(updatedSource.baseUrl, "https://manual.example/plex");
+
+    const listResponse = await fetchLocal(`${baseUrl}/api/sources`, {
+      headers: {
+        cookie: sessionCookie,
+      },
+    });
+    assert.equal(listResponse.status, 200);
+    const listed = await listResponse.json() as { sources?: Array<{ id: string }> };
+    assert.deepEqual(listed.sources?.map((item) => item.id), [source.id]);
+  });
+});
+
+void test("refreshes Jellyfin source health and persists check results", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const account = upsertProviderAccountByAccessToken({
+      providerId: "jellyfin",
+      label: "Jellyfin Account",
+      accessToken: "jellyfin-user-token",
+    });
+    assert(account);
+
+    const source = upsertMediaSource({
+      providerId: "jellyfin",
+      providerAccountId: account.id,
+      externalId: "jellyfin-server-1",
+      name: "Jellyfin",
+      baseUrl: "http://1.1.1.1:8096",
+      credentials: {
+        accessToken: "jellyfin-user-token",
+        userId: "admin-user",
+        deviceId: "device-1",
+      },
+      metadata: {
+        serverName: "Jellyfin",
+      },
+    });
+    assert(source);
+
+    const session = createProviderSession({
+      providerId: "jellyfin",
+      providerAccountId: account.id,
+      userToken: "jellyfin-user-token",
+    });
+
+    await withMockedFetch(async (input) => {
+      const requestUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (requestUrl === "http://1.1.1.1:8096/System/Info/Public") {
+        return jsonResponse({
+          Id: "jellyfin-server-1",
+          ServerName: "Jelly Lab",
+          ProductName: "Jellyfin",
+          Version: "10.9.1",
+        });
+      }
+
+      if (requestUrl === "http://1.1.1.1:8096/Users/Me") {
+        return jsonResponse({
+          Id: "admin-user",
+          Name: "Admin",
+          Policy: {
+            IsAdministrator: true,
+          },
+        });
+      }
+
+      if (requestUrl === "http://1.1.1.1:8096/Sessions?activeWithinSeconds=300") {
+        return jsonResponse([]);
+      }
+
+      throw new Error(`Unexpected fetch: ${requestUrl}`);
+    }, async () => {
+      const response = await fetchLocal(`${baseUrl}/api/sources/${source.id}/check`, {
+        method: "POST",
+        headers: {
+          cookie: `${getSessionCookieName()}=${session.id}`,
+        },
+      });
+
+      assert.equal(response.status, 200);
+      const body = await response.json() as { ok?: boolean; source?: { name?: string; lastError?: string | null } };
+      assert.equal(body.ok, true);
+      assert.equal(body.source?.name, "Jelly Lab");
+      assert.equal(body.source?.lastError, null);
+
+      const updatedSource = getMediaSourceByProviderExternalId("jellyfin", account.id, "jellyfin-server-1");
+      assert(updatedSource);
+      assert.equal(updatedSource.name, "Jelly Lab");
+      assert.equal(updatedSource.lastError, undefined);
+      assert.equal(updatedSource.metadata.version, "10.9.1");
+      assert.match(updatedSource.lastCheckedAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused backend and frontend coverage for source handling, API export paths, editor export decisions, filenames, metadata, and sources modal state
- extract sources modal state helpers so important filtering, edit payload, and refresh-all behavior can be tested without visual/provider integrations
- clean up unused helper exports reported by Knip

## Validation
- pnpm test
- pnpm lint
- pnpm knip