### PR TITLE
feat(cliparr): add logtape wide event logging

### DIFF
--- a/.agents/skills/cliparr-logtape/SKILL.md
+++ b/.agents/skills/cliparr-logtape/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: cliparr-logtape
+description: >
+  Use this skill when changing, reviewing, or adding Cliparr LogTape logging in
+  frontend, server, shared helpers, or tests. Covers Cliparr category taxonomy,
+  wide-event boundaries, flat dot-notated fields, context, redaction/noise
+  rules, no-console enforcement, and validation for logging PRs.
+---
+
+# Cliparr LogTape Logging
+
+## Purpose
+
+Use this skill for Cliparr-specific logging work. It does not replace the
+upstream LogTape docs; it records Cliparr's local policy for categories,
+structured fields, wide events, and validation.
+
+## Start Here
+
+- Read current logging setup before editing:
+  - `apps/server/src/logging.ts`
+  - `apps/frontend/src/logging.ts`
+  - `packages/shared/src/logging.ts`
+- Search existing usage with:
+  - `rg -n "get(Server|Frontend)Logger|logEventFields|console\\." apps packages`
+- Preserve runtime behavior unless the user explicitly asks for behavior
+  changes. Logging edits should not alter response bodies, media behavior, or
+  export semantics.
+
+## Logger Access
+
+- Server app code uses `getServerLogger(...)`.
+- Frontend app code uses `getFrontendLogger(...)`.
+- Do not import or call raw `getLogger()` in Cliparr app code except inside the
+  logging setup helpers.
+- Use array hierarchy segments, not dotted single-string categories:
+
+```typescript
+const logger = getFrontendLogger(["editor", "playback"]);
+const proxyLogger = getServerLogger(["media", "proxy"]);
+```
+
+- Use `logger.getChild("subsystem")` when one file owns several child
+  categories, such as media route logging.
+
+## Category Taxonomy
+
+Keep Cliparr application logs under the app root:
+
+- Frontend: `["cliparr", "frontend", ...]`
+- Server: `["cliparr", "server", ...]`
+
+Keep LogTape internals separate and explicit:
+
+- `["logtape", "meta"]` is reserved for LogTape configuration/sink diagnostics.
+- Configure the meta category at `warning`.
+- Never pass `["logtape", "meta"]` through `getServerLogger()` or
+  `getFrontendLogger()`.
+
+Use these domain categories:
+
+- `frontend.editor.playback`
+- `frontend.editor.export`
+- `frontend.editor.subtitle`
+- `frontend.editor.artwork`
+- `frontend.source`
+- `server.lifecycle`
+- `server.http.request`
+- `server.http.error`
+- `server.db`
+- `server.session`
+- `server.session.store`
+- `server.provider.auth`
+- `server.provider.plex.playback`
+- `server.provider.jellyfin.playback`
+- `server.source`
+- `server.media.discovery`
+- `server.media.local_url`
+- `server.media.proxy`
+
+Categories describe ownership and filtering. Keep `event.name` as the stable
+operation name.
+
+## Structured Fields
+
+- Use flat dot-notated keys only, e.g. `"event.name"`, `"request.id"`,
+  `"provider.id"`, `"media.handle.id"`, `"error.code"`.
+- Use helpers from `@cliparr/shared/logging`:
+  - `logEventFields(name, outcome)`
+  - `logDurationFields(startedAt)`
+  - `logErrorFields(err)`
+  - `compactLogFields(fields)`
+  - `sanitizeUrlForLog(value)`
+- Use `logger.with()` for repeated explicit context such as
+  `"editor.session.id"` and provider IDs.
+- Server request context is implicit via `withContext()`; keep request fields
+  flat and dot-notated.
+- For actual `Error` objects, use `warnWithError`, `errorWithError`, or
+  `fatalWithError` so LogTape receives the error object directly with extra
+  fields.
+
+## Wide Events And Noise
+
+Prefer one structured summary per meaningful operation/outcome. Hot-path media
+internals stay at `trace`; recoverable failures use `warning`; real operation
+failures use `error` or `fatal`.
+
+- HTTP requests: completion at `trace`; slow or 5xx summaries at `warning`.
+- Provider auth/session: auth start, poll complete/expired/fail, credential
+  login complete/fail, restore, logout.
+- Sources: update, delete, check, and refresh-all summaries.
+- Playback discovery: `/api/media/currently-playing` as one aggregate event.
+- Media handles/proxy: creation, reuse, retries, cache, and playlist rewrite at
+  `trace`; missing handles, unsafe URLs, upstream failures, and stream failures
+  at `warning`/`error`.
+- Editor playback: one source-attempt event for success, degraded, and failure.
+- Editor export: start, success, and failure.
+- Subtitle/artwork: concise load success/failure summaries.
+
+Do not log full track arrays, full media metadata, subtitle text, or repeated
+per-frame/per-chunk details by default.
+
+## Redaction Rules
+
+Never log:
+
+- tokens, cookies, passwords, or credentials
+- raw auth URLs
+- raw media URLs with query strings
+- subtitle text
+- full media metadata arrays
+- usernames if they are not necessary for debugging
+
+Prefer IDs, counts, booleans, sanitized origin/path, status codes, durations,
+and failure categories.
+
+## No Console
+
+- Do not add `console.*`.
+- ESLint `no-console` enforces this.
+- CLI/user-facing scripts should use `process.stdout.write` or
+  `process.stderr.write` instead of `console.*`.
+
+## Before Editing Checklist
+
+- Identify the operation boundary and decide whether it needs a wide event or
+  lower-level `trace`.
+- Pick the category from the taxonomy above.
+- Reuse existing helpers and context patterns.
+- Confirm the data is high-value for debugging and low-noise in normal use.
+- Check that sensitive values are omitted or sanitized.
+
+## Validation
+
+For logging changes, run:
+
+- `pnpm --filter @cliparr/server lint`
+- `pnpm --filter @cliparr/frontend lint`
+- `pnpm knip`
+- `rg -n "console\\." . --glob '!node_modules' --glob '!dist' --glob '!*.lock'`
+
+Before committing or updating a PR, run:
+
+- `pnpm preflight`
+
+When category output matters, use a server test that emits logs and confirm
+sample categories render as `cliparr.server.*`; frontend categories should
+compile through `getFrontendLogger()`.

--- a/.agents/skills/cliparr-logtape/agents/openai.yaml
+++ b/.agents/skills/cliparr-logtape/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cliparr LogTape"
+  short_description: "Cliparr LogTape categories and wide-event logging"
+  default_prompt: "Use $cliparr-logtape when changing Cliparr logging."

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "@cliparr/shared": "workspace:*",
+    "@logtape/logtape": "^2.1.1",
     "@mediabunny/aac-encoder": "^1.45.4",
     "@mediabunny/ac3": "^1.45.4",
     "@tanstack/react-router": "^1.170.8",

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -2,14 +2,9 @@ import type { InputAudioTrack, InputVideoTrack } from "mediabunny";
 import {
   editorMediaSourcesEqual,
   isHlsEditorMediaSource,
-  sourceDisplayLabel,
   type EditorMediaSource,
 } from "../../lib/editorMedia";
-import {
-  getTrackCodec,
-  getTrackLanguageCode,
-  getTrackName,
-} from "../../lib/mediabunnyTrackAccess";
+import { getTrackCodec } from "../../lib/mediabunnyTrackAccess";
 import type { PlaybackAudioSelection } from "../../providers/types";
 import { errorMessage, isAc3FamilyCodec } from "./editorUtils";
 
@@ -314,89 +309,4 @@ export async function assessPreviewAudioTrack(track: InputAudioTrack | null) {
   }
 
   return { track, warning: undefined };
-}
-
-async function summarizeVideoTrackForDebug(track: InputVideoTrack | null) {
-  if (!track) {
-    return null;
-  }
-
-  const [codec, title, canDecode] = await Promise.all([
-    getTrackCodec(track),
-    getTrackName(track),
-    track.canDecode().catch(() => null),
-  ]);
-
-  return {
-    trackNumber: track.number,
-    codec: codec ?? null,
-    title: title ?? null,
-    canDecode,
-  };
-}
-
-async function summarizeAudioTrackForDebug(track: InputAudioTrack | null) {
-  if (!track) {
-    return null;
-  }
-
-  const [codec, title, languageCode, canDecode] = await Promise.all([
-    getTrackCodec(track),
-    getTrackName(track),
-    getTrackLanguageCode(track),
-    track.canDecode().catch(() => null),
-  ]);
-
-  return {
-    trackNumber: track.number,
-    codec: codec ?? null,
-    title: title ?? null,
-    languageCode: languageCode ?? null,
-    canDecode,
-  };
-}
-
-async function summarizeAudioTracksForDebug(
-  tracks: readonly InputAudioTrack[],
-) {
-  return Promise.all(tracks.map((track) => summarizeAudioTrackForDebug(track)));
-}
-
-export async function buildPlaybackSourceAnalysis(
-  context: PlaybackSourceAnalysisContext,
-) {
-  const [
-    allAudioTracks,
-    sourceVideoTrack,
-    previewVideoTrack,
-    sourceAudioTrack,
-    previewAudioTrack,
-  ] = await Promise.all([
-    summarizeAudioTracksForDebug(context.allAudioTracks),
-    summarizeVideoTrackForDebug(context.sourceVideoTrack),
-    summarizeVideoTrackForDebug(context.previewVideoTrack),
-    summarizeAudioTrackForDebug(context.sourceAudioTrack),
-    summarizeAudioTrackForDebug(context.previewAudioTrack),
-  ]);
-
-  return {
-    sessionId: context.sessionId,
-    source: context.source,
-    urlClassification: classifyPlaybackSource({
-      label: context.source,
-      source: context.mediaSource,
-    }),
-    sourceLabel: sourceDisplayLabel(context.mediaSource),
-    selectedAudioTrack: context.selectedAudioTrack ?? null,
-    videoTrackCount: context.videoTracks.length,
-    audioTrackCount: context.allAudioTracks.length,
-    allAudioTracks,
-    sourceVideoTrack,
-    previewVideoTrack,
-    sourceAudioTrack,
-    previewAudioTrack,
-    previewAudioWarning: context.previewAudioWarning ?? null,
-    warnings: [...context.warnings],
-    isLivePlayback: context.isLivePlayback,
-  } satisfies Record<string, unknown>;
 }

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
 import {
   buildExportFileName,
@@ -22,6 +27,7 @@ import type {
 import type { PlaybackSubtitleTrack } from "../../providers/types";
 import type { ExportSourcePreference } from "./EditorExportDialog";
 import type { PlaybackFallbackInfo } from "./useEditorPlayback";
+import { getFrontendLogger, warnWithError } from "../../logging";
 
 interface VideoDimensions {
   width: number;
@@ -61,6 +67,8 @@ interface UseEditorExportProps {
   subtitleStyleSettings: SubtitleStyleSettings;
 }
 
+const logger = getFrontendLogger(["editor", "export"]);
+
 export function useEditorExport({
   session,
   startTime,
@@ -90,6 +98,10 @@ export function useEditorExport({
   const [exporting, setExporting] = useState(false);
   const [progress, setProgress] = useState(0);
   const [exportError, setExportError] = useState<string | null>(null);
+  const exportLogger = useMemo(
+    () => logger.with({ "editor.session.id": session.id }),
+    [session.id],
+  );
 
   const effectiveExportSourcePreference =
     exportSourcePreference === "direct" && !session.directSource
@@ -288,6 +300,29 @@ export function useEditorExport({
     setExporting(true);
     setProgress(0);
 
+    const startedAt = Date.now();
+    const baseFields = {
+      "export.format": exportFormat,
+      "export.resolution": resolution,
+      "export.source.kind": readiness.sourceKind,
+      "export.source.role": readiness.source.role,
+      "export.range.start_seconds": startTime,
+      "export.range.end_seconds": endTime,
+      "export.range.duration_seconds": Math.max(0, endTime - startTime),
+      "export.include_audio": includeAudio,
+      "export.subtitle.burn_in": shouldBurnSubtitles,
+      "export.subtitle.cue_count": shouldBurnSubtitles
+        ? clippedSubtitleCues.length
+        : 0,
+      "export.output.width": outputDimensions?.width,
+      "export.output.height": outputDimensions?.height,
+    };
+
+    exportLogger.info("Editor export started.", {
+      ...logEventFields("editor.export", "started"),
+      ...baseFields,
+    });
+
     try {
       const { exportClip } = await import("../../lib/exportClip");
       const blob = await exportClip({
@@ -315,8 +350,20 @@ export function useEditorExport({
       document.body.removeChild(a);
       window.setTimeout(() => URL.revokeObjectURL(url), 0);
       setExportDialogOpen(false);
+
+      exportLogger.info("Editor export completed.", {
+        ...logEventFields("editor.export", "success"),
+        ...logDurationFields(startedAt),
+        ...baseFields,
+        "export.output.bytes": blob.size,
+      });
     } catch (err) {
-      console.error(err);
+      warnWithError(exportLogger, err, "Editor export failed.", {
+        ...logEventFields("editor.export", "failure"),
+        ...logDurationFields(startedAt),
+        ...logErrorFields(err),
+        ...baseFields,
+      });
       setExportError(err instanceof Error ? err.message : "Export failed");
     } finally {
       setExporting(false);
@@ -325,10 +372,12 @@ export function useEditorExport({
     clippedSubtitleCues,
     endTime,
     exportFormat,
+    exportLogger,
     exportSource,
     exporting,
     fileName.fullName,
     includeAudio,
+    outputDimensions,
     resolution,
     selectedSubtitleTrack,
     session.exportMetadata,

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import type {
   AudioBufferSink,
   CanvasSink,
@@ -33,7 +39,6 @@ import {
   browserDecoderEnvironmentWarning,
   buildPlaybackFailure,
   buildPlaybackLoadError,
-  buildPlaybackSourceAnalysis,
   buildPlaybackSourceCandidates,
   describePlaybackFailure,
   formatPlaybackSourceLabel,
@@ -44,6 +49,7 @@ import {
   shouldUseExportFallback,
   type PlaybackFallbackInfo,
   type PlaybackLoadFailure,
+  type PlaybackSourceCandidate,
   type PlaybackSourceAnalysisContext,
 } from "./editorPlaybackSources";
 import {
@@ -58,6 +64,7 @@ import {
 } from "./useEditorPlaybackWarmup";
 import { resolvePreviewPlaybackPlan } from "./editorPlaybackPlan";
 import { resetPlaybackReadyRangeWarmState } from "./editorPlaybackWarmupRange";
+import { getFrontendLogger, warnWithError } from "../../logging";
 
 export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
 export type { PlaybackReadyRange } from "./useEditorPlaybackWarmup";
@@ -88,6 +95,34 @@ interface StaticVideoFrame {
 }
 
 const MAX_STATIC_VIDEO_FRAME_SIZE = 1920;
+const logger = getFrontendLogger(["editor", "playback"]);
+
+function playbackSourceLogFields(
+  playbackSource: PlaybackSourceCandidate,
+  context?: PlaybackSourceAnalysisContext,
+) {
+  return compactLogFields({
+    "playback.source.kind": playbackSource.source.kind,
+    "playback.source.role": playbackSource.source.role,
+    "playback.source.label": playbackSource.label,
+    "playback.video.track_count": context?.videoTracks.length,
+    "playback.audio.track_count": context?.allAudioTracks.length,
+    "playback.video.preview.present": context
+      ? Boolean(context.previewVideoTrack)
+      : undefined,
+    "playback.audio.preview.present": context
+      ? Boolean(context.previewAudioTrack)
+      : undefined,
+    "playback.audio.source.present": context
+      ? Boolean(context.sourceAudioTrack)
+      : undefined,
+    "playback.video.source.present": context
+      ? Boolean(context.sourceVideoTrack)
+      : undefined,
+    "playback.warning.count": context?.warnings.length,
+    "playback.live": context?.isLivePlayback,
+  });
+}
 
 function scaledStaticFrameDimensions(
   width: number,
@@ -199,6 +234,10 @@ export function useEditorPlayback({
     useState<VideoDimensions | null>(null);
   const [playbackReadyRange, setPlaybackReadyRange] =
     useState<PlaybackReadyRange | null>(null);
+  const playbackLogger = useMemo(
+    () => logger.with({ "editor.session.id": sessionId }),
+    [sessionId],
+  );
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const inputRef = useRef<Input | null>(null);
@@ -847,6 +886,7 @@ export function useEditorPlayback({
         let nextHlsFallbackInfo: PlaybackFallbackInfo | null = null;
 
         for (const playbackSource of playbackSources) {
+          const attemptStartedAt = Date.now();
           let playbackSourceAnalysisContext:
             | PlaybackSourceAnalysisContext
             | undefined;
@@ -916,12 +956,17 @@ export function useEditorPlayback({
               !sourceVideoTrack && previewAudioTrack && posterImageUrl
                 ? await loadStaticVideoFrame(posterImageUrl).catch(
                     (err: unknown) => {
-                      console.warn(
-                        "Could not load editor artwork for audio-only preview",
+                      warnWithError(
+                        playbackLogger,
+                        err,
+                        "Could not load editor artwork for audio-only preview.",
                         {
-                          sessionId,
-                          posterImageUrl,
-                          errorMessage: errorMessage(err),
+                          ...logEventFields(
+                            "editor.playback.artwork_load",
+                            "failure",
+                          ),
+                          ...logErrorFields(err),
+                          "media.artwork.present": Boolean(posterImageUrl),
                         },
                       );
                       return null;
@@ -956,11 +1001,20 @@ export function useEditorPlayback({
               !previewAudioTrack &&
               playbackSourceAnalysisContext
             ) {
-              console.warn(
-                "Editor playback source loaded without preview audio",
-                await buildPlaybackSourceAnalysis(
-                  playbackSourceAnalysisContext,
-                ),
+              playbackLogger.warn(
+                "Editor playback source has no preview audio.",
+                {
+                  ...logEventFields(
+                    "editor.playback.source_attempt",
+                    "degraded",
+                  ),
+                  ...logDurationFields(attemptStartedAt),
+                  ...playbackSourceLogFields(
+                    playbackSource,
+                    playbackSourceAnalysisContext,
+                  ),
+                  "playback.degraded.reason": "missing_preview_audio",
+                },
               );
             }
 
@@ -970,11 +1024,20 @@ export function useEditorPlayback({
               !staticVideoFrame &&
               playbackSourceAnalysisContext
             ) {
-              console.warn(
-                "Editor playback source loaded without preview video",
-                await buildPlaybackSourceAnalysis(
-                  playbackSourceAnalysisContext,
-                ),
+              playbackLogger.warn(
+                "Editor playback source has no preview video.",
+                {
+                  ...logEventFields(
+                    "editor.playback.source_attempt",
+                    "degraded",
+                  ),
+                  ...logDurationFields(attemptStartedAt),
+                  ...playbackSourceLogFields(
+                    playbackSource,
+                    playbackSourceAnalysisContext,
+                  ),
+                  "playback.degraded.reason": "missing_preview_video",
+                },
               );
             }
 
@@ -1103,13 +1166,23 @@ export function useEditorPlayback({
                 ? nextHlsFallbackInfo
                 : null,
             );
+            playbackLogger.info("Editor playback source loaded.", {
+              ...logEventFields("editor.playback.source_attempt", "success"),
+              ...logDurationFields(attemptStartedAt),
+              ...playbackSourceLogFields(
+                playbackSource,
+                playbackSourceAnalysisContext,
+              ),
+              "playback.fallback.used": failures.length > 0,
+              "playback.video.width": previewDimensions?.width,
+              "playback.video.height": previewDimensions?.height,
+              "playback.audio.sample_rate": audioTrackSampleRate,
+              "playback.duration.seconds": nextDuration,
+            });
             return;
           } catch (err) {
             const failure = buildPlaybackFailure(playbackSource, err);
             failures.push(failure);
-            const playbackSourceAnalysis = playbackSourceAnalysisContext
-              ? await buildPlaybackSourceAnalysis(playbackSourceAnalysisContext)
-              : undefined;
 
             if (
               (failure.label === "hls stream" || failure.label === "hls url") &&
@@ -1126,14 +1199,25 @@ export function useEditorPlayback({
               };
             }
 
-            console.warn("Editor playback source failed", {
-              sessionId,
-              source: failure.label,
-              classification: failure.classification,
-              category: failure.category,
-              message: failure.message,
-              analysis: playbackSourceAnalysis,
-            });
+            warnWithError(
+              playbackLogger,
+              err,
+              "Editor playback source failed.",
+              {
+                ...logEventFields("editor.playback.source_attempt", "failure"),
+                ...logDurationFields(attemptStartedAt),
+                ...logErrorFields(err),
+                ...playbackSourceLogFields(
+                  playbackSource,
+                  playbackSourceAnalysisContext,
+                ),
+                "playback.failure.classification": failure.classification,
+                "playback.failure.category": failure.category,
+                "playback.failure.message": failure.message,
+                "playback.fallback.available": Boolean(fallbackDirectSource),
+                "playback.fallback.used": Boolean(nextExportFallbackSource),
+              },
+            );
 
             if (cancelled) {
               return;
@@ -1167,6 +1251,7 @@ export function useEditorPlayback({
     hlsSource,
     initialCurrentTime,
     initialDuration,
+    playbackLogger,
     posterImageUrl,
     selectedAudioTrack,
     sessionId,

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -23,14 +23,26 @@ interface UseSubtitleCuesOptions {
 const subtitleRequestTimeoutMs = 15_000;
 const logger = getFrontendLogger(["editor", "subtitles"]);
 
-class SubtitleDownloadError extends Error {
+interface SubtitleDownloadFailure {
   status: number;
+  message: string;
+}
 
-  constructor(status: number) {
-    super(`Could not load subtitles (${status}).`);
-    this.name = "SubtitleDownloadError";
-    this.status = status;
-  }
+type SubtitleDownloadResult =
+  | {
+      ok: true;
+      cues: SubtitleCue[];
+    }
+  | {
+      ok: false;
+      failure: SubtitleDownloadFailure;
+    };
+
+function subtitleDownloadFailure(status: number): SubtitleDownloadFailure {
+  return {
+    status,
+    message: `Could not load subtitles (${status}).`,
+  };
 }
 
 function subtitleTrackLogFields(
@@ -52,13 +64,19 @@ async function downloadSubtitleCues(
   track: PlaybackSubtitleTrack,
   contentUrl: string,
   signal: AbortSignal,
-) {
+): Promise<SubtitleDownloadResult> {
   const response = await fetch(contentUrl, { signal });
   if (!response.ok) {
-    throw new SubtitleDownloadError(response.status);
+    return {
+      ok: false,
+      failure: subtitleDownloadFailure(response.status),
+    };
   }
 
-  return parseSubtitleText(await response.text(), track.contentFormat);
+  return {
+    ok: true,
+    cues: parseSubtitleText(await response.text(), track.contentFormat),
+  };
 }
 
 export function useSubtitleCues({
@@ -110,7 +128,7 @@ export function useSubtitleCues({
 
       const startedAt = Date.now();
       try {
-        const parsedSubtitleCues = await downloadSubtitleCues(
+        const downloadResult = await downloadSubtitleCues(
           selectedSubtitleTrack,
           contentUrl,
           abortController.signal,
@@ -120,6 +138,22 @@ export function useSubtitleCues({
           return;
         }
 
+        if (!downloadResult.ok) {
+          logger.warn("Could not load subtitle cues.", {
+            ...logEventFields("editor.subtitle.load", "failure"),
+            ...logDurationFields(startedAt),
+            ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
+            "subtitle.timeout": false,
+            "http.status_code": downloadResult.failure.status,
+            "error.name": "SubtitleDownloadFailure",
+            "error.message": downloadResult.failure.message,
+          });
+          setSubtitleCues([]);
+          setSubtitleError(downloadResult.failure.message);
+          return;
+        }
+
+        const parsedSubtitleCues = downloadResult.cues;
         setSubtitleCues(parsedSubtitleCues);
         setSubtitleError(
           parsedSubtitleCues.length === 0
@@ -155,8 +189,6 @@ export function useSubtitleCues({
           ...logErrorFields(err),
           ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
           "subtitle.timeout": false,
-          "http.status_code":
-            err instanceof SubtitleDownloadError ? err.status : undefined,
         });
         setSubtitleCues([]);
         setSubtitleError(

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -1,4 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import type { PlaybackSubtitleTrack } from "../../providers/types";
 import {
   subtitleTrackSupportsBurnIn,
@@ -6,6 +12,7 @@ import {
 } from "../../lib/selectPreferredSubtitleTrack";
 import { parseSubtitleText } from "../../lib/subtitles/parseSubtitleText";
 import type { SubtitleCue } from "../../lib/subtitles/types";
+import { getFrontendLogger, warnWithError } from "../../logging";
 
 interface UseSubtitleCuesOptions {
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
@@ -14,36 +21,31 @@ interface UseSubtitleCuesOptions {
 }
 
 const subtitleRequestTimeoutMs = 15_000;
+const logger = getFrontendLogger(["editor", "subtitles"]);
 
-function responseErrorMessage(payload: unknown) {
-  if (!payload || typeof payload !== "object" || !("error" in payload)) {
-    return "";
+class SubtitleDownloadError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super(`Could not load subtitles (${status}).`);
+    this.name = "SubtitleDownloadError";
+    this.status = status;
   }
-
-  const error = payload.error;
-  if (
-    !error ||
-    typeof error !== "object" ||
-    !("message" in error) ||
-    typeof error.message !== "string"
-  ) {
-    return "";
-  }
-
-  return error.message.trim();
 }
 
-async function subtitleDownloadErrorDetail(response: Response) {
-  try {
-    const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.toLowerCase().includes("application/json")) {
-      return responseErrorMessage(await response.json());
-    }
-
-    return (await response.text()).replace(/\s+/g, " ").trim();
-  } catch {
-    return "";
-  }
+function subtitleTrackLogFields(
+  track: PlaybackSubtitleTrack,
+  providerId: string,
+) {
+  return compactLogFields({
+    "provider.id": providerId,
+    "subtitle.track.id": track.streamId,
+    "subtitle.track.index": track.index,
+    "subtitle.format": track.contentFormat,
+    "subtitle.codec": track.codec,
+    "subtitle.text": track.isText,
+    "subtitle.external": track.isExternal,
+  });
 }
 
 async function downloadSubtitleCues(
@@ -53,12 +55,7 @@ async function downloadSubtitleCues(
 ) {
   const response = await fetch(contentUrl, { signal });
   if (!response.ok) {
-    const detail = await subtitleDownloadErrorDetail(response);
-    console.error("Subtitle download failed", {
-      status: response.status,
-      detail,
-    });
-    throw new Error(`Could not load subtitles (${response.status}).`);
+    throw new SubtitleDownloadError(response.status);
   }
 
   return parseSubtitleText(await response.text(), track.contentFormat);
@@ -111,6 +108,7 @@ export function useSubtitleCues({
       setSubtitleLoading(true);
       setSubtitleError(null);
 
+      const startedAt = Date.now();
       try {
         const parsedSubtitleCues = await downloadSubtitleCues(
           selectedSubtitleTrack,
@@ -128,17 +126,38 @@ export function useSubtitleCues({
             ? "No subtitles found in this track."
             : null,
         );
+        logger.info("Subtitle cues loaded.", {
+          ...logEventFields("editor.subtitle.load", "success"),
+          ...logDurationFields(startedAt),
+          ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
+          "subtitle.cue.count": parsedSubtitleCues.length,
+        });
       } catch (err) {
         if (cancelled || abortController.signal.aborted) {
           if (!cancelled) {
             setSubtitleCues([]);
             setSubtitleError("Subtitles timed out. Try again.");
             setSubtitleLoading(false);
+            logger.warn("Subtitle cue load timed out.", {
+              ...logEventFields("editor.subtitle.load", "failure"),
+              ...logDurationFields(startedAt),
+              ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
+              "subtitle.timeout": true,
+              "subtitle.timeout.ms": subtitleRequestTimeoutMs,
+            });
           }
           return;
         }
 
-        console.error("Could not load subtitle cues", err);
+        warnWithError(logger, err, "Could not load subtitle cues.", {
+          ...logEventFields("editor.subtitle.load", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
+          "subtitle.timeout": false,
+          "http.status_code":
+            err instanceof SubtitleDownloadError ? err.status : undefined,
+        });
         setSubtitleCues([]);
         setSubtitleError(
           err instanceof Error ? err.message : "Could not load subtitles.",

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -21,7 +21,7 @@ interface UseSubtitleCuesOptions {
 }
 
 const subtitleRequestTimeoutMs = 15_000;
-const logger = getFrontendLogger(["editor", "subtitles"]);
+const logger = getFrontendLogger(["editor", "subtitle"]);
 
 interface SubtitleDownloadFailure {
   status: number;

--- a/apps/frontend/src/components/sources/useSourcesState.ts
+++ b/apps/frontend/src/components/sources/useSourcesState.ts
@@ -31,7 +31,7 @@ interface SourceActionResult {
   removeSourceId?: string;
 }
 
-const logger = getFrontendLogger(["sources"]);
+const logger = getFrontendLogger("source");
 
 export function useSourcesState({
   isOpen,

--- a/apps/frontend/src/components/sources/useSourcesState.ts
+++ b/apps/frontend/src/components/sources/useSourcesState.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import { cliparrClient } from "../../api/cliparrClient";
 import { useAuth } from "../../auth";
 import type { MediaSource, ProviderSession } from "../../providers/types";
@@ -13,6 +18,7 @@ import {
   sourceProviderOptions,
   sortSources,
 } from "./sourcesStateUtils";
+import { getFrontendLogger, warnWithError } from "../../logging";
 
 interface UseSourcesStateOptions {
   isOpen: boolean;
@@ -24,6 +30,8 @@ interface SourceActionResult {
   source?: MediaSource;
   removeSourceId?: string;
 }
+
+const logger = getFrontendLogger(["sources"]);
 
 export function useSourcesState({
   isOpen,
@@ -48,6 +56,13 @@ export function useSourcesState({
   const [initialSourcesLoaded, setInitialSourcesLoaded] = useState(false);
   const latestLoadRequestIdRef = useRef(0);
   const isOpenRef = useRef(isOpen);
+  const sourceLogger = useMemo(
+    () =>
+      logger.with({
+        "provider.id": auth.providerSession?.providerId,
+      }),
+    [auth.providerSession?.providerId],
+  );
 
   const replaceSources = useCallback((nextSources: MediaSource[]) => {
     setSources(nextSources);
@@ -300,6 +315,7 @@ export function useSourcesState({
       return;
     }
 
+    const startedAt = Date.now();
     setFeedback(null);
     setError("");
     setRefreshingAll(true);
@@ -320,9 +336,39 @@ export function useSourcesState({
 
       setFeedback(merged.feedback);
       await refreshPlaybackView();
+
+      const fulfilled = results.filter(
+        (result) => result.status === "fulfilled",
+      );
+      const healthy = fulfilled.filter((result) => result.value.result.ok);
+      const allSourcesHealthy =
+        healthy.length === sources.length &&
+        fulfilled.length === results.length;
+      const fields = {
+        ...logEventFields(
+          "source.refresh_all",
+          allSourcesHealthy ? "success" : "partial",
+        ),
+        ...logDurationFields(startedAt),
+        "source.count": sources.length,
+        "source.health.ok_count": healthy.length,
+        "source.health.error_count": fulfilled.length - healthy.length,
+        "source.refresh.rejected_count": results.length - fulfilled.length,
+      };
+      if (allSourcesHealthy) {
+        sourceLogger.info("Refreshed all media sources.", fields);
+      } else {
+        sourceLogger.warn("Refreshed all media sources with errors.", fields);
+      }
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Could not refresh sources.";
+      warnWithError(sourceLogger, err, "Could not refresh sources.", {
+        ...logEventFields("source.refresh_all", "failure"),
+        ...logDurationFields(startedAt),
+        ...logErrorFields(err),
+        "source.count": sources.length,
+      });
       setError(message);
     } finally {
       setRefreshingAll(false);

--- a/apps/frontend/src/lib/exportMetadata.ts
+++ b/apps/frontend/src/lib/exportMetadata.ts
@@ -5,7 +5,7 @@ import { describeInputTrack } from "./mediabunnyTrackAccess";
 import type { ExportFormat } from "./exportTypes";
 import { getFrontendLogger, warnWithError } from "../logging";
 
-const logger = getFrontendLogger(["editor", "metadata"]);
+const logger = getFrontendLogger(["editor", "artwork"]);
 
 const discardReasonLabels: Record<DiscardedTrack["reason"], string> = {
   discarded_by_user: "discarded by configuration",

--- a/apps/frontend/src/lib/exportMetadata.ts
+++ b/apps/frontend/src/lib/exportMetadata.ts
@@ -1,7 +1,11 @@
 import type { DiscardedTrack, MetadataTags } from "mediabunny";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import type { MediaExportMetadata } from "../providers/types";
 import { describeInputTrack } from "./mediabunnyTrackAccess";
 import type { ExportFormat } from "./exportTypes";
+import { getFrontendLogger, warnWithError } from "../logging";
+
+const logger = getFrontendLogger(["editor", "metadata"]);
 
 const discardReasonLabels: Record<DiscardedTrack["reason"], string> = {
   discarded_by_user: "discarded by configuration",
@@ -337,6 +341,10 @@ async function fetchAttachedImage(
   try {
     const response = await fetch(url);
     if (!response.ok) {
+      logger.warn("Could not fetch clip artwork.", {
+        ...logEventFields("editor.artwork.load", "failure"),
+        "http.status_code": response.status,
+      });
       return undefined;
     }
 
@@ -360,7 +368,10 @@ async function fetchAttachedImage(
       kind: "coverFront",
     };
   } catch (err) {
-    console.warn("Could not embed clip artwork:", err);
+    warnWithError(logger, err, "Could not embed clip artwork.", {
+      ...logEventFields("editor.artwork.load", "failure"),
+      ...logErrorFields(err),
+    });
     return undefined;
   }
 }

--- a/apps/frontend/src/lib/loggingFields.test.ts
+++ b/apps/frontend/src/lib/loggingFields.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+  sanitizeUrlForLog,
+} from "@cliparr/shared/logging";
+
+void test("builds flat event and duration logging fields", () => {
+  assert.deepEqual(logEventFields("editor.export", "success"), {
+    "event.name": "editor.export",
+    "event.outcome": "success",
+  });
+  assert.deepEqual(logDurationFields(100, 175), {
+    "event.duration.ms": 75,
+  });
+});
+
+void test("compacts undefined log fields without changing dot-notated keys", () => {
+  assert.deepEqual(
+    compactLogFields({
+      "source.id": "source-1",
+      "source.name": undefined,
+      "source.enabled": false,
+    }),
+    {
+      "source.id": "source-1",
+      "source.enabled": false,
+    },
+  );
+});
+
+void test("summarizes errors and sanitized URLs for logs", () => {
+  const error = new Error("Nope") as Error & { code?: string };
+  error.code = "E_NOPE";
+
+  assert.deepEqual(logErrorFields(error), {
+    "error.name": "Error",
+    "error.message": "Nope",
+    "error.code": "E_NOPE",
+  });
+  assert.equal(
+    sanitizeUrlForLog("https://user:secret@example.test/path/video.mp4?x=1#y"),
+    "https://example.test/path/video.mp4",
+  );
+  assert.equal(
+    sanitizeUrlForLog("/api/media/handle?token=secret"),
+    "/api/media/handle",
+  );
+});

--- a/apps/frontend/src/logging.ts
+++ b/apps/frontend/src/logging.ts
@@ -1,0 +1,70 @@
+import {
+  configure,
+  getConsoleSink,
+  getLogger,
+  isLogLevel,
+  type Logger,
+} from "@logtape/logtape";
+
+const LOG_CATEGORY_PREFIX = ["cliparr", "frontend"];
+
+let loggingConfigured: Promise<void> | undefined;
+
+interface ViteLoggingEnv {
+  readonly VITE_CLIPARR_LOG_LEVEL?: string;
+  readonly PROD: boolean;
+}
+
+export function getFrontendLogger(category: string | readonly string[]) {
+  const parts = typeof category === "string" ? [category] : [...category];
+  return getLogger([...LOG_CATEGORY_PREFIX, ...parts]);
+}
+
+export function warnWithError(
+  logger: Logger,
+  error: unknown,
+  message: string,
+  properties: Record<string, unknown>,
+) {
+  if (error instanceof Error) {
+    logger.warn(error, properties);
+    return;
+  }
+
+  logger.warn(message, properties);
+}
+
+export function configureFrontendLogging() {
+  if (loggingConfigured) {
+    return loggingConfigured;
+  }
+
+  const viteEnv = import.meta.env as unknown as ViteLoggingEnv;
+  const configuredLevel = viteEnv.VITE_CLIPARR_LOG_LEVEL?.trim();
+  const lowestLevel =
+    configuredLevel && isLogLevel(configuredLevel)
+      ? configuredLevel
+      : viteEnv.PROD
+        ? "info"
+        : "debug";
+
+  loggingConfigured = configure({
+    sinks: {
+      console: getConsoleSink(),
+    },
+    loggers: [
+      {
+        category: LOG_CATEGORY_PREFIX,
+        sinks: ["console"],
+        lowestLevel,
+      },
+      {
+        category: ["logtape", "meta"],
+        sinks: ["console"],
+        lowestLevel: "warning",
+      },
+    ],
+  });
+
+  return loggingConfigured;
+}

--- a/apps/frontend/src/logging.ts
+++ b/apps/frontend/src/logging.ts
@@ -6,7 +6,9 @@ import {
   type Logger,
 } from "@logtape/logtape";
 
-const LOG_CATEGORY_PREFIX = ["cliparr", "frontend"];
+const FRONTEND_LOG_CATEGORY_PREFIX = ["cliparr", "frontend"] as const;
+// LogTape reserves this category for its own configuration and sink diagnostics.
+const LOGTAPE_META_CATEGORY = ["logtape", "meta"] as const;
 
 let loggingConfigured: Promise<void> | undefined;
 
@@ -17,7 +19,7 @@ interface ViteLoggingEnv {
 
 export function getFrontendLogger(category: string | readonly string[]) {
   const parts = typeof category === "string" ? [category] : [...category];
-  return getLogger([...LOG_CATEGORY_PREFIX, ...parts]);
+  return getLogger([...FRONTEND_LOG_CATEGORY_PREFIX, ...parts]);
 }
 
 export function warnWithError(
@@ -54,12 +56,12 @@ export function configureFrontendLogging() {
     },
     loggers: [
       {
-        category: LOG_CATEGORY_PREFIX,
+        category: [...FRONTEND_LOG_CATEGORY_PREFIX],
         sinks: ["console"],
         lowestLevel,
       },
       {
-        category: ["logtape", "meta"],
+        category: [...LOGTAPE_META_CATEGORY],
         sinks: ["console"],
         lowestLevel: "warning",
       },

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,8 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { configureFrontendLogging } from "./logging";
 
 document.documentElement.classList.add("dark");
+
+await configureFrontendLogging();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -4,10 +4,11 @@ import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "url";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
+import { logErrorFields } from "@cliparr/shared/logging";
 import { prepareDatabaseForMigrations } from "./migrationState.js";
 import * as schema from "./schema.js";
 import { resolveConfiguredDataDir, workspaceRoot } from "../config/loadEnv.js";
-import { getServerLogger, serializeError } from "../logging.js";
+import { getServerLogger } from "../logging.js";
 import { assertAppKeyConfigured } from "../security/secrets.js";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
@@ -30,10 +31,10 @@ function enforcePermissions(targetPath: string, mode: number) {
     fs.chmodSync(targetPath, mode);
   } catch (err) {
     if (process.platform !== "win32") {
-      logger.warn("Could not set permissions on {targetPath}.", {
-        targetPath,
+      logger.warn("Could not set filesystem permissions.", {
+        "file.path": targetPath,
         mode,
-        ...serializeError(err),
+        ...logErrorFields(err),
       });
     }
   }

--- a/apps/server/src/http/errors.ts
+++ b/apps/server/src/http/errors.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
-import { getServerLogger, serializeError } from "../logging.js";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
+import { errorWithError, getServerLogger } from "../logging.js";
 
 const logger = getServerLogger(["http", "error"]);
 
@@ -47,22 +48,21 @@ export function errorHandler(
       : new ApiError(500, "internal_error", "Something went wrong");
 
   if (!(err instanceof ApiError)) {
-    logger.error("Unhandled request error for {method} {originalUrl}.", {
-      ...serializeError(err),
-      method: req.method,
-      originalUrl: req.originalUrl,
+    errorWithError(logger, err, "Unhandled request error.", {
+      ...logEventFields("http.request", "unhandled_error"),
+      ...logErrorFields(err),
+      "http.method": req.method,
+      "http.original_url": req.originalUrl,
     });
   } else if (apiError.status >= 500) {
-    logger.error(
-      "Request failed with API error {code} for {method} {originalUrl}.",
-      {
-        statusCode: apiError.status,
-        code: apiError.code,
-        message: apiError.message,
-        method: req.method,
-        originalUrl: req.originalUrl,
-      },
-    );
+    logger.error(apiError, {
+      ...logEventFields("http.request", "api_error"),
+      "http.status_code": apiError.status,
+      "error.code": apiError.code,
+      "error.message": apiError.message,
+      "http.method": req.method,
+      "http.original_url": req.originalUrl,
+    });
   }
 
   if (res.headersSent) {

--- a/apps/server/src/logging.ts
+++ b/apps/server/src/logging.ts
@@ -7,9 +7,16 @@ import {
   getLogger,
   isLogLevel,
   withContext,
+  type Logger,
 } from "@logtape/logtape";
+import {
+  compactLogFields,
+  logDurationFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 
 const LOG_CATEGORY_PREFIX = ["cliparr"];
+const SLOW_REQUEST_WARNING_MS = 10_000;
 
 let loggingConfigured: Promise<void> | undefined;
 
@@ -18,19 +25,46 @@ export function getServerLogger(category: string | readonly string[]) {
   return getLogger([...LOG_CATEGORY_PREFIX, ...parts]);
 }
 
-export function serializeError(error: unknown) {
+export function warnWithError(
+  logger: Logger,
+  error: unknown,
+  message: string,
+  properties: Record<string, unknown>,
+) {
   if (error instanceof Error) {
-    return {
-      errorName: error.name,
-      errorMessage: error.message,
-      errorStack: error.stack,
-    };
+    logger.warn(error, properties);
+    return;
   }
 
-  return {
-    errorMessage: String(error),
-    errorValue: String(error),
-  };
+  logger.warn(message, properties);
+}
+
+export function errorWithError(
+  logger: Logger,
+  error: unknown,
+  message: string,
+  properties: Record<string, unknown>,
+) {
+  if (error instanceof Error) {
+    logger.error(error, properties);
+    return;
+  }
+
+  logger.error(message, properties);
+}
+
+export function fatalWithError(
+  logger: Logger,
+  error: unknown,
+  message: string,
+  properties: Record<string, unknown>,
+) {
+  if (error instanceof Error) {
+    logger.fatal(error, properties);
+    return;
+  }
+
+  logger.fatal(message, properties);
 }
 
 export function configureLogging() {
@@ -70,6 +104,16 @@ export function configureLogging() {
 
 const requestLogger = getServerLogger(["http", "request"]);
 
+function requestRoute(req: Request) {
+  const route = (req as unknown as { route?: { path?: unknown } }).route;
+  const routePath = typeof route?.path === "string" ? route.path : undefined;
+  if (!routePath) {
+    return undefined;
+  }
+
+  return `${req.baseUrl}${routePath}`;
+}
+
 export function requestLoggingMiddleware(
   req: Request,
   res: Response,
@@ -80,18 +124,35 @@ export function requestLoggingMiddleware(
 
   withContext(
     {
-      requestId,
-      method: req.method,
-      path: req.path,
-      originalUrl: req.originalUrl,
+      "request.id": requestId,
+      "http.method": req.method,
+      "http.path": req.path,
+      "http.original_url": req.originalUrl,
     },
     () => {
       res.setHeader("X-Request-Id", requestId);
       res.once("finish", () => {
-        requestLogger.trace("Completed request {method} {originalUrl}.", {
-          statusCode: res.statusCode,
-          durationMs: Date.now() - startedAt,
+        const durationMs = Date.now() - startedAt;
+        const fields = compactLogFields({
+          ...logEventFields("http.request", "completed"),
+          ...logDurationFields(startedAt, startedAt + durationMs),
+          "http.route": requestRoute(req),
+          "http.status_code": res.statusCode,
         });
+
+        requestLogger.trace("Completed HTTP request.", fields);
+
+        if (
+          res.statusCode >= 500 ||
+          (durationMs >= SLOW_REQUEST_WARNING_MS &&
+            !req.path.startsWith("/api/media/"))
+        ) {
+          requestLogger.warn("HTTP request needs attention.", {
+            ...fields,
+            "event.outcome": res.statusCode >= 500 ? "server_error" : "slow",
+            "http.slow_threshold.ms": SLOW_REQUEST_WARNING_MS,
+          });
+        }
       });
 
       next();

--- a/apps/server/src/logging.ts
+++ b/apps/server/src/logging.ts
@@ -15,14 +15,16 @@ import {
   logEventFields,
 } from "@cliparr/shared/logging";
 
-const LOG_CATEGORY_PREFIX = ["cliparr"];
+const SERVER_LOG_CATEGORY_PREFIX = ["cliparr", "server"] as const;
+// LogTape reserves this category for its own configuration and sink diagnostics.
+const LOGTAPE_META_CATEGORY = ["logtape", "meta"] as const;
 const SLOW_REQUEST_WARNING_MS = 10_000;
 
 let loggingConfigured: Promise<void> | undefined;
 
 export function getServerLogger(category: string | readonly string[]) {
   const parts = typeof category === "string" ? [category] : [...category];
-  return getLogger([...LOG_CATEGORY_PREFIX, ...parts]);
+  return getLogger([...SERVER_LOG_CATEGORY_PREFIX, ...parts]);
 }
 
 export function warnWithError(
@@ -86,12 +88,12 @@ export function configureLogging() {
     },
     loggers: [
       {
-        category: "cliparr",
+        category: [...SERVER_LOG_CATEGORY_PREFIX],
         sinks: ["console"],
         lowestLevel,
       },
       {
-        category: ["logtape", "meta"],
+        category: [...LOGTAPE_META_CATEGORY],
         sinks: ["console"],
         lowestLevel: "warning",
       },

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -1,4 +1,9 @@
 import type { Request, Response } from "express";
+import {
+  logErrorFields,
+  logEventFields,
+  sanitizeUrlForLog,
+} from "@cliparr/shared/logging";
 import type { MediaSource } from "../../db/mediaSourcesRepository.js";
 import { ApiError } from "../../http/errors.js";
 import { getServerLogger } from "../../logging.js";
@@ -625,11 +630,11 @@ async function enrichMetadataItem(
       ...fullItem,
     };
   } catch (err) {
-    logger.warn("Could not fetch Jellyfin metadata for item {itemId}.", {
-      itemId,
-      sourceId: context.sourceId,
-      baseUrl: context.baseUrl,
-      errorMessage: errorMessage(err),
+    logger.warn("Could not fetch Jellyfin metadata.", {
+      ...logErrorFields(err),
+      "metadata.item.id": itemId,
+      "source.id": context.sourceId,
+      "source.base_url": sanitizeUrlForLog(context.baseUrl),
     });
     return item;
   }
@@ -642,11 +647,11 @@ async function loadPlaybackInfo(
   try {
     return await fetchPlaybackInfo(context, itemId);
   } catch (err) {
-    logger.warn("Could not fetch Jellyfin playback info for item {itemId}.", {
-      itemId,
-      sourceId: context.sourceId,
-      baseUrl: context.baseUrl,
-      errorMessage: errorMessage(err),
+    logger.warn("Could not fetch Jellyfin playback info.", {
+      ...logErrorFields(err),
+      "metadata.item.id": itemId,
+      "source.id": context.sourceId,
+      "source.base_url": sanitizeUrlForLog(context.baseUrl),
     });
     return undefined;
   }
@@ -936,14 +941,14 @@ export async function proxyMedia(
 
   const upstreamUrl = mediaHandleRequestUrl(handle).toString();
 
-  logger.trace("Fetching Jellyfin media for handle {handleId}.", {
-    handleId: handle.id,
-    sessionId: session.id,
-    sourceId: handle.sourceId,
-    upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
-    useProviderAuth,
-    hasRange: Boolean(range),
-    accept,
+  logger.trace("Fetching Jellyfin media.", {
+    "media.handle.id": handle.id,
+    "session.id": session.id,
+    "source.id": handle.sourceId,
+    "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
+    "provider.auth.attached": useProviderAuth,
+    "media.range.present": Boolean(range),
+    "http.accept": accept,
   });
 
   await proxyProviderMediaResponse(
@@ -976,15 +981,17 @@ export async function proxyMedia(
 
         return upstream;
       } catch (err) {
-        logger.warn("Jellyfin media request failed for handle {handleId}.", {
-          handleId: handle.id,
-          sessionId: session.id,
-          sourceId: handle.sourceId,
-          upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
-          useProviderAuth,
-          hasRange: Boolean(range),
-          accept,
-          errorMessage: errorMessage(err),
+        logger.warn("Jellyfin media request failed.", {
+          ...logEventFields("media.proxy.upstream", "failure"),
+          ...logErrorFields(err),
+          "media.handle.id": handle.id,
+          "session.id": session.id,
+          "source.id": handle.sourceId,
+          "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
+          "provider.auth.attached": useProviderAuth,
+          "media.range.present": Boolean(range),
+          "http.accept": accept,
+          "error.message": errorMessage(err),
         });
         throw err;
       }

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -53,7 +53,7 @@ import {
   type JellyfinSourceContext,
 } from "./shared.js";
 
-const logger = getServerLogger(["providers", "jellyfin"]);
+const logger = getServerLogger(["provider", "jellyfin", "playback"]);
 const HD_ARTWORK_SIZE = 1920;
 const HD_ARTWORK_QUALITY = 96;
 

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -1,6 +1,11 @@
 import { createHash, randomUUID } from "crypto";
 import type { Request, Response } from "express";
 import {
+  logErrorFields,
+  logEventFields,
+  sanitizeUrlForLog,
+} from "@cliparr/shared/logging";
+import {
   updateMediaSource,
   type MediaSource,
 } from "../../db/mediaSourcesRepository.js";
@@ -848,11 +853,11 @@ async function enrichMetadataItem(context: PlexSourceContext, item: any) {
       Session: item.Session,
     };
   } catch (err) {
-    logger.warn("Could not fetch Plex metadata for {metadataPath}.", {
-      metadataPath: metadataPath(item) ?? "Plex item",
-      sourceId: context.sourceId,
-      baseUrl: context.baseUrl,
-      errorMessage: errorMessage(err),
+    logger.warn("Could not fetch Plex metadata.", {
+      ...logErrorFields(err),
+      "metadata.path": metadataPath(item) ?? "Plex item",
+      "source.id": context.sourceId,
+      "source.base_url": sanitizeUrlForLog(context.baseUrl),
     });
     return item;
   }
@@ -947,11 +952,11 @@ async function resolveMediaPath(
     const fullItem = data?.MediaContainer?.Metadata?.[0];
     return fallbackPartPath(resolveSelectedPart(fullItem, selection)?.part);
   } catch (err) {
-    logger.warn("Could not resolve Plex media part for {metadataPath}.", {
-      metadataPath: path,
-      sourceId: context.sourceId,
-      baseUrl: context.baseUrl,
-      errorMessage: errorMessage(err),
+    logger.warn("Could not resolve Plex media part.", {
+      ...logErrorFields(err),
+      "metadata.path": path,
+      "source.id": context.sourceId,
+      "source.base_url": sanitizeUrlForLog(context.baseUrl),
     });
     return undefined;
   }
@@ -1216,15 +1221,15 @@ export async function proxyMedia(
     headers.set("X-Plex-Session-Identifier", playbackSessionId);
   }
 
-  logger.trace("Fetching Plex media for handle {handleId}.", {
-    handleId: handle.id,
-    sessionId: session.id,
-    sourceId: handle.sourceId,
-    upstreamUrl: sanitizeLoggedMediaPath(url.toString()),
-    useProviderAuth,
-    hasRange: Boolean(range),
-    accept,
-    playbackSessionId,
+  logger.trace("Fetching Plex media.", {
+    "media.handle.id": handle.id,
+    "session.id": session.id,
+    "source.id": handle.sourceId,
+    "upstream.url": sanitizeLoggedMediaPath(url.toString()),
+    "provider.auth.attached": useProviderAuth,
+    "media.range.present": Boolean(range),
+    "http.accept": accept,
+    "plex.playback_session.id": playbackSessionId,
   });
 
   await proxyProviderMediaResponse(
@@ -1241,17 +1246,18 @@ export async function proxyMedia(
           .slice(0, 400)
           .replace(/\s+/g, " ")
           .trim();
-        logger.warn("Plex media request failed for handle {handleId}.", {
-          handleId: handle.id,
-          sessionId: session.id,
-          sourceId: handle.sourceId,
-          upstreamUrl: sanitizeLoggedMediaPath(url.toString()),
-          statusCode: upstream.status,
-          detail,
-          useProviderAuth,
-          hasRange: Boolean(range),
-          accept,
-          playbackSessionId,
+        logger.warn("Plex media request failed.", {
+          ...logEventFields("media.proxy.upstream", "failure"),
+          "media.handle.id": handle.id,
+          "session.id": session.id,
+          "source.id": handle.sourceId,
+          "upstream.url": sanitizeLoggedMediaPath(url.toString()),
+          "upstream.status_code": upstream.status,
+          "upstream.detail": detail,
+          "provider.auth.attached": useProviderAuth,
+          "media.range.present": Boolean(range),
+          "http.accept": accept,
+          "plex.playback_session.id": playbackSessionId,
         });
         throw new ApiError(
           upstream.status,

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -62,7 +62,7 @@ import {
   withPlexBaseUrlMode,
 } from "./connectionState.js";
 
-const logger = getServerLogger(["providers", "plex"]);
+const logger = getServerLogger(["provider", "plex", "playback"]);
 const HD_ARTWORK_SIZE = 1920;
 const PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH = 16;
 

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -5,6 +5,7 @@ import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import type { ReadableStream as WebReadableStream } from "stream/web";
 import type { Response } from "express";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import { ApiError } from "../../http/errors.js";
 import { getServerLogger } from "../../logging.js";
 import type { ProviderSessionRecord } from "../../session/store.js";
@@ -253,7 +254,29 @@ async function resolveHostnameAddresses(hostname: string) {
   return inflight;
 }
 
-function throwUnsafeMediaUrl() {
+function unsafeMediaUrlFields(
+  handle: Pick<MediaHandle, "baseUrl" | "path">,
+  requestUrl: URL,
+  reason: string,
+) {
+  return {
+    ...logEventFields("media.proxy.url_validation", "failure"),
+    "media.path": sanitizeLoggedMediaPath(requestUrl.toString()),
+    "media.base_path": sanitizeLoggedMediaPath(handle.baseUrl),
+    "media.url.hostname": requestUrl.hostname,
+    "media.url.reason": reason,
+  };
+}
+
+function throwUnsafeMediaUrl(
+  handle: Pick<MediaHandle, "baseUrl" | "path">,
+  requestUrl: URL,
+  reason: string,
+) {
+  logger.warn(
+    "Rejected unsafe media URL.",
+    unsafeMediaUrlFields(handle, requestUrl, reason),
+  );
   throw new ApiError(
     400,
     "media_proxy_unsafe_url",
@@ -266,6 +289,10 @@ export async function assertAllowedMediaHandleRequestUrl(
   requestUrl = mediaHandleRequestUrl(handle),
 ) {
   if (requestUrl.protocol !== "http:" && requestUrl.protocol !== "https:") {
+    logger.warn(
+      "Rejected media URL with unsupported protocol.",
+      unsafeMediaUrlFields(handle, requestUrl, "protocol"),
+    );
     throw new ApiError(
       400,
       "media_proxy_unsafe_url",
@@ -274,7 +301,7 @@ export async function assertAllowedMediaHandleRequestUrl(
   }
 
   if (requestUrl.username || requestUrl.password) {
-    throwUnsafeMediaUrl();
+    throwUnsafeMediaUrl(handle, requestUrl, "credentials");
   }
 
   const providerUrl = safeUrl(handle.baseUrl);
@@ -283,12 +310,23 @@ export async function assertAllowedMediaHandleRequestUrl(
   }
 
   if (isUnsafeMediaHostname(requestUrl.hostname)) {
-    throwUnsafeMediaUrl();
+    throwUnsafeMediaUrl(handle, requestUrl, "hostname");
   }
 
-  for (const address of await resolveHostnameAddresses(requestUrl.hostname)) {
+  let addresses: string[];
+  try {
+    addresses = await resolveHostnameAddresses(requestUrl.hostname);
+  } catch (err) {
+    logger.warn("Media URL hostname validation failed.", {
+      ...unsafeMediaUrlFields(handle, requestUrl, "dns_resolution"),
+      ...logErrorFields(err),
+    });
+    throw err;
+  }
+
+  for (const address of addresses) {
     if (isUnsafeMediaHostname(address)) {
-      throwUnsafeMediaUrl();
+      throwUnsafeMediaUrl(handle, requestUrl, "resolved_address");
     }
   }
 }
@@ -493,18 +531,15 @@ export async function fetchMediaHandleRequest(
       }
 
       await closeRetryableResponse(response);
-      logger.trace(
-        "Retrying media request after retryable upstream status for handle {handleId}.",
-        {
-          handleId: handle.id,
-          providerId: handle.providerId,
-          sourceId: handle.sourceId,
-          path: sanitizeLoggedMediaPath(handle.path),
-          statusCode: response.status,
-          attempt: attemptNumber,
-          maxAttempts: totalAttempts,
-        },
-      );
+      logger.trace("Retrying media request after retryable upstream status.", {
+        "media.handle.id": handle.id,
+        "provider.id": handle.providerId,
+        "source.id": handle.sourceId,
+        "media.path": sanitizeLoggedMediaPath(handle.path),
+        "upstream.status_code": response.status,
+        "retry.attempt": attemptNumber,
+        "retry.max_attempts": totalAttempts,
+      });
     } catch (err) {
       cleanup();
       lastError = err;
@@ -515,18 +550,15 @@ export async function fetchMediaHandleRequest(
         throw err;
       }
 
-      logger.trace(
-        "Retrying media request after fetch failure for handle {handleId}.",
-        {
-          handleId: handle.id,
-          providerId: handle.providerId,
-          sourceId: handle.sourceId,
-          path: sanitizeLoggedMediaPath(handle.path),
-          attempt: attemptNumber,
-          maxAttempts: totalAttempts,
-          errorMessage: err instanceof Error ? err.message : String(err),
-        },
-      );
+      logger.trace("Retrying media request after fetch failure.", {
+        "media.handle.id": handle.id,
+        "provider.id": handle.providerId,
+        "source.id": handle.sourceId,
+        "media.path": sanitizeLoggedMediaPath(handle.path),
+        "retry.attempt": attemptNumber,
+        "retry.max_attempts": totalAttempts,
+        "error.message": err instanceof Error ? err.message : String(err),
+      });
     }
 
     await delay(retryDelayMs(attemptIndex, retryBaseDelayMs));
@@ -579,13 +611,14 @@ export function createProviderMediaHandle(
       existingHandle.basePath === normalizedBasePath
     ) {
       existingHandle.lastAccessedAt = accessedAt;
-      logger.trace("Reused provider media handle {handleId}.", {
-        handleId: existingHandle.id,
-        sessionId: session.id,
-        providerId: context.providerId,
-        sourceId: context.sourceId,
-        path: sanitizeLoggedMediaPath(normalizedPath),
-        basePath: sanitizeLoggedMediaPath(normalizedBasePath),
+      logger.trace("Reused provider media handle.", {
+        ...logEventFields("media.handle", "reused"),
+        "media.handle.id": existingHandle.id,
+        "session.id": session.id,
+        "provider.id": context.providerId,
+        "source.id": context.sourceId,
+        "media.path": sanitizeLoggedMediaPath(normalizedPath),
+        "media.base_path": sanitizeLoggedMediaPath(normalizedBasePath),
       });
       return `/api/media/${existingHandle.id}`;
     }
@@ -603,14 +636,15 @@ export function createProviderMediaHandle(
     lastAccessedAt: accessedAt,
   };
   session.mediaHandles.set(handle.id, handle);
-  logger.trace("Created provider media handle {handleId}.", {
-    handleId: handle.id,
-    sessionId: session.id,
-    providerId: handle.providerId,
-    sourceId: handle.sourceId,
-    path: sanitizeLoggedMediaPath(handle.path),
-    basePath: sanitizeLoggedMediaPath(handle.basePath),
-    absolutePath: isAbsoluteUrl(handle.path),
+  logger.trace("Created provider media handle.", {
+    ...logEventFields("media.handle", "created"),
+    "media.handle.id": handle.id,
+    "session.id": session.id,
+    "provider.id": handle.providerId,
+    "source.id": handle.sourceId,
+    "media.path": sanitizeLoggedMediaPath(handle.path),
+    "media.base_path": sanitizeLoggedMediaPath(handle.basePath),
+    "media.path.absolute": isAbsoluteUrl(handle.path),
   });
   return `/api/media/${handle.id}`;
 }
@@ -708,15 +742,16 @@ async function rewriteHlsPlaylist(
     })
     .join("\n");
 
-  logger.trace("Rewrote HLS playlist for media handle {handleId}.", {
-    handleId: handle.id,
-    sessionId: session.id,
-    providerId: handle.providerId,
-    path: sanitizeLoggedMediaPath(handle.path),
-    basePath: sanitizeLoggedMediaPath(basePath),
-    upstreamStatus: upstream.status,
-    rewrittenUriCount,
-    strippedStartHintCount,
+  logger.trace("Rewrote HLS playlist for media handle.", {
+    ...logEventFields("media.hls.playlist_rewrite", "success"),
+    "media.handle.id": handle.id,
+    "session.id": session.id,
+    "provider.id": handle.providerId,
+    "media.path": sanitizeLoggedMediaPath(handle.path),
+    "media.base_path": sanitizeLoggedMediaPath(basePath),
+    "upstream.status_code": upstream.status,
+    "media.hls.rewritten_uri_count": rewrittenUriCount,
+    "media.hls.stripped_start_hint_count": strippedStartHintCount,
   });
 
   return playlist;
@@ -879,30 +914,30 @@ function describeStreamFailure(err: unknown) {
   if (err instanceof Error) {
     const errorWithCause = err as Error & { code?: string; cause?: unknown };
     const properties: Record<string, unknown> = {
-      errorName: err.name,
-      errorMessage: err.message,
+      "error.name": err.name,
+      "error.message": err.message,
     };
 
     if (errorWithCause.code) {
-      properties.errorCode = errorWithCause.code;
+      properties["error.code"] = errorWithCause.code;
     }
 
     if (errorWithCause.cause instanceof Error) {
-      properties.causeName = errorWithCause.cause.name;
-      properties.causeMessage = errorWithCause.cause.message;
+      properties["error.cause.name"] = errorWithCause.cause.name;
+      properties["error.cause.message"] = errorWithCause.cause.message;
       const causeWithCode = errorWithCause.cause as Error & { code?: string };
       if (causeWithCode.code) {
-        properties.causeCode = causeWithCode.code;
+        properties["error.cause.code"] = causeWithCode.code;
       }
     } else if (errorWithCause.cause !== undefined) {
-      properties.causeType = typeof errorWithCause.cause;
+      properties["error.cause.type"] = typeof errorWithCause.cause;
     }
 
     return properties;
   }
 
   return {
-    errorValue: String(err),
+    "error.value": String(err),
   };
 }
 
@@ -916,13 +951,13 @@ export async function proxyUpstreamMediaResponse(
   res.status(upstream.status);
 
   const contentType = upstream.headers.get("content-type") ?? "";
-  logger.trace("Proxying upstream media response for handle {handleId}.", {
-    handleId: handle.id,
-    sessionId: session.id,
-    providerId: handle.providerId,
-    path: sanitizeLoggedMediaPath(handle.path),
-    upstreamStatus: upstream.status,
-    contentType,
+  logger.trace("Proxying upstream media response.", {
+    "media.handle.id": handle.id,
+    "session.id": session.id,
+    "provider.id": handle.providerId,
+    "media.path": sanitizeLoggedMediaPath(handle.path),
+    "upstream.status_code": upstream.status,
+    "upstream.content_type": contentType,
   });
 
   if (isHlsPlaylist(handle, contentType)) {
@@ -961,13 +996,14 @@ export async function proxyUpstreamMediaResponse(
   } catch (err) {
     const responseClosed =
       res.destroyed || res.writableEnded || res.writableFinished;
-    const logMessage = "Streaming media proxy failed for handle {handleId}.";
+    const logMessage = "Streaming media proxy failed.";
     const properties = {
-      handleId: handle.id,
-      sessionId: session.id,
-      providerId: handle.providerId,
-      path: sanitizeLoggedMediaPath(handle.path),
-      responseClosed,
+      ...logEventFields("media.proxy.stream", "failure"),
+      "media.handle.id": handle.id,
+      "session.id": session.id,
+      "provider.id": handle.providerId,
+      "media.path": sanitizeLoggedMediaPath(handle.path),
+      "http.response.closed": responseClosed,
       ...describeStreamFailure(err),
     };
 
@@ -1004,16 +1040,14 @@ export async function proxyProviderMediaResponse(
 
   const cachedResponse = cachedProxyResponses.get(cacheKey);
   if (cachedResponse && cachedResponse.expiresAt > Date.now()) {
-    logger.trace(
-      "Served cached proxied media response for handle {handleId}.",
-      {
-        handleId: handle.id,
-        sessionId: session.id,
-        providerId: handle.providerId,
-        path: sanitizeLoggedMediaPath(handle.path),
-        cacheKey,
-      },
-    );
+    logger.trace("Served cached proxied media response.", {
+      ...logEventFields("media.proxy.cache", "hit"),
+      "media.handle.id": handle.id,
+      "session.id": session.id,
+      "provider.id": handle.providerId,
+      "media.path": sanitizeLoggedMediaPath(handle.path),
+      "media.cache.key": cacheKey,
+    });
     sendCachedProxyResponse(cachedResponse.response, res);
     return;
   }
@@ -1046,16 +1080,14 @@ export async function proxyProviderMediaResponse(
       }
     });
   } else {
-    logger.trace(
-      "Waiting for in-flight proxied media response for handle {handleId}.",
-      {
-        handleId: handle.id,
-        sessionId: session.id,
-        providerId: handle.providerId,
-        path: sanitizeLoggedMediaPath(handle.path),
-        cacheKey,
-      },
-    );
+    logger.trace("Waiting for in-flight proxied media response.", {
+      ...logEventFields("media.proxy.cache", "wait"),
+      "media.handle.id": handle.id,
+      "session.id": session.id,
+      "provider.id": handle.providerId,
+      "media.path": sanitizeLoggedMediaPath(handle.path),
+      "media.cache.key": cacheKey,
+    });
   }
 
   sendCachedProxyResponse(await inflightResponse, res);

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -81,7 +81,7 @@ const DISALLOWED_MEDIA_HOSTNAMES = new Set([
 const RETRYABLE_MEDIA_STATUS_CODES = new Set([
   408, 425, 429, 500, 502, 503, 504,
 ]);
-const logger = getServerLogger(["providers", "media-proxy"]);
+const logger = getServerLogger(["media", "proxy"]);
 const cachedProxyResponses = new Map<
   string,
   {

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -1,8 +1,14 @@
 import { randomUUID } from "crypto";
 import { Router } from "express";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import { listMediaSources } from "../db/mediaSourcesRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
-import { getServerLogger } from "../logging.js";
+import { getServerLogger, warnWithError } from "../logging.js";
 import { getProvider } from "../providers/registry.js";
 import {
   assertAllowedMediaHandleRequestUrl,
@@ -171,22 +177,48 @@ mediaRouter.post(
   "/local-url",
   asyncHandler(async (req, res) => {
     setNoStore(res);
-    pruneSessionMediaHandles(localUrlSession);
+    const startedAt = Date.now();
 
-    const handle = buildLocalUrlMediaHandle(bodyUrl(req.body));
-    await assertAllowedMediaHandleRequestUrl(handle);
-    const mediaUrl = storeLocalUrlMediaHandle(handle);
+    try {
+      const prunedCount = pruneSessionMediaHandles(localUrlSession);
+      const handle = buildLocalUrlMediaHandle(bodyUrl(req.body));
+      await assertAllowedMediaHandleRequestUrl(handle);
+      const mediaUrl = storeLocalUrlMediaHandle(handle);
 
-    logger.trace("Created local URL media handle {handleId}.", {
-      handleId: handle.id,
-      upstreamUrl: sanitizeLoggedMediaPath(handle.path),
-      hls: isHlsPlaylistUrl(handle.path),
-    });
+      logger.trace("Created local URL media handle.", {
+        ...logEventFields("media.local_url.handle", "created"),
+        "media.handle.id": handle.id,
+        "upstream.url": sanitizeLoggedMediaPath(handle.path),
+        "media.hls": isHlsPlaylistUrl(handle.path),
+      });
 
-    res.status(201).json({
-      mediaUrl,
-      hls: isHlsPlaylistUrl(handle.path),
-    });
+      res.status(201).json({
+        mediaUrl,
+        hls: isHlsPlaylistUrl(handle.path),
+      });
+
+      logger.info("Local URL media handle created.", {
+        ...logEventFields("media.local_url.create", "success"),
+        ...logDurationFields(startedAt),
+        "media.handle.id": handle.id,
+        "upstream.url": sanitizeLoggedMediaPath(handle.path),
+        "media.hls": isHlsPlaylistUrl(handle.path),
+        "media.handle.pruned_count": prunedCount,
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Local URL media handle creation failed.",
+        compactLogFields({
+          ...logEventFields("media.local_url.create", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
+    }
   }),
 );
 
@@ -215,12 +247,12 @@ mediaRouter.get(
     }
 
     const upstreamUrl = mediaHandleRequestUrl(handle).toString();
-    logger.trace("Fetching local URL media for handle {handleId}.", {
-      handleId: handle.id,
-      upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
-      hasRange: Boolean(range),
+    logger.trace("Fetching local URL media.", {
+      "media.handle.id": handle.id,
+      "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
+      "media.range.present": Boolean(range),
       accept,
-      prunedCount,
+      "media.handle.pruned_count": prunedCount,
     });
 
     await proxyProviderMediaResponse(
@@ -249,12 +281,13 @@ mediaRouter.get(
 
           return upstream;
         } catch (err) {
-          logger.warn("Local URL media request failed for handle {handleId}.", {
-            handleId: handle.id,
-            upstreamUrl: sanitizeLoggedMediaPath(upstreamUrl),
-            hasRange: Boolean(range),
+          logger.warn("Local URL media request failed.", {
+            ...logEventFields("media.local_url.fetch", "failure"),
+            "media.handle.id": handle.id,
+            "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
+            "media.range.present": Boolean(range),
             accept,
-            errorMessage: errorMessage(err),
+            "error.message": errorMessage(err),
           });
 
           if (err instanceof ApiError) {
@@ -280,6 +313,7 @@ mediaRouter.get(
   "/currently-playing",
   asyncHandler(async (req, res) => {
     setNoStore(res);
+    const startedAt = Date.now();
     const session = requireAccountSession(req);
     const prunedCount = pruneSessionMediaHandles(session);
     const sourceErrors: SourcePlaybackError[] = [];
@@ -338,17 +372,33 @@ mediaRouter.get(
       });
     });
 
-    logger.trace("Listed currently playing media.", {
-      sessionId: session.id,
-      providerId: session.providerId,
-      providerAccountId: session.providerAccountId,
-      sourceCount: sources.length,
-      viewerCount: new Set(entries.map((entry) => entry.viewer.id)).size,
-      entryCount: entries.length,
-      sourceErrorCount: sourceErrors.length,
-      prunedHandleCount: prunedCount,
-      remainingHandleCount: session.mediaHandles.size,
-    });
+    const summaryFields = {
+      ...logEventFields(
+        "playback.currently_playing",
+        sourceErrors.length > 0 ? "partial" : "success",
+      ),
+      ...logDurationFields(startedAt),
+      "session.id": session.id,
+      "provider.id": session.providerId,
+      "provider.account.id": session.providerAccountId,
+      "source.count": sources.length,
+      "viewer.count": new Set(entries.map((entry) => entry.viewer.id)).size,
+      "playback.item.count": entries.length,
+      "source.error.count": sourceErrors.length,
+      "media.handle.pruned_count": prunedCount,
+      "media.handle.remaining_count": session.mediaHandles.size,
+    };
+
+    if (sourceErrors.length > 0) {
+      logger.warn("Listed currently playing media with source errors.", {
+        ...summaryFields,
+        "source.error.provider_ids": [
+          ...new Set(sourceErrors.map((sourceError) => sourceError.providerId)),
+        ],
+      });
+    } else {
+      logger.info("Listed currently playing media.", summaryFields);
+    }
 
     res.json({
       viewers: groupCurrentPlayback(entries),
@@ -365,17 +415,15 @@ mediaRouter.get(
     const prunedCount = pruneSessionMediaHandles(session);
     const handle = session.mediaHandles.get(req.params.handleId as string);
     if (!handle) {
-      logger.warn(
-        "Media handle {handleId} was not found in provider session {sessionId}.",
-        {
-          handleId: req.params.handleId,
-          sessionId: session.id,
-          providerId: session.providerId,
-          providerAccountId: session.providerAccountId,
-          prunedHandleCount: prunedCount,
-          remainingHandleCount: session.mediaHandles.size,
-        },
-      );
+      logger.warn("Media handle was not found in provider session.", {
+        ...logEventFields("media.proxy", "missing_handle"),
+        "media.handle.id": req.params.handleId,
+        "session.id": session.id,
+        "provider.id": session.providerId,
+        "provider.account.id": session.providerAccountId,
+        "media.handle.pruned_count": prunedCount,
+        "media.handle.remaining_count": session.mediaHandles.size,
+      });
       throw new ApiError(
         404,
         "media_not_found",
@@ -385,15 +433,13 @@ mediaRouter.get(
 
     const provider = getProvider(handle.providerId);
     if (!provider) {
-      logger.error(
-        "Provider {providerId} for media handle {handleId} is not registered.",
-        {
-          handleId: handle.id,
-          sessionId: session.id,
-          providerId: handle.providerId,
-          sourceId: handle.sourceId,
-        },
-      );
+      logger.error("Provider for media handle is not registered.", {
+        ...logEventFields("media.proxy", "provider_not_registered"),
+        "media.handle.id": handle.id,
+        "session.id": session.id,
+        "provider.id": handle.providerId,
+        "source.id": handle.sourceId,
+      });
       throw new ApiError(
         500,
         "provider_not_registered",
@@ -401,14 +447,14 @@ mediaRouter.get(
       );
     }
 
-    logger.trace("Proxying media handle {handleId}.", {
-      handleId: handle.id,
-      sessionId: session.id,
-      providerId: handle.providerId,
-      sourceId: handle.sourceId,
-      path: sanitizeLoggedMediaPath(handle.path),
-      basePath: sanitizeLoggedMediaPath(handle.basePath),
-      prunedHandleCount: prunedCount,
+    logger.trace("Proxying media handle.", {
+      "media.handle.id": handle.id,
+      "session.id": session.id,
+      "provider.id": handle.providerId,
+      "source.id": handle.sourceId,
+      "media.path": sanitizeLoggedMediaPath(handle.path),
+      "media.base_path": sanitizeLoggedMediaPath(handle.basePath),
+      "media.handle.pruned_count": prunedCount,
     });
 
     await provider.proxyMedia(session, req.params.handleId as string, req, res);

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -31,7 +31,10 @@ import {
 } from "../session/store.js";
 
 export const mediaRouter = Router();
-const logger = getServerLogger(["routes", "media"]);
+const mediaLogger = getServerLogger("media");
+const localUrlLogger = mediaLogger.getChild("local_url");
+const discoveryLogger = mediaLogger.getChild("discovery");
+const proxyLogger = mediaLogger.getChild("proxy");
 const LOCAL_URL_PROVIDER_ID = "local-url";
 const LOCAL_URL_SOURCE_ID = "remote-url";
 const LOCAL_URL_MEDIA_BASE_URL = "http://cliparr.local";
@@ -185,7 +188,7 @@ mediaRouter.post(
       await assertAllowedMediaHandleRequestUrl(handle);
       const mediaUrl = storeLocalUrlMediaHandle(handle);
 
-      logger.trace("Created local URL media handle.", {
+      localUrlLogger.trace("Created local URL media handle.", {
         ...logEventFields("media.local_url.handle", "created"),
         "media.handle.id": handle.id,
         "upstream.url": sanitizeLoggedMediaPath(handle.path),
@@ -197,7 +200,7 @@ mediaRouter.post(
         hls: isHlsPlaylistUrl(handle.path),
       });
 
-      logger.info("Local URL media handle created.", {
+      localUrlLogger.info("Local URL media handle created.", {
         ...logEventFields("media.local_url.create", "success"),
         ...logDurationFields(startedAt),
         "media.handle.id": handle.id,
@@ -207,7 +210,7 @@ mediaRouter.post(
       });
     } catch (err) {
       warnWithError(
-        logger,
+        localUrlLogger,
         err,
         "Local URL media handle creation failed.",
         compactLogFields({
@@ -247,7 +250,7 @@ mediaRouter.get(
     }
 
     const upstreamUrl = mediaHandleRequestUrl(handle).toString();
-    logger.trace("Fetching local URL media.", {
+    localUrlLogger.trace("Fetching local URL media.", {
       "media.handle.id": handle.id,
       "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
       "media.range.present": Boolean(range),
@@ -281,7 +284,7 @@ mediaRouter.get(
 
           return upstream;
         } catch (err) {
-          logger.warn("Local URL media request failed.", {
+          localUrlLogger.warn("Local URL media request failed.", {
             ...logEventFields("media.local_url.fetch", "failure"),
             "media.handle.id": handle.id,
             "upstream.url": sanitizeLoggedMediaPath(upstreamUrl),
@@ -390,14 +393,19 @@ mediaRouter.get(
     };
 
     if (sourceErrors.length > 0) {
-      logger.warn("Listed currently playing media with source errors.", {
-        ...summaryFields,
-        "source.error.provider_ids": [
-          ...new Set(sourceErrors.map((sourceError) => sourceError.providerId)),
-        ],
-      });
+      discoveryLogger.warn(
+        "Listed currently playing media with source errors.",
+        {
+          ...summaryFields,
+          "source.error.provider_ids": [
+            ...new Set(
+              sourceErrors.map((sourceError) => sourceError.providerId),
+            ),
+          ],
+        },
+      );
     } else {
-      logger.info("Listed currently playing media.", summaryFields);
+      discoveryLogger.info("Listed currently playing media.", summaryFields);
     }
 
     res.json({
@@ -415,7 +423,7 @@ mediaRouter.get(
     const prunedCount = pruneSessionMediaHandles(session);
     const handle = session.mediaHandles.get(req.params.handleId as string);
     if (!handle) {
-      logger.warn("Media handle was not found in provider session.", {
+      proxyLogger.warn("Media handle was not found in provider session.", {
         ...logEventFields("media.proxy", "missing_handle"),
         "media.handle.id": req.params.handleId,
         "session.id": session.id,
@@ -433,7 +441,7 @@ mediaRouter.get(
 
     const provider = getProvider(handle.providerId);
     if (!provider) {
-      logger.error("Provider for media handle is not registered.", {
+      proxyLogger.error("Provider for media handle is not registered.", {
         ...logEventFields("media.proxy", "provider_not_registered"),
         "media.handle.id": handle.id,
         "session.id": session.id,
@@ -447,7 +455,7 @@ mediaRouter.get(
       );
     }
 
-    logger.trace("Proxying media handle.", {
+    proxyLogger.trace("Proxying media handle.", {
       "media.handle.id": handle.id,
       "session.id": session.id,
       "provider.id": handle.providerId,

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -1,9 +1,16 @@
 import { Router } from "express";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import { persistProviderAuth } from "../db/providerPersistence.js";
 import { createRememberedProviderSession } from "../db/rememberedProviderSessionsRepository.js";
 import { ApiError, asyncHandler } from "../http/errors.js";
 import { getRequestRouteUrl } from "../http/requestOrigin.js";
 import { getProvider, listProviders } from "../providers/registry.js";
+import { getServerLogger, warnWithError } from "../logging.js";
 import {
   createProviderSession,
   getRememberedProviderSessionCookieName,
@@ -15,6 +22,7 @@ import {
 import { setNoStore } from "../session/request.js";
 
 export const providersRouter = Router();
+const logger = getServerLogger(["routes", "providers"]);
 const PROVIDER_AUTH_COMPLETE_PATH = (providerId: string) =>
   `/auth/${providerId}/complete`;
 const PROVIDER_AUTH_COOKIE = "cliparr_provider_auth";
@@ -118,12 +126,25 @@ providersRouter.post(
       );
     }
 
-    const authStart = await provider.startAuth(
-      getRequestRouteUrl(
-        req,
-        PROVIDER_AUTH_COMPLETE_PATH(provider.definition.id),
-      ),
-    );
+    const startedAt = Date.now();
+    let authStart: Awaited<ReturnType<NonNullable<typeof provider.startAuth>>>;
+    try {
+      authStart = await provider.startAuth(
+        getRequestRouteUrl(
+          req,
+          PROVIDER_AUTH_COMPLETE_PATH(provider.definition.id),
+        ),
+      );
+    } catch (err) {
+      logger.warn("Provider auth start failed.", {
+        ...logEventFields("provider.auth.start", "failure"),
+        ...logDurationFields(startedAt),
+        ...logErrorFields(err),
+        "provider.id": provider.definition.id,
+        "provider.auth.method": "pin",
+      });
+      throw err;
+    }
 
     res.cookie(
       PROVIDER_AUTH_COOKIE,
@@ -139,6 +160,13 @@ providersRouter.post(
       authId: authStart.authId,
       authUrl: authStart.authUrl,
       expiresAt: authStart.expiresAt,
+    });
+
+    logger.info("Provider auth started.", {
+      ...logEventFields("provider.auth.start", "success"),
+      ...logDurationFields(startedAt),
+      "provider.id": provider.definition.id,
+      "provider.auth.method": "pin",
     });
   }),
 );
@@ -161,66 +189,101 @@ providersRouter.get(
     }
 
     const authId = req.params.authId as string;
-    const authCookie = requireProviderAuthCookie(
-      req.header("cookie"),
-      provider.definition.id,
-      authId,
-    );
-    const authStatus = await provider.pollAuth(authId, authCookie.pollToken);
-    if (authStatus.status !== "complete") {
-      if (authStatus.status === "expired") {
-        res.clearCookie(
-          PROVIDER_AUTH_COOKIE,
-          providerAuthCookieClearOptions(req.secure),
+    const startedAt = Date.now();
+
+    try {
+      const authCookie = requireProviderAuthCookie(
+        req.header("cookie"),
+        provider.definition.id,
+        authId,
+      );
+      const authStatus = await provider.pollAuth(authId, authCookie.pollToken);
+      if (authStatus.status !== "complete") {
+        if (authStatus.status === "expired") {
+          res.clearCookie(
+            PROVIDER_AUTH_COOKIE,
+            providerAuthCookieClearOptions(req.secure),
+          );
+          logger.info("Provider auth expired.", {
+            ...logEventFields("provider.auth.poll", "expired"),
+            ...logDurationFields(startedAt),
+            "provider.id": provider.definition.id,
+            "provider.auth.method": "pin",
+          });
+        }
+        res.json({ status: authStatus.status });
+        return;
+      }
+
+      if (
+        !authStatus.userToken ||
+        !Array.isArray(authStatus.resources) ||
+        authStatus.resources.length === 0
+      ) {
+        throw new ApiError(
+          502,
+          "provider_auth_failed",
+          "Provider auth did not return any available servers",
         );
       }
-      res.json({ status: authStatus.status });
-      return;
-    }
 
-    if (
-      !authStatus.userToken ||
-      !Array.isArray(authStatus.resources) ||
-      authStatus.resources.length === 0
-    ) {
-      throw new ApiError(
-        502,
-        "provider_auth_failed",
-        "Provider auth did not return any available servers",
+      const account = persistProviderAuth({
+        provider: provider.definition,
+        userToken: authStatus.userToken,
+        resources: authStatus.resources,
+      });
+
+      const session = createProviderSession({
+        providerId: provider.definition.id,
+        providerAccountId: account.id,
+        userToken: authStatus.userToken,
+      });
+
+      const rememberedSession = createRememberedProviderSession(
+        session.providerAccountId,
       );
+
+      res.clearCookie(
+        PROVIDER_AUTH_COOKIE,
+        providerAuthCookieClearOptions(req.secure),
+      );
+      res.cookie(
+        getSessionCookieName(),
+        session.id,
+        getSessionCookieOptions(req.secure),
+      );
+      res.cookie(
+        getRememberedProviderSessionCookieName(),
+        rememberedSession.token,
+        getRememberedProviderSessionCookieOptions(req.secure),
+      );
+      res.json({ status: "complete" });
+
+      logger.info("Provider auth completed.", {
+        ...logEventFields("provider.auth.poll", "success"),
+        ...logDurationFields(startedAt),
+        "provider.id": provider.definition.id,
+        "provider.auth.method": "pin",
+        "provider.account.id": account.id,
+        "provider.resource.count": authStatus.resources.length,
+        "session.id": session.id,
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Provider auth poll failed.",
+        compactLogFields({
+          ...logEventFields("provider.auth.poll", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "provider.id": provider.definition.id,
+          "provider.auth.method": "pin",
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
     }
-
-    const account = persistProviderAuth({
-      provider: provider.definition,
-      userToken: authStatus.userToken,
-      resources: authStatus.resources,
-    });
-
-    const session = createProviderSession({
-      providerId: provider.definition.id,
-      providerAccountId: account.id,
-      userToken: authStatus.userToken,
-    });
-
-    const rememberedSession = createRememberedProviderSession(
-      session.providerAccountId,
-    );
-
-    res.clearCookie(
-      PROVIDER_AUTH_COOKIE,
-      providerAuthCookieClearOptions(req.secure),
-    );
-    res.cookie(
-      getSessionCookieName(),
-      session.id,
-      getSessionCookieOptions(req.secure),
-    );
-    res.cookie(
-      getRememberedProviderSessionCookieName(),
-      rememberedSession.token,
-      getRememberedProviderSessionCookieOptions(req.secure),
-    );
-    res.json({ status: "complete" });
   }),
 );
 
@@ -244,47 +307,76 @@ providersRouter.post(
       );
     }
 
-    const authResult = await provider.authenticateWithCredentials(req.body);
-    if (
-      !authResult.userToken ||
-      !Array.isArray(authResult.resources) ||
-      authResult.resources.length === 0
-    ) {
-      throw new ApiError(
-        502,
-        "provider_auth_failed",
-        "Provider auth did not return any available servers",
+    const startedAt = Date.now();
+
+    try {
+      const authResult = await provider.authenticateWithCredentials(req.body);
+      if (
+        !authResult.userToken ||
+        !Array.isArray(authResult.resources) ||
+        authResult.resources.length === 0
+      ) {
+        throw new ApiError(
+          502,
+          "provider_auth_failed",
+          "Provider auth did not return any available servers",
+        );
+      }
+
+      const account = persistProviderAuth({
+        provider: provider.definition,
+        userToken: authResult.userToken,
+        resources: authResult.resources,
+      });
+
+      const session = createProviderSession({
+        providerId: provider.definition.id,
+        providerAccountId: account.id,
+        userToken: authResult.userToken,
+      });
+
+      const rememberedSession = createRememberedProviderSession(
+        session.providerAccountId,
       );
+
+      res.cookie(
+        getSessionCookieName(),
+        session.id,
+        getSessionCookieOptions(req.secure),
+      );
+      res.cookie(
+        getRememberedProviderSessionCookieName(),
+        rememberedSession.token,
+        getRememberedProviderSessionCookieOptions(req.secure),
+      );
+      res.json({
+        session: provider.serializeSession(session),
+      });
+
+      logger.info("Provider credential login completed.", {
+        ...logEventFields("provider.auth.login", "success"),
+        ...logDurationFields(startedAt),
+        "provider.id": provider.definition.id,
+        "provider.auth.method": "credentials",
+        "provider.account.id": account.id,
+        "provider.resource.count": authResult.resources.length,
+        "session.id": session.id,
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Provider credential login failed.",
+        compactLogFields({
+          ...logEventFields("provider.auth.login", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "provider.id": provider.definition.id,
+          "provider.auth.method": "credentials",
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
     }
-
-    const account = persistProviderAuth({
-      provider: provider.definition,
-      userToken: authResult.userToken,
-      resources: authResult.resources,
-    });
-
-    const session = createProviderSession({
-      providerId: provider.definition.id,
-      providerAccountId: account.id,
-      userToken: authResult.userToken,
-    });
-
-    const rememberedSession = createRememberedProviderSession(
-      session.providerAccountId,
-    );
-
-    res.cookie(
-      getSessionCookieName(),
-      session.id,
-      getSessionCookieOptions(req.secure),
-    );
-    res.cookie(
-      getRememberedProviderSessionCookieName(),
-      rememberedSession.token,
-      getRememberedProviderSessionCookieOptions(req.secure),
-    );
-    res.json({
-      session: provider.serializeSession(session),
-    });
   }),
 );

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -22,7 +22,7 @@ import {
 import { setNoStore } from "../session/request.js";
 
 export const providersRouter = Router();
-const logger = getServerLogger(["routes", "providers"]);
+const logger = getServerLogger(["provider", "auth"]);
 const PROVIDER_AUTH_COMPLETE_PATH = (providerId: string) =>
   `/auth/${providerId}/complete`;
 const PROVIDER_AUTH_COOKIE = "cliparr_provider_auth";

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -1,5 +1,10 @@
 import { Router } from "express";
 import {
+  compactLogFields,
+  logDurationFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
+import {
   createRememberedProviderSession,
   getRememberedProviderSession,
   revokeRememberedProviderSession,
@@ -19,20 +24,25 @@ import {
   restoreProviderSessionFromProviderAccount,
 } from "../session/store.js";
 import { getRequestSessionId, setNoStore } from "../session/request.js";
+import { getServerLogger } from "../logging.js";
 
 export const sessionRouter = Router();
+const logger = getServerLogger(["routes", "session"]);
 
 sessionRouter.get(
   "/",
   asyncHandler(async (req, res) => {
     setNoStore(res);
+    const startedAt = Date.now();
     const rememberedToken = readCookie(
       req.header("cookie"),
       getRememberedProviderSessionCookieName(),
     );
     const rememberedSession = getRememberedProviderSession(rememberedToken);
+    const requestSessionId = getRequestSessionId(req);
+    const cookieSession = getProviderSession(requestSessionId);
     const session =
-      getProviderSession(getRequestSessionId(req)) ??
+      cookieSession ??
       restoreProviderSessionFromProviderAccount(
         rememberedSession?.providerAccountId,
       );
@@ -43,6 +53,11 @@ sessionRouter.get(
           getRememberedProviderSessionCookieName(),
           getRememberedProviderSessionCookieClearOptions(req.secure),
         );
+        logger.info("Remembered provider session was revoked.", {
+          ...logEventFields("session.restore", "failure"),
+          ...logDurationFields(startedAt),
+          "session.remembered.present": true,
+        });
       }
       throw new ApiError(
         401,
@@ -82,14 +97,27 @@ sessionRouter.get(
       );
     }
     res.json({ session: provider.serializeSession(session) });
+
+    if (!cookieSession && rememberedSession) {
+      logger.info("Provider session restored.", {
+        ...logEventFields("session.restore", "success"),
+        ...logDurationFields(startedAt),
+        "provider.id": session.providerId,
+        "provider.account.id": session.providerAccountId,
+        "session.id": session.id,
+      });
+    }
   }),
 );
 
 sessionRouter.delete("/", (req, res) => {
   setNoStore(res);
-  revokeRememberedProviderSession(
-    readCookie(req.header("cookie"), getRememberedProviderSessionCookieName()),
+  const session = getProviderSession(getRequestSessionId(req));
+  const rememberedToken = readCookie(
+    req.header("cookie"),
+    getRememberedProviderSessionCookieName(),
   );
+  revokeRememberedProviderSession(rememberedToken);
   deleteProviderSession(getRequestSessionId(req));
   res.clearCookie(
     getSessionCookieName(),
@@ -100,4 +128,14 @@ sessionRouter.delete("/", (req, res) => {
     getRememberedProviderSessionCookieClearOptions(req.secure),
   );
   res.status(204).end();
+
+  logger.info("Provider session logged out.", {
+    ...logEventFields("session.logout", "success"),
+    ...compactLogFields({
+      "provider.id": session?.providerId,
+      "provider.account.id": session?.providerAccountId,
+      "session.id": session?.id,
+      "session.remembered.present": Boolean(rememberedToken),
+    }),
+  });
 });

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -27,7 +27,7 @@ import { getRequestSessionId, setNoStore } from "../session/request.js";
 import { getServerLogger } from "../logging.js";
 
 export const sessionRouter = Router();
-const logger = getServerLogger(["routes", "session"]);
+const logger = getServerLogger("session");
 
 sessionRouter.get(
   "/",

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,5 +1,12 @@
 import { Router } from "express";
 import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+  sanitizeUrlForLog,
+} from "@cliparr/shared/logging";
+import {
   listMediaSources,
   deleteMediaSourceForAccount,
   getMediaSourceForAccount,
@@ -15,8 +22,10 @@ import {
 } from "../providers/plex/connectionState.js";
 import { getProvider } from "../providers/registry.js";
 import { requireAccountSession, setNoStore } from "../session/request.js";
+import { getServerLogger, warnWithError } from "../logging.js";
 
 export const sourcesRouter = Router();
+const logger = getServerLogger(["routes", "sources"]);
 
 function serializeSource(source: MediaSource) {
   return {
@@ -137,6 +146,10 @@ function parseSourceUpdate(body: unknown): UpdateMediaSourceInput {
   return input;
 }
 
+function changedSourceFields(input: UpdateMediaSourceInput) {
+  return Object.keys(input).sort();
+}
+
 sourcesRouter.get(
   "/",
   asyncHandler(async (req, res) => {
@@ -168,30 +181,60 @@ sourcesRouter.patch(
   asyncHandler(async (req, res) => {
     const session = requireAccountSession(req);
     setNoStore(res);
-    const existingSource = requireMediaSource(
-      req.params.id as string,
-      session.providerAccountId,
-    );
-    const input = parseSourceUpdate(req.body);
-    const nextInput =
-      existingSource.providerId === "plex" && input.baseUrl !== undefined
-        ? {
-            ...input,
-            connection: withPlexBaseUrlMode(
-              existingSource.connection,
-              PLEX_BASE_URL_MODE_MANUAL,
-            ),
-          }
-        : input;
-    const source = updateMediaSourceForAccount(
-      req.params.id as string,
-      session.providerAccountId,
-      nextInput,
-    );
-    if (!source) {
-      throw new ApiError(404, "source_not_found", "Source was not found");
+    const startedAt = Date.now();
+    const sourceId = req.params.id as string;
+
+    try {
+      const existingSource = requireMediaSource(
+        sourceId,
+        session.providerAccountId,
+      );
+      const input = parseSourceUpdate(req.body);
+      const nextInput =
+        existingSource.providerId === "plex" && input.baseUrl !== undefined
+          ? {
+              ...input,
+              connection: withPlexBaseUrlMode(
+                existingSource.connection,
+                PLEX_BASE_URL_MODE_MANUAL,
+              ),
+            }
+          : input;
+      const source = updateMediaSourceForAccount(
+        sourceId,
+        session.providerAccountId,
+        nextInput,
+      );
+      if (!source) {
+        throw new ApiError(404, "source_not_found", "Source was not found");
+      }
+      res.json({ source: serializeSource(source) });
+
+      logger.info("Media source updated.", {
+        ...logEventFields("source.update", "success"),
+        ...logDurationFields(startedAt),
+        "source.id": source.id,
+        "provider.id": source.providerId,
+        "provider.account.id": session.providerAccountId,
+        "source.changed_fields": changedSourceFields(input),
+        "source.base_url": sanitizeUrlForLog(input.baseUrl),
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Media source update failed.",
+        compactLogFields({
+          ...logEventFields("source.update", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "source.id": sourceId,
+          "provider.account.id": session.providerAccountId,
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
     }
-    res.json({ source: serializeSource(source) });
   }),
 );
 
@@ -200,15 +243,44 @@ sourcesRouter.delete(
   asyncHandler(async (req, res) => {
     const session = requireAccountSession(req);
     setNoStore(res);
-    const deleted = deleteMediaSourceForAccount(
-      req.params.id as string,
-      session.providerAccountId,
-    );
-    if (!deleted) {
-      throw new ApiError(404, "source_not_found", "Source was not found");
-    }
+    const startedAt = Date.now();
+    const sourceId = req.params.id as string;
 
-    res.status(204).end();
+    try {
+      const source = requireMediaSource(sourceId, session.providerAccountId);
+      const deleted = deleteMediaSourceForAccount(
+        sourceId,
+        session.providerAccountId,
+      );
+      if (!deleted) {
+        throw new ApiError(404, "source_not_found", "Source was not found");
+      }
+
+      res.status(204).end();
+
+      logger.info("Media source deleted.", {
+        ...logEventFields("source.delete", "success"),
+        ...logDurationFields(startedAt),
+        "source.id": source.id,
+        "provider.id": source.providerId,
+        "provider.account.id": session.providerAccountId,
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Media source delete failed.",
+        compactLogFields({
+          ...logEventFields("source.delete", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "source.id": sourceId,
+          "provider.account.id": session.providerAccountId,
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
+    }
   }),
 );
 
@@ -217,30 +289,71 @@ sourcesRouter.post(
   asyncHandler(async (req, res) => {
     const session = requireAccountSession(req);
     setNoStore(res);
+    const startedAt = Date.now();
+    const sourceId = req.params.id as string;
 
-    const source = requireMediaSource(
-      req.params.id as string,
-      session.providerAccountId,
-    );
-    const provider = getProvider(source.providerId);
-    if (!provider) {
-      throw new ApiError(
-        500,
-        "provider_not_registered",
-        "Source provider is not registered",
-      );
-    }
+    try {
+      const source = requireMediaSource(sourceId, session.providerAccountId);
+      const provider = getProvider(source.providerId);
+      if (!provider) {
+        throw new ApiError(
+          500,
+          "provider_not_registered",
+          "Source provider is not registered",
+        );
+      }
 
-    const checkedAt = new Date().toISOString();
-    const result = await provider.checkSource(source);
+      const checkedAt = new Date().toISOString();
+      const result = await provider.checkSource(source);
 
-    if (!result.ok) {
-      const updatedSource = updateMediaSourceHealthForAccount(
+      if (!result.ok) {
+        const updatedSource = updateMediaSourceHealthForAccount(
+          source.id,
+          session.providerAccountId,
+          {
+            lastCheckedAt: checkedAt,
+            lastError: result.message,
+          },
+        );
+
+        if (!updatedSource) {
+          throw new ApiError(404, "source_not_found", "Source was not found");
+        }
+
+        res.json({
+          ok: false,
+          error: {
+            message: result.message,
+          },
+          source: serializeSource(updatedSource),
+        });
+
+        logger.warn("Media source health check failed.", {
+          ...logEventFields("source.check", "failure"),
+          ...logDurationFields(startedAt),
+          "source.id": source.id,
+          "provider.id": source.providerId,
+          "provider.account.id": session.providerAccountId,
+          "source.health.ok": false,
+          "error.message": result.message,
+        });
+        return;
+      }
+
+      const updatedSource = updateMediaSourceForAccount(
         source.id,
         session.providerAccountId,
         {
+          ...(result.name !== undefined ? { name: result.name } : {}),
+          ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
+          ...(result.connection !== undefined
+            ? { connection: result.connection }
+            : {}),
+          ...(result.metadata !== undefined
+            ? { metadata: result.metadata }
+            : {}),
           lastCheckedAt: checkedAt,
-          lastError: result.message,
+          lastError: null,
         },
       );
 
@@ -249,37 +362,34 @@ sourcesRouter.post(
       }
 
       res.json({
-        ok: false,
-        error: {
-          message: result.message,
-        },
+        ok: true,
         source: serializeSource(updatedSource),
       });
-      return;
+
+      logger.info("Media source health check completed.", {
+        ...logEventFields("source.check", "success"),
+        ...logDurationFields(startedAt),
+        "source.id": source.id,
+        "provider.id": source.providerId,
+        "provider.account.id": session.providerAccountId,
+        "source.health.ok": true,
+        "source.base_url": sanitizeUrlForLog(result.baseUrl),
+      });
+    } catch (err) {
+      warnWithError(
+        logger,
+        err,
+        "Media source health check failed.",
+        compactLogFields({
+          ...logEventFields("source.check", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(err),
+          "source.id": sourceId,
+          "provider.account.id": session.providerAccountId,
+          "http.status_code": err instanceof ApiError ? err.status : undefined,
+        }),
+      );
+      throw err;
     }
-
-    const updatedSource = updateMediaSourceForAccount(
-      source.id,
-      session.providerAccountId,
-      {
-        ...(result.name !== undefined ? { name: result.name } : {}),
-        ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
-        ...(result.connection !== undefined
-          ? { connection: result.connection }
-          : {}),
-        ...(result.metadata !== undefined ? { metadata: result.metadata } : {}),
-        lastCheckedAt: checkedAt,
-        lastError: null,
-      },
-    );
-
-    if (!updatedSource) {
-      throw new ApiError(404, "source_not_found", "Source was not found");
-    }
-
-    res.json({
-      ok: true,
-      source: serializeSource(updatedSource),
-    });
   }),
 );

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -25,7 +25,7 @@ import { requireAccountSession, setNoStore } from "../session/request.js";
 import { getServerLogger, warnWithError } from "../logging.js";
 
 export const sourcesRouter = Router();
-const logger = getServerLogger(["routes", "sources"]);
+const logger = getServerLogger("source");
 
 function serializeSource(source: MediaSource) {
   return {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -9,7 +9,7 @@ import {
   getServerLogger,
 } from "./logging.js";
 
-const logger = getServerLogger("server");
+const logger = getServerLogger("lifecycle");
 
 function hasCloseAllConnections(
   server: Server,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,11 +1,12 @@
 import "./config/loadEnv.js";
 import type { Server } from "node:http";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import { createApp } from "./app.js";
 import { closeDatabase } from "./db/database.js";
 import {
   configureLogging,
+  fatalWithError,
   getServerLogger,
-  serializeError,
 } from "./logging.js";
 
 const logger = getServerLogger("server");
@@ -66,7 +67,8 @@ async function startServer() {
     // Force exit after 1s if things hang
     setTimeout(() => {
       logger.warn("Force exiting after shutdown timeout.", {
-        timeoutMs: 1000,
+        ...logEventFields("server.shutdown", "timeout"),
+        "server.shutdown.timeout_ms": 1000,
       });
       closeDatabaseOnce();
       process.exit(1);
@@ -82,7 +84,10 @@ async function startServer() {
 }
 
 startServer().catch((err: unknown) => {
-  logger.fatal("Failed to start server: {errorMessage}", serializeError(err));
+  fatalWithError(logger, err, "Failed to start server.", {
+    ...logEventFields("server.start", "failure"),
+    ...logErrorFields(err),
+  });
   closeDatabase();
   process.exit(1);
 });

--- a/apps/server/src/session/store.test.ts
+++ b/apps/server/src/session/store.test.ts
@@ -134,7 +134,7 @@ void test("remembered provider session tokens are not reusable after APP_KEY cha
         });
 
         const rememberedSession = createRememberedProviderSession(account.id);
-        console.log(rememberedSession.token);
+        process.stdout.write(rememberedSession.token);
       } finally {
         closeDatabase();
       }

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import { getDatabase } from "../db/database.js";
 import { getProviderAccount } from "../db/providerAccountsRepository.js";
 import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "../db/rememberedProviderSessionsRepository.js";
 import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
-import { getServerLogger, serializeError } from "../logging.js";
+import { getServerLogger } from "../logging.js";
 import type { MediaHandle } from "../providers/types.js";
 import { decryptSecret, encryptSecret } from "../security/secrets.js";
 
@@ -124,7 +125,9 @@ export function restoreProviderSessionFromProviderAccount(
     logger.warn(
       "Failed to restore provider session from remembered provider account.",
       {
-        ...serializeError(err),
+        ...logEventFields("session.restore", "failure"),
+        ...logErrorFields(err),
+        "provider.account.id": providerAccountId,
       },
     );
     return undefined;
@@ -148,18 +151,15 @@ export function pruneSessionMediaHandles(
   }
 
   if (prunedCount > 0) {
-    logger.trace(
-      "Pruned stale media handles for provider session {sessionId}.",
-      {
-        sessionId: session.id,
-        providerId: session.providerId,
-        providerAccountId: session.providerAccountId,
-        prunedCount,
-        remainingHandleCount: session.mediaHandles.size,
-        maxIdleMs,
-        cutoff,
-      },
-    );
+    logger.trace("Pruned stale media handles for provider session.", {
+      "session.id": session.id,
+      "provider.id": session.providerId,
+      "provider.account.id": session.providerAccountId,
+      "media.handle.pruned_count": prunedCount,
+      "media.handle.remaining_count": session.mediaHandles.size,
+      "media.handle.max_idle_ms": maxIdleMs,
+      "media.handle.cutoff_ms": cutoff,
+    });
   }
 
   return prunedCount;

--- a/apps/www/scripts/sync-readme.ts
+++ b/apps/www/scripts/sync-readme.ts
@@ -88,10 +88,12 @@ if (mode === "write") {
   if (nextReadme !== readme) {
     fs.writeFileSync(readmePath, nextReadme);
   }
-  console.log("README docs blocks are synced.");
+  process.stdout.write("README docs blocks are synced.\n");
 } else if (nextReadme !== readme) {
-  console.error("README docs blocks are out of sync. Run `pnpm docs:sync`.");
+  process.stderr.write(
+    "README docs blocks are out of sync. Run `pnpm docs:sync`.\n",
+  );
   process.exit(1);
 } else {
-  console.log("README docs blocks are synced.");
+  process.stdout.write("README docs blocks are synced.\n");
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,11 @@ export default tseslint.config(
     },
   },
   js.configs.recommended,
+  {
+    rules: {
+      "no-console": "error",
+    },
+  },
   ...tseslint.configs.recommendedTypeChecked,
   {
     files: ["**/*.{ts,tsx}"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,8 @@
   "types": "./src/providers.ts",
   "exports": {
     "./logging": {
-      "types": "./src/logging.ts",
-      "default": "./src/logging.ts"
+      "types": "./src/logging.d.ts",
+      "default": "./src/logging.js"
     },
     "./providers": {
       "types": "./src/providers.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "types": "./src/providers.ts",
   "exports": {
+    "./logging": {
+      "types": "./src/logging.ts",
+      "default": "./src/logging.ts"
+    },
     "./providers": {
       "types": "./src/providers.ts",
       "default": "./src/providers.ts"

--- a/packages/shared/src/logging.d.ts
+++ b/packages/shared/src/logging.d.ts
@@ -1,0 +1,20 @@
+export type LogFields = Record<string, unknown>;
+
+export declare function compactLogFields(fields: LogFields): LogFields;
+
+export declare function logEventFields(
+  name: string,
+  outcome?: string,
+): LogFields;
+
+export declare function logDurationFields(
+  startedAtMs: number,
+  nowMs?: number,
+  fieldName?: string,
+): LogFields;
+
+export declare function logErrorFields(error: unknown): LogFields;
+
+export declare function sanitizeUrlForLog(
+  value: string | undefined,
+): string | undefined;

--- a/packages/shared/src/logging.js
+++ b/packages/shared/src/logging.js
@@ -1,12 +1,10 @@
-export type LogFields = Record<string, unknown>;
-
-export function compactLogFields(fields: LogFields): LogFields {
+export function compactLogFields(fields) {
   return Object.fromEntries(
     Object.entries(fields).filter((entry) => entry[1] !== undefined),
   );
 }
 
-export function logEventFields(name: string, outcome?: string): LogFields {
+export function logEventFields(name, outcome) {
   return compactLogFields({
     "event.name": name,
     "event.outcome": outcome,
@@ -14,23 +12,21 @@ export function logEventFields(name: string, outcome?: string): LogFields {
 }
 
 export function logDurationFields(
-  startedAtMs: number,
+  startedAtMs,
   nowMs = Date.now(),
   fieldName = "event.duration.ms",
-): LogFields {
+) {
   return {
     [fieldName]: Math.max(0, nowMs - startedAtMs),
   };
 }
 
-export function logErrorFields(error: unknown): LogFields {
+export function logErrorFields(error) {
   if (error instanceof Error) {
-    const errorWithCode = error as Error & { code?: unknown };
     return compactLogFields({
       "error.name": error.name,
       "error.message": error.message,
-      "error.code":
-        typeof errorWithCode.code === "string" ? errorWithCode.code : undefined,
+      "error.code": typeof error.code === "string" ? error.code : undefined,
     });
   }
 
@@ -39,7 +35,7 @@ export function logErrorFields(error: unknown): LogFields {
   };
 }
 
-export function sanitizeUrlForLog(value: string | undefined) {
+export function sanitizeUrlForLog(value) {
   if (!value) {
     return value;
   }

--- a/packages/shared/src/logging.ts
+++ b/packages/shared/src/logging.ts
@@ -1,0 +1,62 @@
+export type LogFields = Record<string, unknown>;
+
+export function compactLogFields(fields: LogFields): LogFields {
+  return Object.fromEntries(
+    Object.entries(fields).filter((entry) => entry[1] !== undefined),
+  );
+}
+
+export function logEventFields(name: string, outcome?: string): LogFields {
+  return compactLogFields({
+    "event.name": name,
+    "event.outcome": outcome,
+  });
+}
+
+export function logDurationFields(
+  startedAtMs: number,
+  nowMs = Date.now(),
+  fieldName = "event.duration.ms",
+): LogFields {
+  return {
+    [fieldName]: Math.max(0, nowMs - startedAtMs),
+  };
+}
+
+export function logErrorFields(error: unknown): LogFields {
+  if (error instanceof Error) {
+    const errorWithCode = error as Error & { code?: unknown };
+    return compactLogFields({
+      "error.name": error.name,
+      "error.message": error.message,
+      "error.code":
+        typeof errorWithCode.code === "string" ? errorWithCode.code : undefined,
+    });
+  }
+
+  return {
+    "error.value": String(error),
+  };
+}
+
+export function sanitizeUrlForLog(value: string | undefined) {
+  if (!value) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    // Relative URLs are logged without query strings or fragments.
+  }
+
+  try {
+    const parsed = new URL(value, "http://cliparr.local");
+    return parsed.origin === "http://cliparr.local"
+      ? parsed.pathname
+      : `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return value.split(/[?#]/, 1)[0] ?? value;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@cliparr/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@logtape/logtape':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@mediabunny/aac-encoder':
         specifier: ^1.45.4
         version: 1.45.4(mediabunny@1.45.4)

--- a/scripts/release/create-github-release.mjs
+++ b/scripts/release/create-github-release.mjs
@@ -166,8 +166,8 @@ export async function main(argv = process.argv.slice(2)) {
   });
 
   if (args.dryRun) {
-    console.log(`# ${args.name}\n`);
-    console.log(body);
+    process.stdout.write(`# ${args.name}\n\n`);
+    process.stdout.write(`${body}\n`);
     writeGithubOutput({ html_url: "" });
     process.exit(0);
   }
@@ -186,7 +186,7 @@ export async function main(argv = process.argv.slice(2)) {
     },
   });
 
-  console.log(`Created release ${release.html_url}`);
+  process.stdout.write(`Created release ${release.html_url}\n`);
   writeGithubOutput({ html_url: release.html_url });
 }
 
@@ -197,7 +197,9 @@ if (
   try {
     await main();
   } catch (error) {
-    console.error(error instanceof Error ? error.message : error);
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
     process.exit(1);
   }
 }

--- a/scripts/release/plan-release.mjs
+++ b/scripts/release/plan-release.mjs
@@ -250,8 +250,10 @@ try {
     writeGithubOutput(plan);
   }
 
-  console.log(JSON.stringify(plan, null, 2));
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
 } catch (error) {
-  console.error(error instanceof Error ? error.message : error);
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`,
+  );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

- Adds shared flat dot-notated logging helpers and frontend LogTape setup.
- Defines high-signal wide events across provider auth/session, source management, playback discovery, media proxy failures, editor playback, export, subtitle, and artwork flows.
- Replaces remaining `console.*` usage and enables ESLint `no-console`.

## Validation

- `pnpm preflight`
- `rg -n "console\\." . --glob '!node_modules' --glob '!dist' --glob '!*.lock'`

