### PR TITLE
refactor(cliparr): use alias imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@ apps/server/.cliparr-data
 
 .git
 .github
-.DS_Store
+**/.DS_Store
 *.log
 
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist/
 coverage/
 .cliparr-data/
 apps/server/.cliparr-data/
-.DS_Store
+**/.DS_Store
 *.log
 *.tsbuildinfo
 .env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY apps/frontend/components.json apps/frontend/index.html apps/frontend/tsconf
 COPY apps/frontend/public apps/frontend/public
 COPY apps/frontend/src apps/frontend/src
 
-RUN pnpm build
+RUN CLIPARR_SERVER_SOURCEMAP=false pnpm build
 
 FROM node:24-slim AS runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY tsconfig.json tsconfig.base.json ./
 COPY packages/shared/src packages/shared/src
-COPY apps/server/tsconfig.json apps/server/tsconfig.build.json apps/server/
+COPY apps/server/tsconfig.json apps/server/tsconfig.build.json apps/server/tsdown.config.ts apps/server/
 COPY apps/server/drizzle apps/server/drizzle
 COPY apps/server/src apps/server/src
 COPY apps/frontend/components.json apps/frontend/index.html apps/frontend/tsconfig.json apps/frontend/vite.config.js apps/frontend/
@@ -33,7 +33,6 @@ COPY apps/frontend/public apps/frontend/public
 COPY apps/frontend/src apps/frontend/src
 
 RUN pnpm build
-RUN pnpm --filter @cliparr/server deploy --legacy --prod /prod/apps/server
 
 FROM node:24-slim AS runner
 
@@ -51,7 +50,8 @@ ENV CLIPARR_VERSION=$CLIPARR_VERSION
 
 WORKDIR /app
 
-COPY --from=build --chown=node:node /prod/apps/server ./apps/server
+COPY --from=build --chown=node:node /app/apps/server/package.json ./apps/server/package.json
+COPY --from=build --chown=node:node /app/apps/server/dist ./apps/server/dist
 COPY --from=build --chown=node:node /app/apps/server/drizzle ./apps/server/drizzle
 COPY --from=build --chown=node:node /app/apps/frontend/dist ./apps/frontend/dist
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import { RouterProvider } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-import { cliparrClient, subscribeToAuthFailure } from "./api/cliparrClient";
-import { AuthProvider } from "./auth";
-import { TooltipProvider } from "./components/ui/tooltip";
-import type { ProviderSession } from "./providers/types";
-import { router } from "./router";
+import { cliparrClient, subscribeToAuthFailure } from "@/api/cliparrClient";
+import { AuthProvider } from "@/auth";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ProviderSession } from "@/providers/types";
+import { router } from "@/router";
 
 const PLEX_AUTH_COMPLETE_PATH = "/auth/plex/complete";
 

--- a/apps/frontend/src/api/cliparrClient.test.ts
+++ b/apps/frontend/src/api/cliparrClient.test.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { cliparrClient, subscribeToAuthFailure } from "./cliparrClient";
+import { cliparrClient, subscribeToAuthFailure } from "@/api/cliparrClient";
 
 function jsonResponse(value: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(value), {

--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -6,7 +6,7 @@ import type {
   ProviderAuthStatus,
   ProviderDefinition,
   ProviderSession,
-} from "../providers/types";
+} from "@/providers/types";
 
 interface ResponseErrorDetails {
   code?: string;

--- a/apps/frontend/src/auth.tsx
+++ b/apps/frontend/src/auth.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import type { RouterAuthContext } from "./router";
+import type { RouterAuthContext } from "@/router";
 
 const AuthContext = createContext<RouterAuthContext | null>(null);
 

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -8,14 +8,17 @@ import {
   Settings2,
   Video,
 } from "lucide-react";
-import { cliparrClient } from "../api/cliparrClient";
-import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "../lib/viewTransitions";
-import { formatProviderName, ProviderGlyph } from "./providers/ProviderGlyph";
+import { cliparrClient } from "@/api/cliparrClient";
+import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
+import {
+  formatProviderName,
+  ProviderGlyph,
+} from "@/components/providers/ProviderGlyph";
 import type {
   CurrentlyPlayingItem,
   SourcePlaybackError,
   ViewerPlaybackGroup,
-} from "../providers/types";
+} from "@/providers/types";
 
 interface Props {
   activeViewTransitionSessionId?: string | null;

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -5,9 +5,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { EditorEditableTimecode } from "./EditorEditableTimecode";
-import { EditorPreviewTimecode } from "./EditorPreviewTimecode";
-import { formatTime, formatTimecodeInput } from "./editorUtils";
+import { EditorEditableTimecode } from "@/components/editor/EditorEditableTimecode";
+import { EditorPreviewTimecode } from "@/components/editor/EditorPreviewTimecode";
+import {
+  formatTime,
+  formatTimecodeInput,
+} from "@/components/editor/editorUtils";
 
 interface EditorControlsProps {
   playing: boolean;

--- a/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
+++ b/apps/frontend/src/components/editor/EditorEditableTimecode.tsx
@@ -7,7 +7,10 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
-import { formatTimecodeInput, parseTimecodeInput } from "./editorUtils";
+import {
+  formatTimecodeInput,
+  parseTimecodeInput,
+} from "@/components/editor/editorUtils";
 
 interface EditorEditableTimecodeProps {
   ariaLabel: string;

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -1,9 +1,9 @@
 import { Download } from "lucide-react";
-import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
+import type { ExportFormat, ExportResolution } from "@/lib/exportClip";
 import {
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
-} from "../../lib/exportFileName";
+} from "@/lib/exportFileName";
 import {
   DialogClose,
   DialogFooter,
@@ -20,7 +20,7 @@ import {
   EditorExportSummaryPanel,
   EditorFilenameTemplateSection,
   formatOptionFor,
-} from "./EditorExportDialogSections";
+} from "@/components/editor/EditorExportDialogSections";
 
 interface VideoDimensions {
   width: number;

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -13,14 +13,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
+import type { ExportFormat, ExportResolution } from "@/lib/exportClip";
 import {
   getExportFileNameTemplateTokens,
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
-} from "../../lib/exportFileName";
-import type { ExportSourcePreference } from "./EditorExportDialog";
-import { formatTime } from "./editorUtils";
+} from "@/lib/exportFileName";
+import type { ExportSourcePreference } from "@/components/editor/EditorExportDialog";
+import { formatTime } from "@/components/editor/editorUtils";
 
 interface VideoDimensions {
   width: number;

--- a/apps/frontend/src/components/editor/EditorLayout.tsx
+++ b/apps/frontend/src/components/editor/EditorLayout.tsx
@@ -8,8 +8,8 @@ import {
 import {
   EDITOR_PANEL_SIZES,
   EDITOR_RESIZE_TARGET_MINIMUM_SIZE,
-} from "./editorLayoutSizing";
-import { EditorSidebar } from "./EditorSidebar";
+} from "@/components/editor/editorLayoutSizing";
+import { EditorSidebar } from "@/components/editor/EditorSidebar";
 
 export type EditorLayoutVariant = "desktop" | "mobile";
 

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -5,37 +5,37 @@ import {
   clampPlaybackTime,
   MIN_CLIP_SECONDS,
   roundTimelineTime,
-} from "./editorUtils";
+} from "@/components/editor/editorUtils";
 import {
   useEditorPlayback,
   type PlaybackFallbackInfo,
-} from "./useEditorPlayback";
-import { useEditorExport } from "./useEditorExport";
-import { useEditorKeyboardShortcuts } from "./useEditorKeyboardShortcuts";
-import { useEditorTimeline } from "./useEditorTimeline";
-import { EditorHeader } from "./EditorHeader";
-import { EditorPreview } from "./EditorPreview";
-import { EditorControls } from "./EditorControls";
-import { EditorPlaybackSourcePanel } from "./EditorPlaybackSourcePanel";
-import { EditorTimeline } from "./EditorTimeline";
-import { EditorSubtitlePanel } from "./EditorSubtitlePanel";
+} from "@/components/editor/useEditorPlayback";
+import { useEditorExport } from "@/components/editor/useEditorExport";
+import { useEditorKeyboardShortcuts } from "@/components/editor/useEditorKeyboardShortcuts";
+import { useEditorTimeline } from "@/components/editor/useEditorTimeline";
+import { EditorHeader } from "@/components/editor/EditorHeader";
+import { EditorPreview } from "@/components/editor/EditorPreview";
+import { EditorControls } from "@/components/editor/EditorControls";
+import { EditorPlaybackSourcePanel } from "@/components/editor/EditorPlaybackSourcePanel";
+import { EditorTimeline } from "@/components/editor/EditorTimeline";
+import { EditorSubtitlePanel } from "@/components/editor/EditorSubtitlePanel";
 import {
   buildClipRangeAfterDurationDiscovery,
   buildInitialClipRange,
-} from "./initialClipRange";
-import { EDITOR_DESKTOP_LAYOUT_QUERY } from "./editorLayoutSizing";
+} from "@/components/editor/initialClipRange";
+import { EDITOR_DESKTOP_LAYOUT_QUERY } from "@/components/editor/editorLayoutSizing";
 import {
   EditorDesktopLayout,
   EditorMobileLayout,
   EditorPreviewPane,
   EditorTimelinePane,
-} from "./EditorLayout";
-import { useEditorSubtitles } from "./useEditorSubtitles";
-import { sourceDisplayLabel, type EditorSession } from "../../lib/editorMedia";
-import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "../../lib/viewTransitions";
+} from "@/components/editor/EditorLayout";
+import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
+import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
+import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
 const EditorExportDialog = lazy(() =>
-  import("./EditorExportDialog").then((module) => ({
+  import("@/components/editor/EditorExportDialog").then((module) => ({
     default: module.EditorExportDialog,
   })),
 );

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -20,9 +20,9 @@ import {
   subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
-} from "../../lib/selectPreferredSubtitleTrack";
-import type { SubtitleStyleSettings } from "../../lib/subtitles/types";
-import type { PlaybackSubtitleTrack } from "../../providers/types";
+} from "@/lib/selectPreferredSubtitleTrack";
+import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
   EditorColorControl,
   EditorPropertyRow,
@@ -30,8 +30,8 @@ import {
   EditorRangeControl,
   editorPropertyLabelClassName,
   editorPropertySelectTriggerClassName,
-} from "./EditorPropertyControls";
-import { useSubtitleFontOptions } from "./useSubtitleFontOptions";
+} from "@/components/editor/EditorPropertyControls";
+import { useSubtitleFontOptions } from "@/components/editor/useSubtitleFontOptions";
 
 interface EditorSubtitlePanelProps {
   providerId?: string;

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -3,8 +3,8 @@ import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { CSSProperties, RefObject } from "react";
 import { Scissors } from "lucide-react";
-import type { PlaybackReadyRange } from "./useEditorPlayback";
-import { isPlaybackReadyRangeVisible } from "./editorPlaybackWarmupRange";
+import type { PlaybackReadyRange } from "@/components/editor/useEditorPlayback";
+import { isPlaybackReadyRangeVisible } from "@/components/editor/editorPlaybackWarmupRange";
 import {
   formatTime,
   getTimelineFillPercentages,
@@ -13,7 +13,7 @@ import {
   type ClipTimelineEffects,
   type ClipTimelineAction,
   type TimelineZoomLevel,
-} from "./editorUtils";
+} from "@/components/editor/editorUtils";
 
 interface EditorTimelineProps {
   timelineRef: RefObject<TimelineState | null>;

--- a/apps/frontend/src/components/editor/editorPlaybackAudio.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackAudio.ts
@@ -1,5 +1,5 @@
 import type { WrappedAudioBuffer } from "mediabunny";
-import { fromSourceTimelineTime } from "../../lib/mediabunnyTrackAccess";
+import { fromSourceTimelineTime } from "@/lib/mediabunnyTrackAccess";
 
 type RefValue<T> = {
   current: T;

--- a/apps/frontend/src/components/editor/editorPlaybackPlan.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackPlan.test.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolvePreviewPlaybackPlan } from "./editorPlaybackPlan";
+import { resolvePreviewPlaybackPlan } from "@/components/editor/editorPlaybackPlan";
 
 void test("snaps to the selection start when the playhead is close", () => {
   assert.deepEqual(

--- a/apps/frontend/src/components/editor/editorPlaybackSinks.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSinks.ts
@@ -5,8 +5,8 @@ import type {
   InputAudioTrack,
   InputVideoTrack,
 } from "mediabunny";
-import { playbackGainValue } from "./editorPlaybackAudio";
-import { PlaybackSourceError } from "./editorPlaybackSources";
+import { playbackGainValue } from "@/components/editor/editorPlaybackAudio";
+import { PlaybackSourceError } from "@/components/editor/editorPlaybackSources";
 
 type RefValue<T> = {
   current: T;

--- a/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import {
   createProviderUrlSource,
   type EditorMediaSource,
-} from "../../lib/editorMedia";
+} from "@/lib/editorMedia";
 import {
   buildPlaybackFailure,
   buildPlaybackLoadError,
@@ -14,7 +14,7 @@ import {
   resolvePlaybackDuration,
   shouldUseExportFallback,
   type PlaybackLoadFailure,
-} from "./editorPlaybackSources";
+} from "@/components/editor/editorPlaybackSources";
 
 function localFileSource(label = "movie.mp4") {
   return {

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -3,10 +3,13 @@ import {
   editorMediaSourcesEqual,
   isHlsEditorMediaSource,
   type EditorMediaSource,
-} from "../../lib/editorMedia";
-import { getTrackCodec } from "../../lib/mediabunnyTrackAccess";
-import type { PlaybackAudioSelection } from "../../providers/types";
-import { errorMessage, isAc3FamilyCodec } from "./editorUtils";
+} from "@/lib/editorMedia";
+import { getTrackCodec } from "@/lib/mediabunnyTrackAccess";
+import type { PlaybackAudioSelection } from "@/providers/types";
+import {
+  errorMessage,
+  isAc3FamilyCodec,
+} from "@/components/editor/editorUtils";
 
 type PlaybackSourceLabel =
   | "hls stream"

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupRange.test.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupRange.test.ts
@@ -8,7 +8,7 @@ import {
   markPlaybackReadyRangeFresh,
   PLAYBACK_READY_RANGE_FRESH_MS,
   resetPlaybackReadyRangeWarmState,
-} from "./editorPlaybackWarmupRange";
+} from "@/components/editor/editorPlaybackWarmupRange";
 
 void test("does not show idle selection readiness", () => {
   const range = createIdlePlaybackReadyRange(10, 20);

--- a/apps/frontend/src/components/editor/editorPlaybackWarmupRange.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackWarmupRange.ts
@@ -1,4 +1,4 @@
-import type { PlaybackReadyRange } from "./editorPlaybackWarmupTypes";
+import type { PlaybackReadyRange } from "@/components/editor/editorPlaybackWarmupTypes";
 
 export const PLAYBACK_READY_RANGE_FRESH_MS = 30_000;
 

--- a/apps/frontend/src/components/editor/initialClipRange.test.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import {
   buildClipRangeAfterDurationDiscovery,
   buildInitialClipRange,
-} from "./initialClipRange";
+} from "@/components/editor/initialClipRange";
 
 void test("starts initial clip range at zero when no playhead is available", () => {
   assert.deepEqual(buildInitialClipRange(120), {

--- a/apps/frontend/src/components/editor/initialClipRange.ts
+++ b/apps/frontend/src/components/editor/initialClipRange.ts
@@ -1,4 +1,7 @@
-import { MIN_CLIP_SECONDS, roundTimelineTime } from "./editorUtils";
+import {
+  MIN_CLIP_SECONDS,
+  roundTimelineTime,
+} from "@/components/editor/editorUtils";
 
 const DEFAULT_INITIAL_CLIP_SECONDS = 10;
 

--- a/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
@@ -2,8 +2,8 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { PlaybackSubtitleTrack } from "../../providers/types";
-import { buildSubtitleExportSummary } from "./subtitleExportSummary";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+import { buildSubtitleExportSummary } from "@/components/editor/subtitleExportSummary";
 
 const supportedTrack = {
   title: "English SDH",

--- a/apps/frontend/src/components/editor/subtitleExportSummary.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.ts
@@ -1,8 +1,8 @@
-import type { PlaybackSubtitleTrack } from "../../providers/types";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
-} from "../../lib/selectPreferredSubtitleTrack";
+} from "@/lib/selectPreferredSubtitleTrack";
 
 interface BuildSubtitleExportSummaryOptions {
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;

--- a/apps/frontend/src/components/editor/timelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.test.ts
@@ -12,12 +12,12 @@ import {
   getFocusedTimelineZoomIndex,
   parseTimecodeInput,
   type TimelineZoomLevel,
-} from "./editorUtils";
+} from "@/components/editor/editorUtils";
 import {
   accumulateTimelineWheelZoomDelta,
   resolveTimelineScrollWheelUpdate,
   resolveTimelineZoomUpdate,
-} from "./timelineZoom";
+} from "@/components/editor/timelineZoom";
 
 const zoomLevels = [
   { scale: 5, scaleSplitCount: 5, scaleWidth: 100 },

--- a/apps/frontend/src/components/editor/timelineZoom.ts
+++ b/apps/frontend/src/components/editor/timelineZoom.ts
@@ -7,7 +7,7 @@ import {
   timelinePixelToTime,
   timelineTimeToPixel,
   type TimelineZoomLevel,
-} from "./editorUtils";
+} from "@/components/editor/editorUtils";
 
 interface ResolveTimelineZoomUpdateOptions {
   availableTimelineZoomLevels: readonly TimelineZoomLevel[];

--- a/apps/frontend/src/components/editor/useEditorExport.test.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import {
   createProviderUrlSource,
   type EditorMediaSource,
-} from "../../lib/editorMedia";
+} from "@/lib/editorMedia";
 import {
   buildExportSourceLabel,
   buildExportSourceMessage,
@@ -13,7 +13,7 @@ import {
   getEditorExportReadiness,
   getOutputDimensions,
   resolveExportSource,
-} from "./useEditorExport";
+} from "@/components/editor/useEditorExport";
 
 const localFileSource = {
   kind: "file",

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -4,7 +4,7 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import type { ExportFormat, ExportResolution } from "../../lib/exportClip";
+import type { ExportFormat, ExportResolution } from "@/lib/exportClip";
 import {
   buildExportFileName,
   defaultExportFileNameTemplates,
@@ -12,22 +12,19 @@ import {
   saveExportFileNameTemplates,
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
-} from "../../lib/exportFileName";
+} from "@/lib/exportFileName";
 import {
   isHlsEditorMediaSource,
   sourceDisplayLabel,
   type EditorMediaSource,
   type EditorSession,
-} from "../../lib/editorMedia";
-import { subtitleTrackSupportsBurnIn } from "../../lib/selectPreferredSubtitleTrack";
-import type {
-  SubtitleCue,
-  SubtitleStyleSettings,
-} from "../../lib/subtitles/types";
-import type { PlaybackSubtitleTrack } from "../../providers/types";
-import type { ExportSourcePreference } from "./EditorExportDialog";
-import type { PlaybackFallbackInfo } from "./useEditorPlayback";
-import { getFrontendLogger, warnWithError } from "../../logging";
+} from "@/lib/editorMedia";
+import { subtitleTrackSupportsBurnIn } from "@/lib/selectPreferredSubtitleTrack";
+import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+import type { ExportSourcePreference } from "@/components/editor/EditorExportDialog";
+import type { PlaybackFallbackInfo } from "@/components/editor/useEditorPlayback";
+import { getFrontendLogger, warnWithError } from "@/logging";
 
 interface VideoDimensions {
   width: number;
@@ -324,7 +321,7 @@ export function useEditorExport({
     });
 
     try {
-      const { exportClip } = await import("../../lib/exportClip");
+      const { exportClip } = await import("@/lib/exportClip");
       const blob = await exportClip({
         mediaSource: readiness.source,
         hls: readiness.sourceKind === "hls",

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -13,27 +13,24 @@ import type {
   WrappedAudioBuffer,
   WrappedCanvas,
 } from "mediabunny";
-import type {
-  SubtitleCue,
-  SubtitleStyleSettings,
-} from "../../lib/subtitles/types";
-import type { EditorMediaSource } from "../../lib/editorMedia";
-import { createCliparrInputFromSource } from "../../lib/mediabunnyInput";
+import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
+import type { EditorMediaSource } from "@/lib/editorMedia";
+import { createCliparrInputFromSource } from "@/lib/mediabunnyInput";
 import {
   fromSourceTimelineTime,
   getAudioTrackSampleRate,
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
   toSourceTimelineTime,
-} from "../../lib/mediabunnyTrackAccess";
-import { selectPreferredPairableAudioTrack } from "../../lib/selectPreferredAudioTrack";
-import type { PlaybackAudioSelection } from "../../providers/types";
-import { errorMessage } from "./editorUtils";
+} from "@/lib/mediabunnyTrackAccess";
+import { selectPreferredPairableAudioTrack } from "@/lib/selectPreferredAudioTrack";
+import type { PlaybackAudioSelection } from "@/providers/types";
+import { errorMessage } from "@/components/editor/editorUtils";
 import {
   applyPlaybackGain,
   runPlaybackAudioIterator,
   stopQueuedAudioNodes,
-} from "./editorPlaybackAudio";
+} from "@/components/editor/editorPlaybackAudio";
 import {
   assessPreviewAudioTrack,
   browserDecoderEnvironmentWarning,
@@ -51,23 +48,23 @@ import {
   type PlaybackLoadFailure,
   type PlaybackSourceCandidate,
   type PlaybackSourceAnalysisContext,
-} from "./editorPlaybackSources";
+} from "@/components/editor/editorPlaybackSources";
 import {
   createPlaybackSinkResources,
   disposePlaybackSinkResources,
   getAudioContextConstructor,
-} from "./editorPlaybackSinks";
-import { useEditorPlaybackRenderLoop } from "./useEditorPlaybackRenderLoop";
+} from "@/components/editor/editorPlaybackSinks";
+import { useEditorPlaybackRenderLoop } from "@/components/editor/useEditorPlaybackRenderLoop";
 import {
   useEditorPlaybackWarmup,
   type PlaybackReadyRange,
-} from "./useEditorPlaybackWarmup";
-import { resolvePreviewPlaybackPlan } from "./editorPlaybackPlan";
-import { resetPlaybackReadyRangeWarmState } from "./editorPlaybackWarmupRange";
-import { getFrontendLogger, warnWithError } from "../../logging";
+} from "@/components/editor/useEditorPlaybackWarmup";
+import { resolvePreviewPlaybackPlan } from "@/components/editor/editorPlaybackPlan";
+import { resetPlaybackReadyRangeWarmState } from "@/components/editor/editorPlaybackWarmupRange";
+import { getFrontendLogger, warnWithError } from "@/logging";
 
-export type { PlaybackFallbackInfo } from "./editorPlaybackSources";
-export type { PlaybackReadyRange } from "./useEditorPlaybackWarmup";
+export type { PlaybackFallbackInfo } from "@/components/editor/editorPlaybackSources";
+export type { PlaybackReadyRange } from "@/components/editor/useEditorPlaybackWarmup";
 
 interface UseEditorPlaybackProps {
   hlsSource?: EditorMediaSource;
@@ -190,7 +187,7 @@ function initialPlaybackTime(
 }
 
 async function ensurePlaybackCodecs() {
-  const { ensureMediabunnyCodecs } = await import("../../lib/mediabunnyCodecs");
+  const { ensureMediabunnyCodecs } = await import("@/lib/mediabunnyCodecs");
   await ensureMediabunnyCodecs();
 }
 

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -3,14 +3,11 @@ import type { CanvasSink, Input, WrappedCanvas } from "mediabunny";
 import {
   fromSourceTimelineTime,
   toSourceTimelineTime,
-} from "../../lib/mediabunnyTrackAccess";
-import { getActiveSubtitleCue } from "../../lib/subtitles/getActiveSubtitleCue";
-import { renderSubtitleCue } from "../../lib/subtitles/renderSubtitleCue";
-import type {
-  SubtitleCue,
-  SubtitleStyleSettings,
-} from "../../lib/subtitles/types";
-import { errorMessage, themeValue } from "./editorUtils";
+} from "@/lib/mediabunnyTrackAccess";
+import { getActiveSubtitleCue } from "@/lib/subtitles/getActiveSubtitleCue";
+import { renderSubtitleCue } from "@/lib/subtitles/renderSubtitleCue";
+import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
+import { errorMessage, themeValue } from "@/components/editor/editorUtils";
 
 type RefValue<T> = {
   current: T;

--- a/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackSelectionWarmup.ts
@@ -13,19 +13,19 @@ import type {
 import {
   fromSourceTimelineTime,
   toSourceTimelineTime,
-} from "../../lib/mediabunnyTrackAccess";
+} from "@/lib/mediabunnyTrackAccess";
 import {
   createIdlePlaybackReadyRange,
   isPlaybackReadyRangeVisible,
   markPlaybackReadyRangeFresh,
   samePlaybackReadyRange,
-} from "./editorPlaybackWarmupRange";
-import { isPresent } from "./editorPlaybackSources";
+} from "@/components/editor/editorPlaybackWarmupRange";
+import { isPresent } from "@/components/editor/editorPlaybackSources";
 import type {
   PlaybackReadyRange,
   RefValue,
   WarmClipSelectionOptions,
-} from "./editorPlaybackWarmupTypes";
+} from "@/components/editor/editorPlaybackWarmupTypes";
 
 interface UseEditorPlaybackSelectionWarmupOptions {
   loadingPreview: boolean;

--- a/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackWarmup.ts
@@ -5,11 +5,14 @@ import type {
   WrappedAudioBuffer,
   WrappedCanvas,
 } from "mediabunny";
-import { toSourceTimelineTime } from "../../lib/mediabunnyTrackAccess";
-import { useEditorPlaybackSelectionWarmup } from "./useEditorPlaybackSelectionWarmup";
-import type { PlaybackReadyRange, RefValue } from "./editorPlaybackWarmupTypes";
+import { toSourceTimelineTime } from "@/lib/mediabunnyTrackAccess";
+import { useEditorPlaybackSelectionWarmup } from "@/components/editor/useEditorPlaybackSelectionWarmup";
+import type {
+  PlaybackReadyRange,
+  RefValue,
+} from "@/components/editor/editorPlaybackWarmupTypes";
 
-export type { PlaybackReadyRange } from "./editorPlaybackWarmupTypes";
+export type { PlaybackReadyRange } from "@/components/editor/editorPlaybackWarmupTypes";
 
 interface UseEditorPlaybackWarmupOptions {
   loadingPreview: boolean;

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -1,18 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { EditorSession } from "../../lib/editorMedia";
+import type { EditorSession } from "@/lib/editorMedia";
 import {
   selectPreferredSubtitleTrack,
   subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
-} from "../../lib/selectPreferredSubtitleTrack";
+} from "@/lib/selectPreferredSubtitleTrack";
 import {
   loadSubtitleStyleSettings,
   saveSubtitleStyleSettings,
-} from "../../lib/subtitles/settings";
-import { trimSubtitleCues } from "../../lib/subtitles/trimSubtitleCues";
-import type { PlaybackSubtitleTrack } from "../../providers/types";
-import { buildSubtitleExportSummary } from "./subtitleExportSummary";
-import { useSubtitleCues } from "./useSubtitleCues";
+} from "@/lib/subtitles/settings";
+import { trimSubtitleCues } from "@/lib/subtitles/trimSubtitleCues";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+import { buildSubtitleExportSummary } from "@/components/editor/subtitleExportSummary";
+import { useSubtitleCues } from "@/components/editor/useSubtitleCues";
 
 interface UseEditorSubtitlesProps {
   session: EditorSession;

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -20,12 +20,12 @@ import {
   timelineTimeToPixel,
   type ClipTimelineData,
   type ClipTimelineEffects,
-} from "./editorUtils";
+} from "@/components/editor/editorUtils";
 import {
   accumulateTimelineWheelZoomDelta,
   resolveTimelineScrollWheelUpdate,
   resolveTimelineZoomUpdate,
-} from "./timelineZoom";
+} from "@/components/editor/timelineZoom";
 
 interface UseEditorTimelineProps {
   duration: number;

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -5,14 +5,14 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import type { PlaybackSubtitleTrack } from "../../providers/types";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
-} from "../../lib/selectPreferredSubtitleTrack";
-import { parseSubtitleText } from "../../lib/subtitles/parseSubtitleText";
-import type { SubtitleCue } from "../../lib/subtitles/types";
-import { getFrontendLogger, warnWithError } from "../../logging";
+} from "@/lib/selectPreferredSubtitleTrack";
+import { parseSubtitleText } from "@/lib/subtitles/parseSubtitleText";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+import { getFrontendLogger, warnWithError } from "@/logging";
 
 interface UseSubtitleCuesOptions {
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;

--- a/apps/frontend/src/components/editor/useSubtitleFontOptions.ts
+++ b/apps/frontend/src/components/editor/useSubtitleFontOptions.ts
@@ -4,7 +4,7 @@ import {
   loadLocalSubtitleFontOptions,
   SUBTITLE_FONT_OPTIONS,
   type SubtitleFontOption,
-} from "../../lib/subtitles/settings";
+} from "@/lib/subtitles/settings";
 
 interface UseSubtitleFontOptionsResult {
   currentFontOption: SubtitleFontOption | null;

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -4,10 +4,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createElement, createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import AuthCompleteScreen from "./AuthCompleteScreen";
-import { EditorPreview } from "./editor/EditorPreview";
-import { LocalVideoOpenDialog } from "./local-media/LocalVideoOpenDialog";
-import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "../lib/viewTransitions";
+import AuthCompleteScreen from "@/components/AuthCompleteScreen";
+import { EditorPreview } from "@/components/editor/EditorPreview";
+import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
+import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
 void test("renders the provider auth completion screen", () => {
   const markup = renderToStaticMarkup(createElement(AuthCompleteScreen));

--- a/apps/frontend/src/components/local-media/LocalVideoOpenDialog.tsx
+++ b/apps/frontend/src/components/local-media/LocalVideoOpenDialog.tsx
@@ -26,8 +26,8 @@ import {
   createLocalSessionFromUrl,
   LOCAL_VIDEO_FILE_ACCEPT,
   localMediaPickerSupported,
-} from "../../lib/localMediaRegistry";
-import { cn } from "../../lib/utils";
+} from "@/lib/localMediaRegistry";
+import { cn } from "@/lib/utils";
 
 interface LocalVideoOpenDialogProps {
   isOpen: boolean;

--- a/apps/frontend/src/components/provider-connect/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectFlow.tsx
@@ -1,16 +1,16 @@
 import { AnimatePresence, motion } from "motion/react";
 import { ArrowRight, Check, ExternalLink, Server } from "lucide-react";
 import type { ReactNode } from "react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
   ProviderBadge,
   ProviderConnectError,
   ProviderOption,
   ProviderStatusMessage,
   providerPresentation,
-} from "./ProviderConnectFlowSections";
-import { ProviderGlyph } from "../providers/ProviderGlyph";
-import { useProviderConnectFlow } from "./useProviderConnectFlow";
+} from "@/components/provider-connect/ProviderConnectFlowSections";
+import { ProviderGlyph } from "@/components/providers/ProviderGlyph";
+import { useProviderConnectFlow } from "@/components/provider-connect/useProviderConnectFlow";
 import {
   Tabs,
   TabsList,
@@ -25,10 +25,7 @@ import {
   screenTextInputClasses as baseScreenInputClasses,
   textInputClasses,
 } from "@/components/ui/control-styles";
-import type {
-  ProviderDefinition,
-  ProviderSession,
-} from "../../providers/types";
+import type { ProviderDefinition, ProviderSession } from "@/providers/types";
 
 interface Props {
   onConnected: (session: ProviderSession) => Promise<void> | void;

--- a/apps/frontend/src/components/provider-connect/ProviderConnectFlowSections.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectFlowSections.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "motion/react";
-import { cn } from "../../lib/utils";
-import type { ProviderDefinition } from "../../providers/types";
-import { ProviderGlyph } from "../providers/ProviderGlyph";
+import { cn } from "@/lib/utils";
+import type { ProviderDefinition } from "@/providers/types";
+import { ProviderGlyph } from "@/components/providers/ProviderGlyph";
 
 export function providerPresentation(
   provider: ProviderDefinition,

--- a/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
@@ -1,7 +1,7 @@
 import { FolderOpen } from "lucide-react";
-import ProviderConnectFlow from "./ProviderConnectFlow";
+import ProviderConnectFlow from "@/components/provider-connect/ProviderConnectFlow";
 import { secondaryButtonClasses } from "@/components/ui/control-styles";
-import type { ProviderSession } from "../../providers/types";
+import type { ProviderSession } from "@/providers/types";
 
 interface Props {
   onConnected: (session: ProviderSession) => Promise<void> | void;

--- a/apps/frontend/src/components/provider-connect/useProviderConnectFlow.ts
+++ b/apps/frontend/src/components/provider-connect/useProviderConnectFlow.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { cliparrClient } from "../../api/cliparrClient";
-import type {
-  ProviderDefinition,
-  ProviderSession,
-} from "../../providers/types";
+import { cliparrClient } from "@/api/cliparrClient";
+import type { ProviderDefinition, ProviderSession } from "@/providers/types";
 
 interface UseProviderConnectFlowOptions {
   onConnected: (session: ProviderSession) => Promise<void> | void;

--- a/apps/frontend/src/components/providers/ProviderGlyph.tsx
+++ b/apps/frontend/src/components/providers/ProviderGlyph.tsx
@@ -1,7 +1,7 @@
 import { Film, Server } from "lucide-react";
-import plexLogoUrl from "../../assets/providers/plex.svg";
-import jellyfinLogoUrl from "../../assets/providers/jellyfin.svg";
-import { cn } from "../../lib/utils";
+import plexLogoUrl from "@/assets/providers/plex.svg";
+import jellyfinLogoUrl from "@/assets/providers/jellyfin.svg";
+import { cn } from "@/lib/utils";
 
 export function formatProviderName(providerId: string) {
   return providerId

--- a/apps/frontend/src/components/sources/SourceConnectPanel.tsx
+++ b/apps/frontend/src/components/sources/SourceConnectPanel.tsx
@@ -1,5 +1,5 @@
-import ProviderConnectFlow from "../provider-connect/ProviderConnectFlow";
-import type { ProviderSession } from "../../providers/types";
+import ProviderConnectFlow from "@/components/provider-connect/ProviderConnectFlow";
+import type { ProviderSession } from "@/providers/types";
 
 interface Props {
   onConnected: (session: ProviderSession) => Promise<void> | void;

--- a/apps/frontend/src/components/sources/SourcesDialog.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialog.tsx
@@ -7,8 +7,8 @@ import {
   SourcesDialogAlerts,
   SourcesDialogFilters,
   SourcesDialogHeader,
-} from "./SourcesDialogSections";
-import { useSourcesState } from "./useSourcesState";
+} from "@/components/sources/SourcesDialogSections";
+import { useSourcesState } from "@/components/sources/useSourcesState";
 
 interface Props {
   isOpen: boolean;

--- a/apps/frontend/src/components/sources/SourcesDialogSections.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialogSections.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -22,10 +22,10 @@ import {
   iconButtonClasses,
   textInputClasses as inputClasses,
 } from "@/components/ui/control-styles";
-import type { MediaSource, ProviderSession } from "../../providers/types";
-import { formatProviderName } from "../providers/ProviderGlyph";
-import SourceConnectPanel from "./SourceConnectPanel";
-import type { Feedback, SourceFilter } from "./sourcesTypes";
+import type { MediaSource, ProviderSession } from "@/providers/types";
+import { formatProviderName } from "@/components/providers/ProviderGlyph";
+import SourceConnectPanel from "@/components/sources/SourceConnectPanel";
+import type { Feedback, SourceFilter } from "@/components/sources/sourcesTypes";
 
 function TooltipWrap({
   message,

--- a/apps/frontend/src/components/sources/sourcesStateUtils.ts
+++ b/apps/frontend/src/components/sources/sourcesStateUtils.ts
@@ -1,8 +1,5 @@
-import type {
-  MediaSource,
-  MediaSourceCheckResult,
-} from "../../providers/types";
-import type { Feedback, SourceFilter } from "./sourcesTypes";
+import type { MediaSource, MediaSourceCheckResult } from "@/providers/types";
+import type { Feedback, SourceFilter } from "@/components/sources/sourcesTypes";
 
 function compareStrings(left: string, right: string) {
   return left.localeCompare(right, undefined, { sensitivity: "base" });

--- a/apps/frontend/src/components/sources/useSourcesState.test.ts
+++ b/apps/frontend/src/components/sources/useSourcesState.test.ts
@@ -2,10 +2,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import type {
-  MediaSource,
-  MediaSourceCheckResult,
-} from "../../providers/types";
+import type { MediaSource, MediaSourceCheckResult } from "@/providers/types";
 import {
   buildSourceEditInput,
   draftBaseUrlsFor,
@@ -14,7 +11,7 @@ import {
   mergeRefreshAllSourceResults,
   sourceCounts,
   sourceProviderOptions,
-} from "./sourcesStateUtils";
+} from "@/components/sources/sourcesStateUtils";
 
 function source(
   overrides: Partial<MediaSource> &

--- a/apps/frontend/src/components/sources/useSourcesState.ts
+++ b/apps/frontend/src/components/sources/useSourcesState.ts
@@ -4,10 +4,10 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { cliparrClient } from "../../api/cliparrClient";
-import { useAuth } from "../../auth";
-import type { MediaSource, ProviderSession } from "../../providers/types";
-import type { Feedback, SourceFilter } from "./sourcesTypes";
+import { cliparrClient } from "@/api/cliparrClient";
+import { useAuth } from "@/auth";
+import type { MediaSource, ProviderSession } from "@/providers/types";
+import type { Feedback, SourceFilter } from "@/components/sources/sourcesTypes";
 import {
   buildSourceEditInput,
   draftBaseUrlsFor,
@@ -17,8 +17,8 @@ import {
   sourceCounts,
   sourceProviderOptions,
   sortSources,
-} from "./sourcesStateUtils";
-import { getFrontendLogger, warnWithError } from "../../logging";
+} from "@/components/sources/sourcesStateUtils";
+import { getFrontendLogger, warnWithError } from "@/logging";
 
 interface UseSourcesStateOptions {
   isOpen: boolean;

--- a/apps/frontend/src/lib/editorMedia.test.ts
+++ b/apps/frontend/src/lib/editorMedia.test.ts
@@ -2,8 +2,11 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { editorSessionFromCurrentlyPlaying, titleFromUrl } from "./editorMedia";
-import type { CurrentlyPlayingItem } from "../providers/types";
+import {
+  editorSessionFromCurrentlyPlaying,
+  titleFromUrl,
+} from "@/lib/editorMedia";
+import type { CurrentlyPlayingItem } from "@/providers/types";
 
 void test("uses the URL host as the title when no path segment is present", () => {
   assert.equal(titleFromUrl("https://example.com/"), "example.com");

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -5,8 +5,8 @@ import type {
   PlaybackSource,
   PlaybackSubtitleSelection,
   PlaybackSubtitleTrack,
-} from "../providers/types";
-import { isHlsPlaylistUrl } from "./mediabunnyInput";
+} from "@/providers/types";
+import { isHlsPlaylistUrl } from "@/lib/mediabunnyInput";
 
 const LOCAL_PROVIDER_ID = "local";
 

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -3,9 +3,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ConversionOptions } from "mediabunny";
-import { exportClipWithRuntime } from "./exportClip";
-import type { EditorMediaSource } from "./editorMedia";
-import type { SubtitleStyleSettings } from "./subtitles/types";
+import { exportClipWithRuntime } from "@/lib/exportClip";
+import type { EditorMediaSource } from "@/lib/editorMedia";
+import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 
 type ExportRuntime = Parameters<typeof exportClipWithRuntime>[1];
 type CliparrInput = Awaited<

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -8,32 +8,32 @@ import {
   WebMOutputFormat,
 } from "mediabunny";
 import type { ConversionOptions, VideoSample } from "mediabunny";
-import type { EditorMediaSource } from "./editorMedia";
-import { createCliparrInputFromSource } from "./mediabunnyInput";
-import { ensureMediabunnyCodecs } from "./mediabunnyCodecs";
+import type { EditorMediaSource } from "@/lib/editorMedia";
+import { createCliparrInputFromSource } from "@/lib/mediabunnyInput";
+import { ensureMediabunnyCodecs } from "@/lib/mediabunnyCodecs";
 import {
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
   toSourceTimelineTime,
-} from "./mediabunnyTrackAccess";
-import { selectPreferredPairableAudioTrack } from "./selectPreferredAudioTrack";
+} from "@/lib/mediabunnyTrackAccess";
+import { selectPreferredPairableAudioTrack } from "@/lib/selectPreferredAudioTrack";
 import type {
   MediaExportMetadata,
   PlaybackAudioSelection,
-} from "../providers/types";
+} from "@/providers/types";
 import {
   buildMetadataTags,
   describeDiscardedTracks,
   isIsobmffExportFormat,
   patchMp4MetadataBoxes,
-} from "./exportMetadata";
-import type { ExportFormat, ExportResolution } from "./exportTypes";
-import { getActiveSubtitleCue } from "./subtitles/getActiveSubtitleCue";
-import { renderSubtitleCue } from "./subtitles/renderSubtitleCue";
-import { trimSubtitleCues } from "./subtitles/trimSubtitleCues";
-import type { SubtitleCue, SubtitleStyleSettings } from "./subtitles/types";
+} from "@/lib/exportMetadata";
+import type { ExportFormat, ExportResolution } from "@/lib/exportTypes";
+import { getActiveSubtitleCue } from "@/lib/subtitles/getActiveSubtitleCue";
+import { renderSubtitleCue } from "@/lib/subtitles/renderSubtitleCue";
+import { trimSubtitleCues } from "@/lib/subtitles/trimSubtitleCues";
+import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
 
-export type { ExportFormat, ExportResolution } from "./exportTypes";
+export type { ExportFormat, ExportResolution } from "@/lib/exportTypes";
 
 interface ExportClipOptions {
   mediaSource: EditorMediaSource;

--- a/apps/frontend/src/lib/exportFileName.test.ts
+++ b/apps/frontend/src/lib/exportFileName.test.ts
@@ -9,7 +9,7 @@ import {
   loadExportFileNameTemplates,
   saveExportFileNameTemplates,
   type ExportFileNameTemplateSettings,
-} from "./exportFileName";
+} from "@/lib/exportFileName";
 
 const legacyMovieTemplate =
   "{source_title} ({year}) - clip {clip_start} to {clip_end}";

--- a/apps/frontend/src/lib/exportFileName.ts
+++ b/apps/frontend/src/lib/exportFileName.ts
@@ -1,5 +1,5 @@
-import type { MediaExportMetadata } from "../providers/types";
-import type { ExportFormat } from "./exportClip";
+import type { MediaExportMetadata } from "@/providers/types";
+import type { ExportFormat } from "@/lib/exportClip";
 
 export type ExportFileNameTemplateKind = "movie" | "episode";
 

--- a/apps/frontend/src/lib/exportMetadata.test.ts
+++ b/apps/frontend/src/lib/exportMetadata.test.ts
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { MetadataTags } from "mediabunny";
-import { buildMetadataTags, patchMp4MetadataBoxes } from "./exportMetadata";
+import { buildMetadataTags, patchMp4MetadataBoxes } from "@/lib/exportMetadata";
 
 function bytes(...values: number[]) {
   return new Uint8Array(values);

--- a/apps/frontend/src/lib/exportMetadata.ts
+++ b/apps/frontend/src/lib/exportMetadata.ts
@@ -1,9 +1,9 @@
 import type { DiscardedTrack, MetadataTags } from "mediabunny";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import type { MediaExportMetadata } from "../providers/types";
-import { describeInputTrack } from "./mediabunnyTrackAccess";
-import type { ExportFormat } from "./exportTypes";
-import { getFrontendLogger, warnWithError } from "../logging";
+import type { MediaExportMetadata } from "@/providers/types";
+import { describeInputTrack } from "@/lib/mediabunnyTrackAccess";
+import type { ExportFormat } from "@/lib/exportTypes";
+import { getFrontendLogger, warnWithError } from "@/logging";
 
 const logger = getFrontendLogger(["editor", "artwork"]);
 

--- a/apps/frontend/src/lib/localMediaRegistry.test.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.test.ts
@@ -2,14 +2,14 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { BrowserFileHandle } from "./editorMedia";
+import type { BrowserFileHandle } from "@/lib/editorMedia";
 import {
   createLocalSessionFromFile,
   createLocalSessionFromUrl,
   resolveFileHandleReadPermission,
   resolveLocalMediaSession,
   validateLocalMediaUrl,
-} from "./localMediaRegistry";
+} from "@/lib/localMediaRegistry";
 
 async function withMockedLocalMediaUrl<T>(callback: () => Promise<T>) {
   const originalFetch = globalThis.fetch;

--- a/apps/frontend/src/lib/localMediaRegistry.ts
+++ b/apps/frontend/src/lib/localMediaRegistry.ts
@@ -8,9 +8,9 @@ import {
   type EditorUrlMediaSource,
   titleFromFileName,
   titleFromUrl,
-} from "./editorMedia";
-import { cliparrClient } from "../api/cliparrClient";
-import { isHlsPlaylistUrl } from "./mediabunnyInput";
+} from "@/lib/editorMedia";
+import { cliparrClient } from "@/api/cliparrClient";
+import { isHlsPlaylistUrl } from "@/lib/mediabunnyInput";
 
 const DATABASE_NAME = "cliparr-local-media";
 const DATABASE_VERSION = 1;

--- a/apps/frontend/src/lib/mediabunnyInput.ts
+++ b/apps/frontend/src/lib/mediabunnyInput.ts
@@ -1,5 +1,5 @@
 import type { Input } from "mediabunny";
-import type { EditorMediaSource } from "./editorMedia";
+import type { EditorMediaSource } from "@/lib/editorMedia";
 
 const HLS_PLAYLIST_PATTERN = /\.m3u8(?:$|[?#])/i;
 const HLS_URL_SOURCE_OPTIONS = {

--- a/apps/frontend/src/lib/selectPreferredAudioTrack.ts
+++ b/apps/frontend/src/lib/selectPreferredAudioTrack.ts
@@ -1,6 +1,9 @@
 import type { InputAudioTrack, InputVideoTrack } from "mediabunny";
-import type { PlaybackAudioSelection } from "../providers/types";
-import { getTrackLanguageCode, getTrackName } from "./mediabunnyTrackAccess";
+import type { PlaybackAudioSelection } from "@/providers/types";
+import {
+  getTrackLanguageCode,
+  getTrackName,
+} from "@/lib/mediabunnyTrackAccess";
 
 function normalizedText(value: string | null | undefined) {
   const trimmed = value?.trim().toLowerCase();

--- a/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
+++ b/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
@@ -1,7 +1,7 @@
 import type {
   PlaybackSubtitleSelection,
   PlaybackSubtitleTrack,
-} from "../providers/types";
+} from "@/providers/types";
 
 function normalizedText(value: string | null | undefined) {
   const trimmed = value?.trim().toLowerCase();

--- a/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.ts
@@ -1,4 +1,4 @@
-import type { SubtitleCue } from "./types";
+import type { SubtitleCue } from "@/lib/subtitles/types";
 
 export function getActiveSubtitleCue(
   cues: readonly SubtitleCue[],

--- a/apps/frontend/src/lib/subtitles/parseSubtitleText.ts
+++ b/apps/frontend/src/lib/subtitles/parseSubtitleText.ts
@@ -1,4 +1,4 @@
-import type { SubtitleCue } from "./types";
+import type { SubtitleCue } from "@/lib/subtitles/types";
 
 type SubtitleTextFormat = "vtt" | "srt";
 

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -1,4 +1,4 @@
-import type { SubtitleCue, SubtitleStyleSettings } from "./types";
+import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
 
 interface SubtitleLayout {
   font: string;

--- a/apps/frontend/src/lib/subtitles/settings.ts
+++ b/apps/frontend/src/lib/subtitles/settings.ts
@@ -1,4 +1,4 @@
-import type { SubtitleStyleSettings } from "./types";
+import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 
 const SUBTITLE_STYLE_SETTINGS_STORAGE_KEY =
   "cliparr.subtitle.style-settings.v1";

--- a/apps/frontend/src/lib/subtitles/trimSubtitleCues.ts
+++ b/apps/frontend/src/lib/subtitles/trimSubtitleCues.ts
@@ -1,4 +1,4 @@
-import type { SubtitleCue } from "./types";
+import type { SubtitleCue } from "@/lib/subtitles/types";
 
 export function trimSubtitleCues(
   cues: readonly SubtitleCue[],

--- a/apps/frontend/src/lib/viewTransitions.test.ts
+++ b/apps/frontend/src/lib/viewTransitions.test.ts
@@ -2,13 +2,13 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { EditorSession } from "./editorMedia";
+import type { EditorSession } from "@/lib/editorMedia";
 import {
   clearPendingEditorTransitionSession,
   EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME,
   getPendingEditorTransitionSession,
   setPendingEditorTransitionSession,
-} from "./viewTransitions";
+} from "@/lib/viewTransitions";
 
 function buildEditorSession(id: string): EditorSession {
   return {

--- a/apps/frontend/src/lib/viewTransitions.ts
+++ b/apps/frontend/src/lib/viewTransitions.ts
@@ -1,4 +1,4 @@
-import type { EditorSession } from "./editorMedia";
+import type { EditorSession } from "@/lib/editorMedia";
 
 export const EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME = "cliparr-editor-thumbnail";
 

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,8 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
-import "./index.css";
-import { configureFrontendLogging } from "./logging";
+import App from "@/App.tsx";
+import "@/index.css";
+import { configureFrontendLogging } from "@/logging";
 
 document.documentElement.classList.add("dark");
 

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -1,6 +1,6 @@
 import { createRouter } from "@tanstack/react-router";
-import type { ProviderSession } from "./providers/types";
-import { routeTree } from "./routeTree.gen";
+import type { ProviderSession } from "@/providers/types";
+import { routeTree } from "@/routeTree.gen";
 
 export interface RouterAuthContext {
   providerSession: ProviderSession | null;

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
-import type { RouterContext } from "../router";
+import type { RouterContext } from "@/router";
 
 function RootRouteComponent() {
   return <Outlet />;

--- a/apps/frontend/src/routes/_app.dashboard.tsx
+++ b/apps/frontend/src/routes/_app.dashboard.tsx
@@ -1,15 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { flushSync } from "react-dom";
-import { useAuth } from "../auth";
-import DashboardScreen from "../components/DashboardScreen";
-import { LocalVideoOpenDialog } from "../components/local-media/LocalVideoOpenDialog";
-import { editorSessionFromCurrentlyPlaying } from "../lib/editorMedia";
+import { useAuth } from "@/auth";
+import DashboardScreen from "@/components/DashboardScreen";
+import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
+import { editorSessionFromCurrentlyPlaying } from "@/lib/editorMedia";
 import {
   runViewTransition,
   setPendingEditorTransitionSession,
-} from "../lib/viewTransitions";
-import { router } from "../router";
+} from "@/lib/viewTransitions";
+import { router } from "@/router";
 
 function DashboardRouteComponent() {
   const auth = useAuth();

--- a/apps/frontend/src/routes/_app.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/_app.edit.$sessionId.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { cliparrClient } from "../api/cliparrClient";
-import EditorScreen from "../components/editor/EditorScreen";
+import { cliparrClient } from "@/api/cliparrClient";
+import EditorScreen from "@/components/editor/EditorScreen";
 import {
   editorSessionFromCurrentlyPlaying,
   type EditorSession,
-} from "../lib/editorMedia";
-import { getPendingEditorTransitionSession } from "../lib/viewTransitions";
-import { router } from "../router";
+} from "@/lib/editorMedia";
+import { getPendingEditorTransitionSession } from "@/lib/viewTransitions";
+import { router } from "@/router";
 
 function errorMessage(err: unknown, fallback: string) {
   return err instanceof Error && err.message ? err.message : fallback;

--- a/apps/frontend/src/routes/_app.sources.tsx
+++ b/apps/frontend/src/routes/_app.sources.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
-import SourcesDialog from "../components/sources/SourcesDialog";
-import { router } from "../router";
+import SourcesDialog from "@/components/sources/SourcesDialog";
+import { router } from "@/router";
 
 function SourcesRouteComponent() {
   const canGoBack = useCanGoBack();

--- a/apps/frontend/src/routes/auth.plex.complete.tsx
+++ b/apps/frontend/src/routes/auth.plex.complete.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import AuthCompleteScreen from "../components/AuthCompleteScreen";
+import AuthCompleteScreen from "@/components/AuthCompleteScreen";
 
 export const Route = createFileRoute("/auth/plex/complete")({
   component: AuthCompleteScreen,

--- a/apps/frontend/src/routes/local.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/local.edit.$sessionId.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
 import { FolderOpen, ShieldCheck, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import EditorScreen from "../components/editor/EditorScreen";
-import { LocalVideoOpenDialog } from "../components/local-media/LocalVideoOpenDialog";
+import EditorScreen from "@/components/editor/EditorScreen";
+import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
 import {
   primaryButtonClasses,
   secondaryButtonClasses,
@@ -11,8 +11,8 @@ import {
 import {
   resolveLocalMediaSession,
   type LocalMediaResolution,
-} from "../lib/localMediaRegistry";
-import { router } from "../router";
+} from "@/lib/localMediaRegistry";
+import { router } from "@/router";
 
 function LocalEditorRouteComponent() {
   const { sessionId } = Route.useParams();

--- a/apps/frontend/src/routes/providers.connect.tsx
+++ b/apps/frontend/src/routes/providers.connect.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
-import { useAuth } from "../auth";
-import { LocalVideoOpenDialog } from "../components/local-media/LocalVideoOpenDialog";
-import ProviderConnectScreen from "../components/provider-connect/ProviderConnectScreen";
-import { router } from "../router";
+import { useAuth } from "@/auth";
+import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
+import ProviderConnectScreen from "@/components/provider-connect/ProviderConnectScreen";
+import { router } from "@/router";
 
 function ProviderConnectRouteComponent() {
   const auth = useAuth();

--- a/apps/server/drizzle.config.ts
+++ b/apps/server/drizzle.config.ts
@@ -1,10 +1,7 @@
-import "./src/config/loadEnv.ts";
+import "#/config/loadEnv.js";
 import path from "path";
 import { defineConfig } from "drizzle-kit";
-import {
-  resolveConfiguredDataDir,
-  workspaceRoot,
-} from "./src/config/loadEnv.ts";
+import { resolveConfiguredDataDir, workspaceRoot } from "#/config/loadEnv.js";
 
 const configuredDataDir = process.env.CLIPARR_DATA_DIR?.trim();
 const dataDir = configuredDataDir

--- a/apps/server/drizzle.config.ts
+++ b/apps/server/drizzle.config.ts
@@ -1,7 +1,7 @@
-import "#/config/loadEnv.js";
+import "@/config/loadEnv";
 import path from "path";
 import { defineConfig } from "drizzle-kit";
-import { resolveConfiguredDataDir, workspaceRoot } from "#/config/loadEnv.js";
+import { resolveConfiguredDataDir, workspaceRoot } from "@/config/loadEnv";
 
 const configuredDataDir = process.env.CLIPARR_DATA_DIR?.trim();
 const dataDir = configuredDataDir

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,16 +2,23 @@
   "name": "@cliparr/server",
   "private": true,
   "type": "module",
+  "imports": {
+    "#/*.js": {
+      "types": "./src/*.ts",
+      "cliparr-source": "./src/*.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "scripts": {
-    "dev": "node --watch-path=./src --import tsx ./src/server.ts",
+    "dev": "node --conditions=cliparr-source --watch-path=./src --import tsx ./src/server.ts",
     "build": "tsc -p tsconfig.build.json",
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm exec eslint \"src/**/*.ts\"",
     "lint:types": "tsc --noEmit",
-    "test": "node --import tsx --test src/**/*.test.ts",
-    "db:generate": "drizzle-kit generate",
-    "db:export": "drizzle-kit export --sql",
-    "preview": "NODE_ENV=production tsx src/server.ts",
+    "test": "node --conditions=cliparr-source --import tsx --test src/**/*.test.ts",
+    "db:generate": "NODE_OPTIONS=--conditions=cliparr-source drizzle-kit generate",
+    "db:export": "NODE_OPTIONS=--conditions=cliparr-source drizzle-kit export --sql",
+    "preview": "NODE_ENV=production node --conditions=cliparr-source --import tsx src/server.ts",
     "start": "NODE_ENV=production node dist/server.js",
     "clean": "rm -rf dist"
   },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,23 +2,16 @@
   "name": "@cliparr/server",
   "private": true,
   "type": "module",
-  "imports": {
-    "#/*.js": {
-      "types": "./src/*.ts",
-      "cliparr-source": "./src/*.ts",
-      "default": "./dist/*.js"
-    }
-  },
   "scripts": {
-    "dev": "node --conditions=cliparr-source --watch-path=./src --import tsx ./src/server.ts",
-    "build": "tsc -p tsconfig.build.json",
+    "dev": "node --watch-path=./src --import tsx ./src/server.ts",
+    "build": "tsdown",
     "lint": "pnpm lint:eslint && pnpm lint:types",
     "lint:eslint": "pnpm exec eslint \"src/**/*.ts\"",
     "lint:types": "tsc --noEmit",
-    "test": "node --conditions=cliparr-source --import tsx --test src/**/*.test.ts",
-    "db:generate": "NODE_OPTIONS=--conditions=cliparr-source drizzle-kit generate",
-    "db:export": "NODE_OPTIONS=--conditions=cliparr-source drizzle-kit export --sql",
-    "preview": "NODE_ENV=production node --conditions=cliparr-source --import tsx src/server.ts",
+    "test": "node --import tsx --test src/**/*.test.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:export": "drizzle-kit export --sql",
+    "preview": "NODE_ENV=production node --import tsx src/server.ts",
     "start": "NODE_ENV=production node dist/server.js",
     "clean": "rm -rf dist"
   },
@@ -33,6 +26,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.9.1",
     "drizzle-kit": "1.0.0-rc.4-273829f",
+    "tsdown": "^0.22.1",
     "tsx": "^4.22.3",
     "typescript": "~6.0.3"
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,15 +1,15 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import { CLIPARR_VERSION } from "./config/version.js";
-import { checkDatabaseHealth, initializeDatabase } from "./db/database.js";
-import { errorHandler, notFoundHandler } from "./http/errors.js";
-import { requestOriginIsPotentiallyTrustworthy } from "./http/requestOrigin.js";
-import { configureLogging, requestLoggingMiddleware } from "./logging.js";
-import { mediaRouter } from "./routes/media.js";
-import { providersRouter } from "./routes/providers.js";
-import { sessionRouter } from "./routes/session.js";
-import { sourcesRouter } from "./routes/sources.js";
+import { CLIPARR_VERSION } from "#/config/version.js";
+import { checkDatabaseHealth, initializeDatabase } from "#/db/database.js";
+import { errorHandler, notFoundHandler } from "#/http/errors.js";
+import { requestOriginIsPotentiallyTrustworthy } from "#/http/requestOrigin.js";
+import { configureLogging, requestLoggingMiddleware } from "#/logging.js";
+import { mediaRouter } from "#/routes/media.js";
+import { providersRouter } from "#/routes/providers.js";
+import { sessionRouter } from "#/routes/session.js";
+import { sourcesRouter } from "#/routes/sources.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,15 +1,15 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import { CLIPARR_VERSION } from "#/config/version.js";
-import { checkDatabaseHealth, initializeDatabase } from "#/db/database.js";
-import { errorHandler, notFoundHandler } from "#/http/errors.js";
-import { requestOriginIsPotentiallyTrustworthy } from "#/http/requestOrigin.js";
-import { configureLogging, requestLoggingMiddleware } from "#/logging.js";
-import { mediaRouter } from "#/routes/media.js";
-import { providersRouter } from "#/routes/providers.js";
-import { sessionRouter } from "#/routes/session.js";
-import { sourcesRouter } from "#/routes/sources.js";
+import { CLIPARR_VERSION } from "@/config/version";
+import { checkDatabaseHealth, initializeDatabase } from "@/db/database";
+import { errorHandler, notFoundHandler } from "@/http/errors";
+import { requestOriginIsPotentiallyTrustworthy } from "@/http/requestOrigin";
+import { configureLogging, requestLoggingMiddleware } from "@/logging";
+import { mediaRouter } from "@/routes/media";
+import { providersRouter } from "@/routes/providers";
+import { sessionRouter } from "@/routes/session";
+import { sourcesRouter } from "@/routes/sources";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");

--- a/apps/server/src/config/loadEnv.ts
+++ b/apps/server/src/config/loadEnv.ts
@@ -3,12 +3,38 @@ import path from "path";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const initialCliparrDataDir = process.env.CLIPARR_DATA_DIR;
 const initialEnvKeys = new Set(Object.keys(process.env));
 let configuredDataDirBaseDir: string | undefined;
 
-export const workspaceRoot = path.resolve(__dirname, "../../../..");
+function findAncestorWith(startDir: string, entryName: string) {
+  let currentDir = path.resolve(startDir);
+
+  while (true) {
+    if (fs.existsSync(path.join(currentDir, entryName))) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+export const serverRoot =
+  findAncestorWith(moduleDir, "drizzle") ??
+  findAncestorWith(process.cwd(), "drizzle") ??
+  path.resolve(moduleDir, "..");
+
+export const workspaceRoot =
+  findAncestorWith(moduleDir, "pnpm-workspace.yaml") ??
+  findAncestorWith(process.cwd(), "pnpm-workspace.yaml") ??
+  path.resolve(serverRoot, "../..");
+
 const envPaths = [
   path.join(workspaceRoot, ".env"),
   path.join(process.cwd(), ".env"),

--- a/apps/server/src/config/version.test.ts
+++ b/apps/server/src/config/version.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import {
   resolveCliparrClientVersion,
   resolveCliparrVersion,
-} from "./version.js";
+} from "#/config/version.js";
 
 void test("uses CI build identity exactly as provided", () => {
   assert.equal(

--- a/apps/server/src/config/version.test.ts
+++ b/apps/server/src/config/version.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import {
   resolveCliparrClientVersion,
   resolveCliparrVersion,
-} from "#/config/version.js";
+} from "@/config/version";
 
 void test("uses CI build identity exactly as provided", () => {
   assert.equal(

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -1,22 +1,22 @@
 import fs from "fs";
 import path from "path";
 import { DatabaseSync } from "node:sqlite";
-import { fileURLToPath } from "url";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import { logErrorFields } from "@cliparr/shared/logging";
-import { prepareDatabaseForMigrations } from "#/db/migrationState.js";
-import * as schema from "#/db/schema.js";
-import { resolveConfiguredDataDir, workspaceRoot } from "#/config/loadEnv.js";
-import { getServerLogger } from "#/logging.js";
-import { assertAppKeyConfigured } from "#/security/secrets.js";
+import { prepareDatabaseForMigrations } from "@/db/migrationState";
+import * as schema from "@/db/schema";
+import {
+  resolveConfiguredDataDir,
+  serverRoot,
+  workspaceRoot,
+} from "@/config/loadEnv";
+import { getServerLogger } from "@/logging";
+import { assertAppKeyConfigured } from "@/security/secrets";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
 const DEFAULT_DEVELOPMENT_DATA_DIR = ".cliparr-data";
-const MIGRATIONS_FOLDER = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../drizzle",
-);
+const MIGRATIONS_FOLDER = path.join(serverRoot, "drizzle");
 
 type CliparrDatabase = NodeSQLiteDatabase<typeof schema>;
 

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -5,11 +5,11 @@ import { fileURLToPath } from "url";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import { logErrorFields } from "@cliparr/shared/logging";
-import { prepareDatabaseForMigrations } from "./migrationState.js";
-import * as schema from "./schema.js";
-import { resolveConfiguredDataDir, workspaceRoot } from "../config/loadEnv.js";
-import { getServerLogger } from "../logging.js";
-import { assertAppKeyConfigured } from "../security/secrets.js";
+import { prepareDatabaseForMigrations } from "#/db/migrationState.js";
+import * as schema from "#/db/schema.js";
+import { resolveConfiguredDataDir, workspaceRoot } from "#/config/loadEnv.js";
+import { getServerLogger } from "#/logging.js";
+import { assertAppKeyConfigured } from "#/security/secrets.js";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
 const DEFAULT_DEVELOPMENT_DATA_DIR = ".cliparr-data";

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "crypto";
 import { and, asc, eq, type SQL } from "drizzle-orm";
-import { getDatabase } from "./database.js";
-import { mediaSources, type MediaSourceRow } from "./schema.js";
-import { currentTimestampSql } from "./timestamps.js";
-import { decryptJsonSecrets, encryptJsonSecrets } from "../security/secrets.js";
+import { getDatabase } from "#/db/database.js";
+import { mediaSources, type MediaSourceRow } from "#/db/schema.js";
+import { currentTimestampSql } from "#/db/timestamps.js";
+import { decryptJsonSecrets, encryptJsonSecrets } from "#/security/secrets.js";
 
 export interface MediaSource {
   id: string;

--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "crypto";
 import { and, asc, eq, type SQL } from "drizzle-orm";
-import { getDatabase } from "#/db/database.js";
-import { mediaSources, type MediaSourceRow } from "#/db/schema.js";
-import { currentTimestampSql } from "#/db/timestamps.js";
-import { decryptJsonSecrets, encryptJsonSecrets } from "#/security/secrets.js";
+import { getDatabase } from "@/db/database";
+import { mediaSources, type MediaSourceRow } from "@/db/schema";
+import { currentTimestampSql } from "@/db/timestamps";
+import { decryptJsonSecrets, encryptJsonSecrets } from "@/security/secrets";
 
 export interface MediaSource {
   id: string;

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "crypto";
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
-import { getDatabase } from "./database.js";
-import { providerAccounts, type ProviderAccountRow } from "./schema.js";
-import { currentTimestampSql } from "./timestamps.js";
+import { getDatabase } from "#/db/database.js";
+import { providerAccounts, type ProviderAccountRow } from "#/db/schema.js";
+import { currentTimestampSql } from "#/db/timestamps.js";
 import {
   decryptSecret,
   encryptSecret,
   hashSecret,
-} from "../security/secrets.js";
+} from "#/security/secrets.js";
 
 export interface ProviderAccount {
   id: string;

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -1,13 +1,9 @@
 import { randomUUID } from "crypto";
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
-import { getDatabase } from "#/db/database.js";
-import { providerAccounts, type ProviderAccountRow } from "#/db/schema.js";
-import { currentTimestampSql } from "#/db/timestamps.js";
-import {
-  decryptSecret,
-  encryptSecret,
-  hashSecret,
-} from "#/security/secrets.js";
+import { getDatabase } from "@/db/database";
+import { providerAccounts, type ProviderAccountRow } from "@/db/schema";
+import { currentTimestampSql } from "@/db/timestamps";
+import { decryptSecret, encryptSecret, hashSecret } from "@/security/secrets";
 
 export interface ProviderAccount {
   id: string;

--- a/apps/server/src/db/providerPersistence.test.ts
+++ b/apps/server/src/db/providerPersistence.test.ts
@@ -3,14 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase, initializeDatabase } from "#/db/database.js";
+import { closeDatabase, initializeDatabase } from "@/db/database";
 import {
   getMediaSourceByProviderExternalId,
   listMediaSources,
   updateMediaSource,
-} from "#/db/mediaSourcesRepository.js";
-import { persistProviderAuth } from "#/db/providerPersistence.js";
-import { PLEX_BASE_URL_MODE_MANUAL } from "#/providers/plex/connectionState.js";
+} from "@/db/mediaSourcesRepository";
+import { persistProviderAuth } from "@/db/providerPersistence";
+import { PLEX_BASE_URL_MODE_MANUAL } from "@/providers/plex/connectionState";
 
 const TEST_APP_KEY = "provider-persistence-test-key-with-32-characters";
 

--- a/apps/server/src/db/providerPersistence.test.ts
+++ b/apps/server/src/db/providerPersistence.test.ts
@@ -3,14 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase, initializeDatabase } from "./database.js";
+import { closeDatabase, initializeDatabase } from "#/db/database.js";
 import {
   getMediaSourceByProviderExternalId,
   listMediaSources,
   updateMediaSource,
-} from "./mediaSourcesRepository.js";
-import { persistProviderAuth } from "./providerPersistence.js";
-import { PLEX_BASE_URL_MODE_MANUAL } from "../providers/plex/connectionState.js";
+} from "#/db/mediaSourcesRepository.js";
+import { persistProviderAuth } from "#/db/providerPersistence.js";
+import { PLEX_BASE_URL_MODE_MANUAL } from "#/providers/plex/connectionState.js";
 
 const TEST_APP_KEY = "provider-persistence-test-key-with-32-characters";
 

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -1,22 +1,22 @@
-import { ApiError } from "#/http/errors.js";
+import { ApiError } from "@/http/errors";
 import type {
   ProviderConnection,
   ProviderDefinition,
   ProviderResource,
-} from "#/providers/types.js";
+} from "@/providers/types";
 import {
   getMediaSourceByProviderExternalId,
   listMediaSources,
   updateMediaSource,
   upsertMediaSource,
-} from "#/db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
+} from "@/db/mediaSourcesRepository";
+import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
 import {
   plexBaseUrlMode,
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   withPlexBaseUrlMode,
-} from "#/providers/plex/connectionState.js";
+} from "@/providers/plex/connectionState";
 
 function connectionRank(connection: ProviderConnection) {
   if (connection.local && !connection.relay) {

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -1,22 +1,22 @@
-import { ApiError } from "../http/errors.js";
+import { ApiError } from "#/http/errors.js";
 import type {
   ProviderConnection,
   ProviderDefinition,
   ProviderResource,
-} from "../providers/types.js";
+} from "#/providers/types.js";
 import {
   getMediaSourceByProviderExternalId,
   listMediaSources,
   updateMediaSource,
   upsertMediaSource,
-} from "./mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "./providerAccountsRepository.js";
+} from "#/db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
 import {
   plexBaseUrlMode,
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   withPlexBaseUrlMode,
-} from "../providers/plex/connectionState.js";
+} from "#/providers/plex/connectionState.js";
 
 function connectionRank(connection: ProviderConnection) {
   if (connection.local && !connection.relay) {

--- a/apps/server/src/db/rememberedProviderSessionsRepository.ts
+++ b/apps/server/src/db/rememberedProviderSessionsRepository.ts
@@ -1,12 +1,12 @@
 import { randomBytes, randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
-import { getDatabase } from "./database.js";
+import { getDatabase } from "#/db/database.js";
 import {
   rememberedProviderSessions,
   type RememberedProviderSessionRow,
-} from "./schema.js";
-import { currentTimestampSql } from "./timestamps.js";
-import { hashSecret } from "../security/secrets.js";
+} from "#/db/schema.js";
+import { currentTimestampSql } from "#/db/timestamps.js";
+import { hashSecret } from "#/security/secrets.js";
 
 export const REMEMBERED_PROVIDER_SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 365;
 

--- a/apps/server/src/db/rememberedProviderSessionsRepository.ts
+++ b/apps/server/src/db/rememberedProviderSessionsRepository.ts
@@ -1,12 +1,12 @@
 import { randomBytes, randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
-import { getDatabase } from "#/db/database.js";
+import { getDatabase } from "@/db/database";
 import {
   rememberedProviderSessions,
   type RememberedProviderSessionRow,
-} from "#/db/schema.js";
-import { currentTimestampSql } from "#/db/timestamps.js";
-import { hashSecret } from "#/security/secrets.js";
+} from "@/db/schema";
+import { currentTimestampSql } from "@/db/timestamps";
+import { hashSecret } from "@/security/secrets";
 
 export const REMEMBERED_PROVIDER_SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 365;
 

--- a/apps/server/src/http/errors.ts
+++ b/apps/server/src/http/errors.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { errorWithError, getServerLogger } from "#/logging.js";
+import { errorWithError, getServerLogger } from "@/logging";
 
 const logger = getServerLogger(["http", "error"]);
 

--- a/apps/server/src/http/errors.ts
+++ b/apps/server/src/http/errors.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { errorWithError, getServerLogger } from "../logging.js";
+import { errorWithError, getServerLogger } from "#/logging.js";
 
 const logger = getServerLogger(["http", "error"]);
 

--- a/apps/server/src/http/requestOrigin.test.ts
+++ b/apps/server/src/http/requestOrigin.test.ts
@@ -4,11 +4,11 @@ import type { Request } from "express";
 import {
   getRequestRouteUrl,
   requestOriginIsPotentiallyTrustworthy,
-} from "#/http/requestOrigin.js";
+} from "@/http/requestOrigin";
 import {
   getSessionCookieClearOptions,
   getSessionCookieOptions,
-} from "#/session/store.js";
+} from "@/session/store";
 
 function makeRequest(
   secure: boolean,

--- a/apps/server/src/http/requestOrigin.test.ts
+++ b/apps/server/src/http/requestOrigin.test.ts
@@ -4,11 +4,11 @@ import type { Request } from "express";
 import {
   getRequestRouteUrl,
   requestOriginIsPotentiallyTrustworthy,
-} from "./requestOrigin.js";
+} from "#/http/requestOrigin.js";
 import {
   getSessionCookieClearOptions,
   getSessionCookieOptions,
-} from "../session/store.js";
+} from "#/session/store.js";
 
 function makeRequest(
   secure: boolean,

--- a/apps/server/src/http/requestOrigin.ts
+++ b/apps/server/src/http/requestOrigin.ts
@@ -1,6 +1,6 @@
 import { isIP } from "node:net";
 import type { Request } from "express";
-import { ApiError } from "./errors.js";
+import { ApiError } from "#/http/errors.js";
 
 type OriginAwareRequest = Pick<Request, "get" | "hostname" | "secure">;
 

--- a/apps/server/src/http/requestOrigin.ts
+++ b/apps/server/src/http/requestOrigin.ts
@@ -1,6 +1,6 @@
 import { isIP } from "node:net";
 import type { Request } from "express";
-import { ApiError } from "#/http/errors.js";
+import { ApiError } from "@/http/errors";
 
 type OriginAwareRequest = Pick<Request, "get" | "hostname" | "secure">;
 

--- a/apps/server/src/providers/jellyfin/auth.ts
+++ b/apps/server/src/providers/jellyfin/auth.ts
@@ -1,7 +1,7 @@
-import type { MediaSource } from "../../db/mediaSourcesRepository.js";
-import { ApiError } from "../../http/errors.js";
-import type { ProviderResource } from "../types.js";
-import { stringValue } from "../shared/utils.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import { ApiError } from "#/http/errors.js";
+import type { ProviderResource } from "#/providers/types.js";
+import { stringValue } from "#/providers/shared/utils.js";
 import {
   connectionInfo,
   fetchCurrentUser,
@@ -15,7 +15,7 @@ import {
   sourceContext,
   type JellyfinAuthenticationResult,
   type JellyfinPublicSystemInfo,
-} from "./shared.js";
+} from "#/providers/jellyfin/shared.js";
 
 async function parseCredentialsInput(body: unknown) {
   if (!body || typeof body !== "object" || Array.isArray(body)) {

--- a/apps/server/src/providers/jellyfin/auth.ts
+++ b/apps/server/src/providers/jellyfin/auth.ts
@@ -1,7 +1,7 @@
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import { ApiError } from "#/http/errors.js";
-import type { ProviderResource } from "#/providers/types.js";
-import { stringValue } from "#/providers/shared/utils.js";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import { ApiError } from "@/http/errors";
+import type { ProviderResource } from "@/providers/types";
+import { stringValue } from "@/providers/shared/utils";
 import {
   connectionInfo,
   fetchCurrentUser,
@@ -15,7 +15,7 @@ import {
   sourceContext,
   type JellyfinAuthenticationResult,
   type JellyfinPublicSystemInfo,
-} from "#/providers/jellyfin/shared.js";
+} from "@/providers/jellyfin/shared";
 
 async function parseCredentialsInput(body: unknown) {
   if (!body || typeof body !== "object" || Array.isArray(body)) {

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -4,17 +4,17 @@ import {
   logEventFields,
   sanitizeUrlForLog,
 } from "@cliparr/shared/logging";
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import { ApiError } from "#/http/errors.js";
-import { getServerLogger } from "#/logging.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import { ApiError } from "@/http/errors";
+import { getServerLogger } from "@/logging";
+import type { ProviderSessionRecord } from "@/session/store";
 import type {
   CurrentlyPlayingEntry,
   MediaExportMetadata,
   PlaybackAudioSelection,
   PlaybackSubtitleSelection,
   PlaybackSubtitleTrack,
-} from "#/providers/types.js";
+} from "@/providers/types";
 import {
   createProviderMediaHandle,
   fetchMediaHandleRequest,
@@ -24,12 +24,12 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "#/providers/shared/mediaProxy.js";
+} from "@/providers/shared/mediaProxy";
 import {
   isTextSubtitleCodec,
   normalizeSubtitleCodec,
   subtitleContentFormat,
-} from "#/providers/shared/subtitles.js";
+} from "@/providers/shared/subtitles";
 import {
   asArray,
   buildEpisodeSourceTitle,
@@ -37,7 +37,7 @@ import {
   numberValue,
   stringValue,
   uniqueStrings,
-} from "#/providers/shared/utils.js";
+} from "@/providers/shared/utils";
 import {
   booleanValue,
   fetchItem,
@@ -51,7 +51,7 @@ import {
   type JellyfinPlaybackInfo,
   type JellyfinSessionInfo,
   type JellyfinSourceContext,
-} from "#/providers/jellyfin/shared.js";
+} from "@/providers/jellyfin/shared";
 
 const logger = getServerLogger(["provider", "jellyfin", "playback"]);
 const HD_ARTWORK_SIZE = 1920;

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -4,17 +4,17 @@ import {
   logEventFields,
   sanitizeUrlForLog,
 } from "@cliparr/shared/logging";
-import type { MediaSource } from "../../db/mediaSourcesRepository.js";
-import { ApiError } from "../../http/errors.js";
-import { getServerLogger } from "../../logging.js";
-import type { ProviderSessionRecord } from "../../session/store.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import { ApiError } from "#/http/errors.js";
+import { getServerLogger } from "#/logging.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
 import type {
   CurrentlyPlayingEntry,
   MediaExportMetadata,
   PlaybackAudioSelection,
   PlaybackSubtitleSelection,
   PlaybackSubtitleTrack,
-} from "../types.js";
+} from "#/providers/types.js";
 import {
   createProviderMediaHandle,
   fetchMediaHandleRequest,
@@ -24,12 +24,12 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "../shared/mediaProxy.js";
+} from "#/providers/shared/mediaProxy.js";
 import {
   isTextSubtitleCodec,
   normalizeSubtitleCodec,
   subtitleContentFormat,
-} from "../shared/subtitles.js";
+} from "#/providers/shared/subtitles.js";
 import {
   asArray,
   buildEpisodeSourceTitle,
@@ -37,7 +37,7 @@ import {
   numberValue,
   stringValue,
   uniqueStrings,
-} from "../shared/utils.js";
+} from "#/providers/shared/utils.js";
 import {
   booleanValue,
   fetchItem,
@@ -51,7 +51,7 @@ import {
   type JellyfinPlaybackInfo,
   type JellyfinSessionInfo,
   type JellyfinSourceContext,
-} from "./shared.js";
+} from "#/providers/jellyfin/shared.js";
 
 const logger = getServerLogger(["provider", "jellyfin", "playback"]);
 const HD_ARTWORK_SIZE = 1920;

--- a/apps/server/src/providers/jellyfin/provider.ts
+++ b/apps/server/src/providers/jellyfin/provider.ts
@@ -1,13 +1,13 @@
-import type { ProviderImplementation } from "#/providers/types.js";
+import type { ProviderImplementation } from "@/providers/types";
 import {
   authenticateWithCredentials,
   checkSource,
-} from "#/providers/jellyfin/auth.js";
+} from "@/providers/jellyfin/auth";
 import {
   listCurrentlyPlaying,
   proxyMedia,
   sourceSupportsCurrentlyPlaying,
-} from "#/providers/jellyfin/playback.js";
+} from "@/providers/jellyfin/playback";
 
 export const jellyfinProvider: ProviderImplementation = {
   definition: {

--- a/apps/server/src/providers/jellyfin/provider.ts
+++ b/apps/server/src/providers/jellyfin/provider.ts
@@ -1,10 +1,13 @@
-import type { ProviderImplementation } from "../types.js";
-import { authenticateWithCredentials, checkSource } from "./auth.js";
+import type { ProviderImplementation } from "#/providers/types.js";
+import {
+  authenticateWithCredentials,
+  checkSource,
+} from "#/providers/jellyfin/auth.js";
 import {
   listCurrentlyPlaying,
   proxyMedia,
   sourceSupportsCurrentlyPlaying,
-} from "./playback.js";
+} from "#/providers/jellyfin/playback.js";
 
 export const jellyfinProvider: ProviderImplementation = {
   definition: {

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -1,15 +1,15 @@
 import { createHash, randomUUID } from "crypto";
 import { lookup } from "dns/promises";
 import { isIP } from "net";
-import { CLIPARR_CLIENT_VERSION } from "#/config/version.js";
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import { ApiError } from "#/http/errors.js";
+import { CLIPARR_CLIENT_VERSION } from "@/config/version";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import { ApiError } from "@/http/errors";
 import {
   errorMessage,
   numberValue,
   stringValue,
   uniqueStrings,
-} from "#/providers/shared/utils.js";
+} from "@/providers/shared/utils";
 
 const JELLYFIN_PRODUCT = "Cliparr";
 const JELLYFIN_DEVICE_NAME = "Cliparr";

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -1,15 +1,15 @@
 import { createHash, randomUUID } from "crypto";
 import { lookup } from "dns/promises";
 import { isIP } from "net";
-import { CLIPARR_CLIENT_VERSION } from "../../config/version.js";
-import type { MediaSource } from "../../db/mediaSourcesRepository.js";
-import { ApiError } from "../../http/errors.js";
+import { CLIPARR_CLIENT_VERSION } from "#/config/version.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import { ApiError } from "#/http/errors.js";
 import {
   errorMessage,
   numberValue,
   stringValue,
   uniqueStrings,
-} from "../shared/utils.js";
+} from "#/providers/shared/utils.js";
 
 const JELLYFIN_PRODUCT = "Cliparr";
 const JELLYFIN_DEVICE_NAME = "Cliparr";

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { Request, Response } from "express";
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import type { ProviderSessionRecord } from "@/session/store";
 import {
   buildPreviewPath,
   deriveSelectedSubtitleTrack,
@@ -10,8 +10,8 @@ import {
   listCurrentlyPlaying,
   playheadSecondsFromPositionTicks,
   proxyMedia,
-} from "#/providers/jellyfin/playback.js";
-import type { JellyfinSourceContext } from "#/providers/jellyfin/shared.js";
+} from "@/providers/jellyfin/playback";
+import type { JellyfinSourceContext } from "@/providers/jellyfin/shared";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { Request, Response } from "express";
-import type { MediaSource } from "../db/mediaSourcesRepository.js";
-import type { ProviderSessionRecord } from "../session/store.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
 import {
   buildPreviewPath,
   deriveSelectedSubtitleTrack,
@@ -10,8 +10,8 @@ import {
   listCurrentlyPlaying,
   playheadSecondsFromPositionTicks,
   proxyMedia,
-} from "./jellyfin/playback.js";
-import type { JellyfinSourceContext } from "./jellyfin/shared.js";
+} from "#/providers/jellyfin/playback.js";
+import type { JellyfinSourceContext } from "#/providers/jellyfin/shared.js";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { Response } from "express";
-import { ApiError } from "../http/errors.js";
-import type { ProviderSessionRecord } from "../session/store.js";
-import type { MediaHandle } from "./types.js";
+import { ApiError } from "#/http/errors.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
+import type { MediaHandle } from "#/providers/types.js";
 import {
   assertAllowedMediaHandleRequestUrl,
   fetchMediaHandleRequest,
@@ -13,7 +13,7 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "./shared/mediaProxy.js";
+} from "#/providers/shared/mediaProxy.js";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { Response } from "express";
-import { ApiError } from "#/http/errors.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
-import type { MediaHandle } from "#/providers/types.js";
+import { ApiError } from "@/http/errors";
+import type { ProviderSessionRecord } from "@/session/store";
+import type { MediaHandle } from "@/providers/types";
 import {
   assertAllowedMediaHandleRequestUrl,
   fetchMediaHandleRequest,
@@ -13,7 +13,7 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "#/providers/shared/mediaProxy.js";
+} from "@/providers/shared/mediaProxy";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
-import { ApiError } from "#/http/errors.js";
+import { ApiError } from "@/http/errors";
 import {
   AUTH_TTL_MS,
   MAX_PENDING_AUTH_REQUESTS,
@@ -10,7 +10,7 @@ import {
   requirePlexServerResources,
   type PlexAuthRequest,
   type PlexResourceResponse,
-} from "#/providers/plex/shared.js";
+} from "@/providers/plex/shared";
 
 const authRequests = new Map<string, PlexAuthRequest>();
 const AUTH_POLL_TOKEN_BYTES = 32;

--- a/apps/server/src/providers/plex/auth.ts
+++ b/apps/server/src/providers/plex/auth.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
-import { ApiError } from "../../http/errors.js";
+import { ApiError } from "#/http/errors.js";
 import {
   AUTH_TTL_MS,
   MAX_PENDING_AUTH_REQUESTS,
@@ -10,7 +10,7 @@ import {
   requirePlexServerResources,
   type PlexAuthRequest,
   type PlexResourceResponse,
-} from "./shared.js";
+} from "#/providers/plex/shared.js";
 
 const authRequests = new Map<string, PlexAuthRequest>();
 const AUTH_POLL_TOKEN_BYTES = 32;

--- a/apps/server/src/providers/plex/connectionState.ts
+++ b/apps/server/src/providers/plex/connectionState.ts
@@ -1,4 +1,4 @@
-import { stringValue } from "../shared/utils.js";
+import { stringValue } from "#/providers/shared/utils.js";
 
 export const PLEX_BASE_URL_MODE_AUTO = "auto";
 export const PLEX_BASE_URL_MODE_MANUAL = "manual";

--- a/apps/server/src/providers/plex/connectionState.ts
+++ b/apps/server/src/providers/plex/connectionState.ts
@@ -1,4 +1,4 @@
-import { stringValue } from "#/providers/shared/utils.js";
+import { stringValue } from "@/providers/shared/utils";
 
 export const PLEX_BASE_URL_MODE_AUTO = "auto";
 export const PLEX_BASE_URL_MODE_MANUAL = "manual";

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -8,10 +8,10 @@ import {
 import {
   updateMediaSource,
   type MediaSource,
-} from "../../db/mediaSourcesRepository.js";
-import { ApiError } from "../../http/errors.js";
-import { getServerLogger } from "../../logging.js";
-import type { ProviderSessionRecord } from "../../session/store.js";
+} from "#/db/mediaSourcesRepository.js";
+import { ApiError } from "#/http/errors.js";
+import { getServerLogger } from "#/logging.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
 import type {
   CurrentlyPlayingEntry,
   MediaExportMetadata,
@@ -20,7 +20,7 @@ import type {
   PlaybackSubtitleTrack,
   ProviderConnection,
   ProviderResource,
-} from "../types.js";
+} from "#/providers/types.js";
 import {
   createProviderMediaHandle,
   fetchMediaHandleRequest,
@@ -29,14 +29,14 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "../shared/mediaProxy.js";
+} from "#/providers/shared/mediaProxy.js";
 import {
   booleanFlag,
   isTextSubtitleCodec,
   normalizeSubtitleCodec,
   subtitleContentFormat,
   subtitleFileExtension,
-} from "../shared/subtitles.js";
+} from "#/providers/shared/subtitles.js";
 import {
   asArray,
   buildEpisodeSourceTitle,
@@ -44,7 +44,7 @@ import {
   numberValue,
   stringValue,
   uniqueStrings,
-} from "../shared/utils.js";
+} from "#/providers/shared/utils.js";
 import {
   buildSourceContext,
   candidateConnections,
@@ -54,13 +54,13 @@ import {
   sourceResource,
   unreachableConnectionMessage,
   type PlexSourceContext,
-} from "./shared.js";
+} from "#/providers/plex/shared.js";
 import {
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   type PlexBaseUrlMode,
   withPlexBaseUrlMode,
-} from "./connectionState.js";
+} from "#/providers/plex/connectionState.js";
 
 const logger = getServerLogger(["provider", "plex", "playback"]);
 const HD_ARTWORK_SIZE = 1920;

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -8,10 +8,10 @@ import {
 import {
   updateMediaSource,
   type MediaSource,
-} from "#/db/mediaSourcesRepository.js";
-import { ApiError } from "#/http/errors.js";
-import { getServerLogger } from "#/logging.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
+} from "@/db/mediaSourcesRepository";
+import { ApiError } from "@/http/errors";
+import { getServerLogger } from "@/logging";
+import type { ProviderSessionRecord } from "@/session/store";
 import type {
   CurrentlyPlayingEntry,
   MediaExportMetadata,
@@ -20,7 +20,7 @@ import type {
   PlaybackSubtitleTrack,
   ProviderConnection,
   ProviderResource,
-} from "#/providers/types.js";
+} from "@/providers/types";
 import {
   createProviderMediaHandle,
   fetchMediaHandleRequest,
@@ -29,14 +29,14 @@ import {
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
   shouldForwardMediaRange,
-} from "#/providers/shared/mediaProxy.js";
+} from "@/providers/shared/mediaProxy";
 import {
   booleanFlag,
   isTextSubtitleCodec,
   normalizeSubtitleCodec,
   subtitleContentFormat,
   subtitleFileExtension,
-} from "#/providers/shared/subtitles.js";
+} from "@/providers/shared/subtitles";
 import {
   asArray,
   buildEpisodeSourceTitle,
@@ -44,7 +44,7 @@ import {
   numberValue,
   stringValue,
   uniqueStrings,
-} from "#/providers/shared/utils.js";
+} from "@/providers/shared/utils";
 import {
   buildSourceContext,
   candidateConnections,
@@ -54,13 +54,13 @@ import {
   sourceResource,
   unreachableConnectionMessage,
   type PlexSourceContext,
-} from "#/providers/plex/shared.js";
+} from "@/providers/plex/shared";
 import {
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   type PlexBaseUrlMode,
   withPlexBaseUrlMode,
-} from "#/providers/plex/connectionState.js";
+} from "@/providers/plex/connectionState";
 
 const logger = getServerLogger(["provider", "plex", "playback"]);
 const HD_ARTWORK_SIZE = 1920;

--- a/apps/server/src/providers/plex/provider.ts
+++ b/apps/server/src/providers/plex/provider.ts
@@ -1,16 +1,16 @@
-import { ApiError } from "#/http/errors.js";
-import type { ProviderImplementation } from "#/providers/types.js";
-import { pollAuth, startAuth } from "#/providers/plex/auth.js";
+import { ApiError } from "@/http/errors";
+import type { ProviderImplementation } from "@/providers/types";
+import { pollAuth, startAuth } from "@/providers/plex/auth";
 import {
   PLEX_BASE_URL_MODE_AUTO,
   withPlexBaseUrlMode,
-} from "#/providers/plex/connectionState.js";
-import { listCurrentlyPlaying, proxyMedia } from "#/providers/plex/playback.js";
+} from "@/providers/plex/connectionState";
+import { listCurrentlyPlaying, proxyMedia } from "@/providers/plex/playback";
 import {
   selectReachableConnection,
   sourceResource,
   sourceSupportsCurrentlyPlaying,
-} from "#/providers/plex/shared.js";
+} from "@/providers/plex/shared";
 
 async function checkSource(
   source: Parameters<ProviderImplementation["checkSource"]>[0],

--- a/apps/server/src/providers/plex/provider.ts
+++ b/apps/server/src/providers/plex/provider.ts
@@ -1,16 +1,16 @@
-import { ApiError } from "../../http/errors.js";
-import type { ProviderImplementation } from "../types.js";
-import { pollAuth, startAuth } from "./auth.js";
+import { ApiError } from "#/http/errors.js";
+import type { ProviderImplementation } from "#/providers/types.js";
+import { pollAuth, startAuth } from "#/providers/plex/auth.js";
 import {
   PLEX_BASE_URL_MODE_AUTO,
   withPlexBaseUrlMode,
-} from "./connectionState.js";
-import { listCurrentlyPlaying, proxyMedia } from "./playback.js";
+} from "#/providers/plex/connectionState.js";
+import { listCurrentlyPlaying, proxyMedia } from "#/providers/plex/playback.js";
 import {
   selectReachableConnection,
   sourceResource,
   sourceSupportsCurrentlyPlaying,
-} from "./shared.js";
+} from "#/providers/plex/shared.js";
 
 async function checkSource(
   source: Parameters<ProviderImplementation["checkSource"]>[0],

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -1,19 +1,19 @@
 import { randomUUID } from "crypto";
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import { ApiError } from "#/http/errors.js";
-import { normalizeMediaPath } from "#/providers/shared/mediaProxy.js";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import { ApiError } from "@/http/errors";
+import { normalizeMediaPath } from "@/providers/shared/mediaProxy";
 import {
   errorMessage,
   numberValue,
   stringValue,
-} from "#/providers/shared/utils.js";
-import type { ProviderResource } from "#/providers/types.js";
+} from "@/providers/shared/utils";
+import type { ProviderResource } from "@/providers/types";
 import {
   plexBaseUrlMode,
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   type PlexBaseUrlMode,
-} from "#/providers/plex/connectionState.js";
+} from "@/providers/plex/connectionState";
 
 export const PLEX_PRODUCT = "Cliparr";
 export const PLEX_CLIENT_IDENTIFIER =

--- a/apps/server/src/providers/plex/shared.ts
+++ b/apps/server/src/providers/plex/shared.ts
@@ -1,15 +1,19 @@
 import { randomUUID } from "crypto";
-import type { MediaSource } from "../../db/mediaSourcesRepository.js";
-import { ApiError } from "../../http/errors.js";
-import { normalizeMediaPath } from "../shared/mediaProxy.js";
-import { errorMessage, numberValue, stringValue } from "../shared/utils.js";
-import type { ProviderResource } from "../types.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import { ApiError } from "#/http/errors.js";
+import { normalizeMediaPath } from "#/providers/shared/mediaProxy.js";
+import {
+  errorMessage,
+  numberValue,
+  stringValue,
+} from "#/providers/shared/utils.js";
+import type { ProviderResource } from "#/providers/types.js";
 import {
   plexBaseUrlMode,
   PLEX_BASE_URL_MODE_AUTO,
   PLEX_BASE_URL_MODE_MANUAL,
   type PlexBaseUrlMode,
-} from "./connectionState.js";
+} from "#/providers/plex/connectionState.js";
 
 export const PLEX_PRODUCT = "Cliparr";
 export const PLEX_CLIENT_IDENTIFIER =

--- a/apps/server/src/providers/plexAuth.test.ts
+++ b/apps/server/src/providers/plexAuth.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ApiError } from "../http/errors.js";
-import { pollAuth, startAuth } from "./plex/auth.js";
+import { ApiError } from "#/http/errors.js";
+import { pollAuth, startAuth } from "#/providers/plex/auth.js";
 
 function jsonResponse(value: unknown) {
   return new Response(JSON.stringify(value), {

--- a/apps/server/src/providers/plexAuth.test.ts
+++ b/apps/server/src/providers/plexAuth.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ApiError } from "#/http/errors.js";
-import { pollAuth, startAuth } from "#/providers/plex/auth.js";
+import { ApiError } from "@/http/errors";
+import { pollAuth, startAuth } from "@/providers/plex/auth";
 
 function jsonResponse(value: unknown) {
   return new Response(JSON.stringify(value), {

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { ProviderSessionRecord } from "../session/store.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
 import {
   createCliparrPlexTranscodeSessionId,
   createPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
   playheadSecondsFromViewOffset,
-} from "./plex/playback.js";
-import type { PlexSourceContext } from "./plex/shared.js";
+} from "#/providers/plex/playback.js";
+import type { PlexSourceContext } from "#/providers/plex/shared.js";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { ProviderSessionRecord } from "#/session/store.js";
+import type { ProviderSessionRecord } from "@/session/store";
 import {
   createCliparrPlexTranscodeSessionId,
   createPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
   playheadSecondsFromViewOffset,
-} from "#/providers/plex/playback.js";
-import type { PlexSourceContext } from "#/providers/plex/shared.js";
+} from "@/providers/plex/playback";
+import type { PlexSourceContext } from "@/providers/plex/shared";
 
 function createSession(): ProviderSessionRecord {
   return {

--- a/apps/server/src/providers/plexShared.test.ts
+++ b/apps/server/src/providers/plexShared.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ApiError } from "../http/errors.js";
-import type { ProviderResource } from "./types.js";
+import { ApiError } from "#/http/errors.js";
+import type { ProviderResource } from "#/providers/types.js";
 import {
   normalizeResources,
   requirePlexServerResources,
-} from "./plex/shared.js";
+} from "#/providers/plex/shared.js";
 
 void test("normalizes Plex server resources when Plex flags are strings", () => {
   const resources = normalizeResources([

--- a/apps/server/src/providers/plexShared.test.ts
+++ b/apps/server/src/providers/plexShared.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ApiError } from "#/http/errors.js";
-import type { ProviderResource } from "#/providers/types.js";
+import { ApiError } from "@/http/errors";
+import type { ProviderResource } from "@/providers/types";
 import {
   normalizeResources,
   requirePlexServerResources,
-} from "#/providers/plex/shared.js";
+} from "@/providers/plex/shared";
 
 void test("normalizes Plex server resources when Plex flags are strings", () => {
   const resources = normalizeResources([

--- a/apps/server/src/providers/registry.ts
+++ b/apps/server/src/providers/registry.ts
@@ -1,6 +1,6 @@
-import type { ProviderImplementation } from "./types.js";
-import { jellyfinProvider } from "./jellyfin/provider.js";
-import { plexProvider } from "./plex/provider.js";
+import type { ProviderImplementation } from "#/providers/types.js";
+import { jellyfinProvider } from "#/providers/jellyfin/provider.js";
+import { plexProvider } from "#/providers/plex/provider.js";
 
 const providers = new Map<string, ProviderImplementation>();
 

--- a/apps/server/src/providers/registry.ts
+++ b/apps/server/src/providers/registry.ts
@@ -1,6 +1,6 @@
-import type { ProviderImplementation } from "#/providers/types.js";
-import { jellyfinProvider } from "#/providers/jellyfin/provider.js";
-import { plexProvider } from "#/providers/plex/provider.js";
+import type { ProviderImplementation } from "@/providers/types";
+import { jellyfinProvider } from "@/providers/jellyfin/provider";
+import { plexProvider } from "@/providers/plex/provider";
 
 const providers = new Map<string, ProviderImplementation>();
 

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -6,10 +6,10 @@ import { pipeline } from "stream/promises";
 import type { ReadableStream as WebReadableStream } from "stream/web";
 import type { Response } from "express";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { ApiError } from "../../http/errors.js";
-import { getServerLogger } from "../../logging.js";
-import type { ProviderSessionRecord } from "../../session/store.js";
-import type { MediaHandle } from "../types.js";
+import { ApiError } from "#/http/errors.js";
+import { getServerLogger } from "#/logging.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
+import type { MediaHandle } from "#/providers/types.js";
 
 interface MediaHandleContext {
   providerId: MediaHandle["providerId"];

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -6,10 +6,10 @@ import { pipeline } from "stream/promises";
 import type { ReadableStream as WebReadableStream } from "stream/web";
 import type { Response } from "express";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { ApiError } from "#/http/errors.js";
-import { getServerLogger } from "#/logging.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
-import type { MediaHandle } from "#/providers/types.js";
+import { ApiError } from "@/http/errors";
+import { getServerLogger } from "@/logging";
+import type { ProviderSessionRecord } from "@/session/store";
+import type { MediaHandle } from "@/providers/types";
 
 interface MediaHandleContext {
   providerId: MediaHandle["providerId"];

--- a/apps/server/src/providers/shared/subtitles.ts
+++ b/apps/server/src/providers/shared/subtitles.ts
@@ -1,4 +1,4 @@
-import { stringValue } from "./utils.js";
+import { stringValue } from "#/providers/shared/utils.js";
 
 const TEXT_SUBTITLE_CODECS = new Set([
   "ass",

--- a/apps/server/src/providers/shared/subtitles.ts
+++ b/apps/server/src/providers/shared/subtitles.ts
@@ -1,4 +1,4 @@
-import { stringValue } from "#/providers/shared/utils.js";
+import { stringValue } from "@/providers/shared/utils";
 
 const TEXT_SUBTITLE_CODECS = new Set([
   "ass",

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -9,8 +9,8 @@ import type {
   SourcePlaybackError,
   ViewerPlaybackGroup,
 } from "@cliparr/shared/providers";
-import type { MediaSource } from "#/db/mediaSourcesRepository.js";
-import type { ProviderSessionRecord } from "#/session/store.js";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+import type { ProviderSessionRecord } from "@/session/store";
 
 export type {
   MediaExportMetadata,

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -9,8 +9,8 @@ import type {
   SourcePlaybackError,
   ViewerPlaybackGroup,
 } from "@cliparr/shared/providers";
-import type { MediaSource } from "../db/mediaSourcesRepository.js";
-import type { ProviderSessionRecord } from "../session/store.js";
+import type { MediaSource } from "#/db/mediaSourcesRepository.js";
+import type { ProviderSessionRecord } from "#/session/store.js";
 
 export type {
   MediaExportMetadata,

--- a/apps/server/src/routes/media.test.ts
+++ b/apps/server/src/routes/media.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import express from "express";
-import { errorHandler } from "#/http/errors.js";
-import { mediaRouter } from "#/routes/media.js";
+import { errorHandler } from "@/http/errors";
+import { mediaRouter } from "@/routes/media";
 
 async function withMediaApp<T>(callback: (baseUrl: string) => Promise<T>) {
   const app = express();

--- a/apps/server/src/routes/media.test.ts
+++ b/apps/server/src/routes/media.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import express from "express";
-import { errorHandler } from "../http/errors.js";
-import { mediaRouter } from "./media.js";
+import { errorHandler } from "#/http/errors.js";
+import { mediaRouter } from "#/routes/media.js";
 
 async function withMediaApp<T>(callback: (baseUrl: string) => Promise<T>) {
   const app = express();

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -6,10 +6,10 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { listMediaSources } from "#/db/mediaSourcesRepository.js";
-import { ApiError, asyncHandler } from "#/http/errors.js";
-import { getServerLogger, warnWithError } from "#/logging.js";
-import { getProvider } from "#/providers/registry.js";
+import { listMediaSources } from "@/db/mediaSourcesRepository";
+import { ApiError, asyncHandler } from "@/http/errors";
+import { getServerLogger, warnWithError } from "@/logging";
+import { getProvider } from "@/providers/registry";
 import {
   assertAllowedMediaHandleRequestUrl,
   fetchMediaHandleRequest,
@@ -17,18 +17,18 @@ import {
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
   shouldForwardMediaRange,
-} from "#/providers/shared/mediaProxy.js";
+} from "@/providers/shared/mediaProxy";
 import type {
   CurrentlyPlayingEntry,
   MediaHandle,
   SourcePlaybackError,
   ViewerPlaybackGroup,
-} from "#/providers/types.js";
-import { requireAccountSession, setNoStore } from "#/session/request.js";
+} from "@/providers/types";
+import { requireAccountSession, setNoStore } from "@/session/request";
 import {
   pruneSessionMediaHandles,
   type ProviderSessionRecord,
-} from "#/session/store.js";
+} from "@/session/store";
 
 export const mediaRouter = Router();
 const mediaLogger = getServerLogger("media");

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -6,10 +6,10 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { listMediaSources } from "../db/mediaSourcesRepository.js";
-import { ApiError, asyncHandler } from "../http/errors.js";
-import { getServerLogger, warnWithError } from "../logging.js";
-import { getProvider } from "../providers/registry.js";
+import { listMediaSources } from "#/db/mediaSourcesRepository.js";
+import { ApiError, asyncHandler } from "#/http/errors.js";
+import { getServerLogger, warnWithError } from "#/logging.js";
+import { getProvider } from "#/providers/registry.js";
 import {
   assertAllowedMediaHandleRequestUrl,
   fetchMediaHandleRequest,
@@ -17,18 +17,18 @@ import {
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
   shouldForwardMediaRange,
-} from "../providers/shared/mediaProxy.js";
+} from "#/providers/shared/mediaProxy.js";
 import type {
   CurrentlyPlayingEntry,
   MediaHandle,
   SourcePlaybackError,
   ViewerPlaybackGroup,
-} from "../providers/types.js";
-import { requireAccountSession, setNoStore } from "../session/request.js";
+} from "#/providers/types.js";
+import { requireAccountSession, setNoStore } from "#/session/request.js";
 import {
   pruneSessionMediaHandles,
   type ProviderSessionRecord,
-} from "../session/store.js";
+} from "#/session/store.js";
 
 export const mediaRouter = Router();
 const mediaLogger = getServerLogger("media");

--- a/apps/server/src/routes/mediaCurrentPlaying.test.ts
+++ b/apps/server/src/routes/mediaCurrentPlaying.test.ts
@@ -3,19 +3,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase } from "#/db/database.js";
+import { closeDatabase } from "@/db/database";
 import {
   upsertMediaSource,
   type MediaSource,
-} from "#/db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
-import { createApp } from "#/app.js";
-import { plexProvider } from "#/providers/plex/provider.js";
-import type { CurrentlyPlayingEntry } from "#/providers/types.js";
-import {
-  createProviderSession,
-  getSessionCookieName,
-} from "#/session/store.js";
+} from "@/db/mediaSourcesRepository";
+import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
+import { createApp } from "@/app";
+import { plexProvider } from "@/providers/plex/provider";
+import type { CurrentlyPlayingEntry } from "@/providers/types";
+import { createProviderSession, getSessionCookieName } from "@/session/store";
 
 const TEST_APP_KEY = "media-currently-playing-test-key-with-32-chars";
 

--- a/apps/server/src/routes/mediaCurrentPlaying.test.ts
+++ b/apps/server/src/routes/mediaCurrentPlaying.test.ts
@@ -3,19 +3,19 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase } from "../db/database.js";
+import { closeDatabase } from "#/db/database.js";
 import {
   upsertMediaSource,
   type MediaSource,
-} from "../db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
-import { createApp } from "../app.js";
-import { plexProvider } from "../providers/plex/provider.js";
-import type { CurrentlyPlayingEntry } from "../providers/types.js";
+} from "#/db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
+import { createApp } from "#/app.js";
+import { plexProvider } from "#/providers/plex/provider.js";
+import type { CurrentlyPlayingEntry } from "#/providers/types.js";
 import {
   createProviderSession,
   getSessionCookieName,
-} from "../session/store.js";
+} from "#/session/store.js";
 
 const TEST_APP_KEY = "media-currently-playing-test-key-with-32-chars";
 

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -3,20 +3,20 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase } from "../db/database.js";
+import { closeDatabase } from "#/db/database.js";
 import {
   getMediaSourceByProviderExternalId,
   getMediaSourceForAccount,
   listMediaSources,
   upsertMediaSource,
-} from "../db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "../db/providerAccountsRepository.js";
-import { createApp } from "../app.js";
+} from "#/db/mediaSourcesRepository.js";
+import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
+import { createApp } from "#/app.js";
 import {
   createProviderSession,
   getSessionCookieName,
-} from "../session/store.js";
-import { PLEX_BASE_URL_MODE_MANUAL } from "../providers/plex/connectionState.js";
+} from "#/session/store.js";
+import { PLEX_BASE_URL_MODE_MANUAL } from "#/providers/plex/connectionState.js";
 
 const TEST_APP_KEY = "provider-routes-test-key-with-at-least-32-characters";
 

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -3,20 +3,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { closeDatabase } from "#/db/database.js";
+import { closeDatabase } from "@/db/database";
 import {
   getMediaSourceByProviderExternalId,
   getMediaSourceForAccount,
   listMediaSources,
   upsertMediaSource,
-} from "#/db/mediaSourcesRepository.js";
-import { upsertProviderAccountByAccessToken } from "#/db/providerAccountsRepository.js";
-import { createApp } from "#/app.js";
-import {
-  createProviderSession,
-  getSessionCookieName,
-} from "#/session/store.js";
-import { PLEX_BASE_URL_MODE_MANUAL } from "#/providers/plex/connectionState.js";
+} from "@/db/mediaSourcesRepository";
+import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
+import { createApp } from "@/app";
+import { createProviderSession, getSessionCookieName } from "@/session/store";
+import { PLEX_BASE_URL_MODE_MANUAL } from "@/providers/plex/connectionState";
 
 const TEST_APP_KEY = "provider-routes-test-key-with-at-least-32-characters";
 

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -5,12 +5,12 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { persistProviderAuth } from "#/db/providerPersistence.js";
-import { createRememberedProviderSession } from "#/db/rememberedProviderSessionsRepository.js";
-import { ApiError, asyncHandler } from "#/http/errors.js";
-import { getRequestRouteUrl } from "#/http/requestOrigin.js";
-import { getProvider, listProviders } from "#/providers/registry.js";
-import { getServerLogger, warnWithError } from "#/logging.js";
+import { persistProviderAuth } from "@/db/providerPersistence";
+import { createRememberedProviderSession } from "@/db/rememberedProviderSessionsRepository";
+import { ApiError, asyncHandler } from "@/http/errors";
+import { getRequestRouteUrl } from "@/http/requestOrigin";
+import { getProvider, listProviders } from "@/providers/registry";
+import { getServerLogger, warnWithError } from "@/logging";
 import {
   createProviderSession,
   getRememberedProviderSessionCookieName,
@@ -18,8 +18,8 @@ import {
   getSessionCookieName,
   getSessionCookieOptions,
   readCookie,
-} from "#/session/store.js";
-import { setNoStore } from "#/session/request.js";
+} from "@/session/store";
+import { setNoStore } from "@/session/request";
 
 export const providersRouter = Router();
 const logger = getServerLogger(["provider", "auth"]);

--- a/apps/server/src/routes/providers.ts
+++ b/apps/server/src/routes/providers.ts
@@ -5,12 +5,12 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { persistProviderAuth } from "../db/providerPersistence.js";
-import { createRememberedProviderSession } from "../db/rememberedProviderSessionsRepository.js";
-import { ApiError, asyncHandler } from "../http/errors.js";
-import { getRequestRouteUrl } from "../http/requestOrigin.js";
-import { getProvider, listProviders } from "../providers/registry.js";
-import { getServerLogger, warnWithError } from "../logging.js";
+import { persistProviderAuth } from "#/db/providerPersistence.js";
+import { createRememberedProviderSession } from "#/db/rememberedProviderSessionsRepository.js";
+import { ApiError, asyncHandler } from "#/http/errors.js";
+import { getRequestRouteUrl } from "#/http/requestOrigin.js";
+import { getProvider, listProviders } from "#/providers/registry.js";
+import { getServerLogger, warnWithError } from "#/logging.js";
 import {
   createProviderSession,
   getRememberedProviderSessionCookieName,
@@ -18,8 +18,8 @@ import {
   getSessionCookieName,
   getSessionCookieOptions,
   readCookie,
-} from "../session/store.js";
-import { setNoStore } from "../session/request.js";
+} from "#/session/store.js";
+import { setNoStore } from "#/session/request.js";
 
 export const providersRouter = Router();
 const logger = getServerLogger(["provider", "auth"]);

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -8,9 +8,9 @@ import {
   createRememberedProviderSession,
   getRememberedProviderSession,
   revokeRememberedProviderSession,
-} from "../db/rememberedProviderSessionsRepository.js";
-import { ApiError, asyncHandler } from "../http/errors.js";
-import { getProvider } from "../providers/registry.js";
+} from "#/db/rememberedProviderSessionsRepository.js";
+import { ApiError, asyncHandler } from "#/http/errors.js";
+import { getProvider } from "#/providers/registry.js";
 import {
   deleteProviderSession,
   getRememberedProviderSessionCookieClearOptions,
@@ -22,9 +22,9 @@ import {
   getProviderSession,
   readCookie,
   restoreProviderSessionFromProviderAccount,
-} from "../session/store.js";
-import { getRequestSessionId, setNoStore } from "../session/request.js";
-import { getServerLogger } from "../logging.js";
+} from "#/session/store.js";
+import { getRequestSessionId, setNoStore } from "#/session/request.js";
+import { getServerLogger } from "#/logging.js";
 
 export const sessionRouter = Router();
 const logger = getServerLogger("session");

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -8,9 +8,9 @@ import {
   createRememberedProviderSession,
   getRememberedProviderSession,
   revokeRememberedProviderSession,
-} from "#/db/rememberedProviderSessionsRepository.js";
-import { ApiError, asyncHandler } from "#/http/errors.js";
-import { getProvider } from "#/providers/registry.js";
+} from "@/db/rememberedProviderSessionsRepository";
+import { ApiError, asyncHandler } from "@/http/errors";
+import { getProvider } from "@/providers/registry";
 import {
   deleteProviderSession,
   getRememberedProviderSessionCookieClearOptions,
@@ -22,9 +22,9 @@ import {
   getProviderSession,
   readCookie,
   restoreProviderSessionFromProviderAccount,
-} from "#/session/store.js";
-import { getRequestSessionId, setNoStore } from "#/session/request.js";
-import { getServerLogger } from "#/logging.js";
+} from "@/session/store";
+import { getRequestSessionId, setNoStore } from "@/session/request";
+import { getServerLogger } from "@/logging";
 
 export const sessionRouter = Router();
 const logger = getServerLogger("session");

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -14,15 +14,15 @@ import {
   type MediaSource,
   type UpdateMediaSourceInput,
   updateMediaSourceForAccount,
-} from "../db/mediaSourcesRepository.js";
-import { ApiError, asyncHandler } from "../http/errors.js";
+} from "#/db/mediaSourcesRepository.js";
+import { ApiError, asyncHandler } from "#/http/errors.js";
 import {
   PLEX_BASE_URL_MODE_MANUAL,
   withPlexBaseUrlMode,
-} from "../providers/plex/connectionState.js";
-import { getProvider } from "../providers/registry.js";
-import { requireAccountSession, setNoStore } from "../session/request.js";
-import { getServerLogger, warnWithError } from "../logging.js";
+} from "#/providers/plex/connectionState.js";
+import { getProvider } from "#/providers/registry.js";
+import { requireAccountSession, setNoStore } from "#/session/request.js";
+import { getServerLogger, warnWithError } from "#/logging.js";
 
 export const sourcesRouter = Router();
 const logger = getServerLogger("source");

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -14,15 +14,15 @@ import {
   type MediaSource,
   type UpdateMediaSourceInput,
   updateMediaSourceForAccount,
-} from "#/db/mediaSourcesRepository.js";
-import { ApiError, asyncHandler } from "#/http/errors.js";
+} from "@/db/mediaSourcesRepository";
+import { ApiError, asyncHandler } from "@/http/errors";
 import {
   PLEX_BASE_URL_MODE_MANUAL,
   withPlexBaseUrlMode,
-} from "#/providers/plex/connectionState.js";
-import { getProvider } from "#/providers/registry.js";
-import { requireAccountSession, setNoStore } from "#/session/request.js";
-import { getServerLogger, warnWithError } from "#/logging.js";
+} from "@/providers/plex/connectionState";
+import { getProvider } from "@/providers/registry";
+import { requireAccountSession, setNoStore } from "@/session/request";
+import { getServerLogger, warnWithError } from "@/logging";
 
 export const sourcesRouter = Router();
 const logger = getServerLogger("source");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,13 +1,13 @@
-import "./config/loadEnv.js";
+import "#/config/loadEnv.js";
 import type { Server } from "node:http";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { createApp } from "./app.js";
-import { closeDatabase } from "./db/database.js";
+import { createApp } from "#/app.js";
+import { closeDatabase } from "#/db/database.js";
 import {
   configureLogging,
   fatalWithError,
   getServerLogger,
-} from "./logging.js";
+} from "#/logging.js";
 
 const logger = getServerLogger("lifecycle");
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,13 +1,9 @@
-import "#/config/loadEnv.js";
+import "@/config/loadEnv";
 import type { Server } from "node:http";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { createApp } from "#/app.js";
-import { closeDatabase } from "#/db/database.js";
-import {
-  configureLogging,
-  fatalWithError,
-  getServerLogger,
-} from "#/logging.js";
+import { createApp } from "@/app";
+import { closeDatabase } from "@/db/database";
+import { configureLogging, fatalWithError, getServerLogger } from "@/logging";
 
 const logger = getServerLogger("lifecycle");
 

--- a/apps/server/src/session/request.ts
+++ b/apps/server/src/session/request.ts
@@ -1,11 +1,11 @@
 import type { Request, Response } from "express";
-import { ApiError } from "../http/errors.js";
+import { ApiError } from "#/http/errors.js";
 import {
   getProviderSession,
   getSessionCookieName,
   readCookie,
   type ProviderSessionRecord,
-} from "./store.js";
+} from "#/session/store.js";
 
 export function getRequestSessionId(req: Request) {
   return readCookie(req.header("cookie"), getSessionCookieName());

--- a/apps/server/src/session/request.ts
+++ b/apps/server/src/session/request.ts
@@ -1,11 +1,11 @@
 import type { Request, Response } from "express";
-import { ApiError } from "#/http/errors.js";
+import { ApiError } from "@/http/errors";
 import {
   getProviderSession,
   getSessionCookieName,
   readCookie,
   type ProviderSessionRecord,
-} from "#/session/store.js";
+} from "@/session/store";
 
 export function getRequestSessionId(req: Request) {
   return readCookie(req.header("cookie"), getSessionCookieName());

--- a/apps/server/src/session/store.test.ts
+++ b/apps/server/src/session/store.test.ts
@@ -9,17 +9,13 @@ const TEST_APP_KEY = "session-store-test-key-with-at-least-32-characters";
 const MISMATCHED_APP_KEY =
   "session-store-test-key-with-a-different-32-char-secret";
 
-const appModuleUrl = new URL("../app.js", import.meta.url).href;
-const databaseModuleUrl = new URL("../db/database.js", import.meta.url).href;
-const providerAccountsRepositoryModuleUrl = new URL(
-  "../db/providerAccountsRepository.js",
-  import.meta.url,
-).href;
-const rememberedProviderSessionsRepositoryModuleUrl = new URL(
-  "../db/rememberedProviderSessionsRepository.js",
-  import.meta.url,
-).href;
-const storeModuleUrl = new URL("./store.js", import.meta.url).href;
+const appModuleSpecifier = "#/app.js";
+const databaseModuleSpecifier = "#/db/database.js";
+const providerAccountsRepositoryModuleSpecifier =
+  "#/db/providerAccountsRepository.js";
+const rememberedProviderSessionsRepositoryModuleSpecifier =
+  "#/db/rememberedProviderSessionsRepository.js";
+const storeModuleSpecifier = "#/session/store.js";
 
 function runStoreScript(
   script: string,
@@ -30,7 +26,14 @@ function runStoreScript(
 ) {
   const child = spawnSync(
     process.execPath,
-    ["--import", "tsx", "--input-type=module", "--eval", script],
+    [
+      "--conditions=cliparr-source",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      script,
+    ],
     {
       cwd: process.cwd(),
       env: {
@@ -62,14 +65,14 @@ void test("restores a provider session from an opaque remembered provider sessio
       `
       import assert from "node:assert/strict";
 
-      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
       const {
         createRememberedProviderSession,
         getRememberedProviderSession,
         revokeRememberedProviderSession,
-      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
-      const { restoreProviderSessionFromProviderAccount } = await import(${JSON.stringify(storeModuleUrl)});
+      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
+      const { restoreProviderSessionFromProviderAccount } = await import(${JSON.stringify(storeModuleSpecifier)});
 
       try {
         initializeDatabase();
@@ -120,9 +123,9 @@ void test("remembered provider session tokens are not reusable after APP_KEY cha
   try {
     const token = runStoreScript(
       `
-      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
-      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
+      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
 
       try {
         initializeDatabase();
@@ -146,8 +149,8 @@ void test("remembered provider session tokens are not reusable after APP_KEY cha
       `
       import assert from "node:assert/strict";
 
-      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { getRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      const { initializeDatabase, closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { getRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
 
       try {
         initializeDatabase();
@@ -176,11 +179,11 @@ void test("restores /api/session from a remembered provider session cookie", () 
       `
       import assert from "node:assert/strict";
 
-      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
-      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
-      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
-      const { getRememberedProviderSessionCookieName, getSessionCookieName } = await import(${JSON.stringify(storeModuleUrl)});
+      const { createApp } = await import(${JSON.stringify(appModuleSpecifier)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
+      const { createRememberedProviderSession } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
+      const { getRememberedProviderSessionCookieName, getSessionCookieName } = await import(${JSON.stringify(storeModuleSpecifier)});
 
       const { app } = await createApp();
       const server = app.listen(0, "127.0.0.1");
@@ -236,9 +239,9 @@ void test("clears invalid remembered provider session cookies from /api/session"
       `
       import assert from "node:assert/strict";
 
-      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
-      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { getRememberedProviderSessionCookieName } = await import(${JSON.stringify(storeModuleUrl)});
+      const { createApp } = await import(${JSON.stringify(appModuleSpecifier)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { getRememberedProviderSessionCookieName } = await import(${JSON.stringify(storeModuleSpecifier)});
 
       const { app } = await createApp();
       const server = app.listen(0, "127.0.0.1");
@@ -285,18 +288,18 @@ void test("logout revokes the remembered provider session token", () => {
       `
       import assert from "node:assert/strict";
 
-      const { createApp } = await import(${JSON.stringify(appModuleUrl)});
-      const { closeDatabase } = await import(${JSON.stringify(databaseModuleUrl)});
-      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleUrl)});
+      const { createApp } = await import(${JSON.stringify(appModuleSpecifier)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
       const {
         createRememberedProviderSession,
         getRememberedProviderSession,
-      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleUrl)});
+      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
       const {
         createProviderSession,
         getRememberedProviderSessionCookieName,
         getSessionCookieName,
-      } = await import(${JSON.stringify(storeModuleUrl)});
+      } = await import(${JSON.stringify(storeModuleSpecifier)});
 
       const { app } = await createApp();
       const server = app.listen(0, "127.0.0.1");

--- a/apps/server/src/session/store.test.ts
+++ b/apps/server/src/session/store.test.ts
@@ -9,13 +9,13 @@ const TEST_APP_KEY = "session-store-test-key-with-at-least-32-characters";
 const MISMATCHED_APP_KEY =
   "session-store-test-key-with-a-different-32-char-secret";
 
-const appModuleSpecifier = "#/app.js";
-const databaseModuleSpecifier = "#/db/database.js";
+const appModuleSpecifier = "@/app";
+const databaseModuleSpecifier = "@/db/database";
 const providerAccountsRepositoryModuleSpecifier =
-  "#/db/providerAccountsRepository.js";
+  "@/db/providerAccountsRepository";
 const rememberedProviderSessionsRepositoryModuleSpecifier =
-  "#/db/rememberedProviderSessionsRepository.js";
-const storeModuleSpecifier = "#/session/store.js";
+  "@/db/rememberedProviderSessionsRepository";
+const storeModuleSpecifier = "@/session/store";
 
 function runStoreScript(
   script: string,
@@ -26,14 +26,7 @@ function runStoreScript(
 ) {
   const child = spawnSync(
     process.execPath,
-    [
-      "--conditions=cliparr-source",
-      "--import",
-      "tsx",
-      "--input-type=module",
-      "--eval",
-      script,
-    ],
+    ["--import", "tsx", "--input-type=module", "--eval", script],
     {
       cwd: process.cwd(),
       env: {

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { getDatabase } from "../db/database.js";
-import { getProviderAccount } from "../db/providerAccountsRepository.js";
-import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "../db/rememberedProviderSessionsRepository.js";
-import { providerSessions, type ProviderSessionRow } from "../db/schema.js";
-import { getServerLogger } from "../logging.js";
-import type { MediaHandle } from "../providers/types.js";
-import { decryptSecret, encryptSecret } from "../security/secrets.js";
+import { getDatabase } from "#/db/database.js";
+import { getProviderAccount } from "#/db/providerAccountsRepository.js";
+import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "#/db/rememberedProviderSessionsRepository.js";
+import { providerSessions, type ProviderSessionRow } from "#/db/schema.js";
+import { getServerLogger } from "#/logging.js";
+import type { MediaHandle } from "#/providers/types.js";
+import { decryptSecret, encryptSecret } from "#/security/secrets.js";
 
 const SESSION_COOKIE = "cliparr_session";
 const REMEMBERED_PROVIDER_SESSION_COOKIE = "cliparr_remember";

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
-import { getDatabase } from "#/db/database.js";
-import { getProviderAccount } from "#/db/providerAccountsRepository.js";
-import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "#/db/rememberedProviderSessionsRepository.js";
-import { providerSessions, type ProviderSessionRow } from "#/db/schema.js";
-import { getServerLogger } from "#/logging.js";
-import type { MediaHandle } from "#/providers/types.js";
-import { decryptSecret, encryptSecret } from "#/security/secrets.js";
+import { getDatabase } from "@/db/database";
+import { getProviderAccount } from "@/db/providerAccountsRepository";
+import { REMEMBERED_PROVIDER_SESSION_TTL_MS } from "@/db/rememberedProviderSessionsRepository";
+import { providerSessions, type ProviderSessionRow } from "@/db/schema";
+import { getServerLogger } from "@/logging";
+import type { MediaHandle } from "@/providers/types";
+import { decryptSecret, encryptSecret } from "@/security/secrets";
 
 const SESSION_COOKIE = "cliparr_session";
 const REMEMBERED_PROVIDER_SESSION_COOKIE = "cliparr_remember";

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "customConditions": ["cliparr-source"],
+    "paths": {
+      "#/*.js": ["./src/*.ts"]
+    },
     "types": ["node"],
     "noEmit": true
   },

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "customConditions": ["cliparr-source"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "paths": {
-      "#/*.js": ["./src/*.ts"]
+      "@/*": ["./src/*"]
     },
     "types": ["node"],
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "drizzle.config.ts", "tsdown.config.ts"]
 }

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "tsdown";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  entry: {
+    server: "src/server.ts",
+  },
+  format: "esm",
+  platform: "node",
+  target: "node24",
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  fixedExtension: false,
+  alias: {
+    "@": path.resolve(__dirname, "src"),
+  },
+  deps: {
+    onlyBundle: false,
+    alwaysBundle: [
+      /^@cliparr\/shared(?:\/.*)?$/,
+      /^@logtape\/logtape(?:\/.*)?$/,
+      /^dotenv(?:\/.*)?$/,
+      /^drizzle-orm(?:\/.*)?$/,
+      /^express(?:\/.*)?$/,
+    ],
+  },
+});

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "tsdown";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const includeSourceMap = process.env.CLIPARR_SERVER_SOURCEMAP !== "false";
 
 export default defineConfig({
   entry: {
@@ -13,7 +14,7 @@ export default defineConfig({
   target: "node24",
   outDir: "dist",
   clean: true,
-  sourcemap: true,
+  sourcemap: includeSourceMap,
   fixedExtension: false,
   alias: {
     "@": path.resolve(__dirname, "src"),

--- a/apps/www/astro.config.ts
+++ b/apps/www/astro.config.ts
@@ -2,6 +2,10 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   site: "https://cliparr.dev",
@@ -24,5 +28,10 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "src"),
+      },
+    },
   },
 });

--- a/apps/www/scripts/sync-readme.ts
+++ b/apps/www/scripts/sync-readme.ts
@@ -1,12 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import prettier from "prettier";
-import {
-  dockerRunCommand,
-  envVars,
-  features,
-  warnings,
-} from "../src/data/product";
+import { dockerRunCommand, envVars, features, warnings } from "@/data/product";
 
 const rootDir = path.resolve(import.meta.dirname, "../../..");
 const readmePath = path.join(rootDir, "README.md");

--- a/apps/www/src/components/BaseLayout.astro
+++ b/apps/www/src/components/BaseLayout.astro
@@ -1,9 +1,9 @@
 ---
 import { ClientRouter, fade } from "astro:transitions";
-import Footer from "./Footer.astro";
-import Header from "./Header.astro";
-import { site } from "../data/product";
-import "../styles/global.css";
+import Footer from "@/components/Footer.astro";
+import Header from "@/components/Header.astro";
+import { site } from "@/data/product";
+import "@/styles/global.css";
 
 interface Props {
   title?: string;

--- a/apps/www/src/components/DocsLayout.astro
+++ b/apps/www/src/components/DocsLayout.astro
@@ -1,6 +1,6 @@
 ---
-import BaseLayout from "./BaseLayout.astro";
-import DocsNav from "./DocsNav.astro";
+import BaseLayout from "@/components/BaseLayout.astro";
+import DocsNav from "@/components/DocsNav.astro";
 
 interface Props {
   title: string;

--- a/apps/www/src/components/EnvVarTable.astro
+++ b/apps/www/src/components/EnvVarTable.astro
@@ -1,5 +1,5 @@
 ---
-import { envVars } from "../data/product";
+import { envVars } from "@/data/product";
 ---
 
 <div class="my-6 overflow-x-auto rounded-lg border border-border">

--- a/apps/www/src/components/FeatureGrid.astro
+++ b/apps/www/src/components/FeatureGrid.astro
@@ -1,5 +1,5 @@
 ---
-import { features } from "../data/product";
+import { features } from "@/data/product";
 ---
 
 <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/www/src/components/Footer.astro
+++ b/apps/www/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { site } from "../data/product";
+import { site } from "@/data/product";
 
 const year = new Date().getFullYear();
 ---

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { site } from "../data/product";
+import { site } from "@/data/product";
 
 const links = [
   { href: "/#features", label: "Features" },

--- a/apps/www/src/content.config.ts
+++ b/apps/www/src/content.config.ts
@@ -1,7 +1,7 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
-import { githubReleasesLoader } from "./lib/githubReleases";
+import { githubReleasesLoader } from "@/lib/githubReleases";
 
 const docs = defineCollection({
   loader: glob({

--- a/apps/www/src/content/docs/configuration.mdx
+++ b/apps/www/src/content/docs/configuration.mdx
@@ -4,8 +4,8 @@ description: Environment variables, credential encryption, persistent data, and 
 order: 20
 ---
 
-import Callout from "../../components/Callout.astro";
-import EnvVarTable from "../../components/EnvVarTable.astro";
+import Callout from "@/components/Callout.astro";
+import EnvVarTable from "@/components/EnvVarTable.astro";
 
 Cliparr only needs a few settings in production: a stable `APP_KEY` and a persistent data directory.
 

--- a/apps/www/src/content/docs/development.mdx
+++ b/apps/www/src/content/docs/development.mdx
@@ -4,11 +4,8 @@ description: Set up the local workspace and run the checks before opening a pull
 order: 50
 ---
 
-import CommandBlock from "../../components/CommandBlock.astro";
-import {
-  developmentSetupCommands,
-  preflightCommands,
-} from "../../data/product";
+import CommandBlock from "@/components/CommandBlock.astro";
+import { developmentSetupCommands, preflightCommands } from "@/data/product";
 
 Development uses the root pnpm workspace. You need Node.js 24 or newer and pnpm 11.2.2 via Corepack.
 

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -4,9 +4,9 @@ description: Run Cliparr with Docker, keep settings persistent, and open the app
 order: 10
 ---
 
-import Callout from "../../components/Callout.astro";
-import CommandBlock from "../../components/CommandBlock.astro";
-import { dockerComposeExample, dockerRunCommand } from "../../data/product";
+import Callout from "@/components/Callout.astro";
+import CommandBlock from "@/components/CommandBlock.astro";
+import { dockerComposeExample, dockerRunCommand } from "@/data/product";
 
 Run Cliparr in Docker, then open the app and connect Plex, Jellyfin, or a local video. Mount `/data` before connecting media servers so settings and encrypted credentials survive updates.
 

--- a/apps/www/src/content/docs/providers.mdx
+++ b/apps/www/src/content/docs/providers.mdx
@@ -4,8 +4,8 @@ description: How Cliparr connects to Plex and Jellyfin sources.
 order: 40
 ---
 
-import Callout from "../../components/Callout.astro";
-import { providers } from "../../data/product";
+import Callout from "@/components/Callout.astro";
+import { providers } from "@/data/product";
 
 Cliparr uses provider sources to discover active playback sessions, load playable streams, and attach useful metadata to exported clips.
 

--- a/apps/www/src/lib/githubReleases.ts
+++ b/apps/www/src/lib/githubReleases.ts
@@ -1,5 +1,5 @@
 import type { Loader } from "astro/loaders";
-import { site } from "../data/product";
+import { site } from "@/data/product";
 
 interface GitHubRelease {
   id: number;

--- a/apps/www/src/pages/404.astro
+++ b/apps/www/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "../components/BaseLayout.astro";
+import BaseLayout from "@/components/BaseLayout.astro";
 ---
 
 <BaseLayout

--- a/apps/www/src/pages/changelog.astro
+++ b/apps/www/src/pages/changelog.astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getCollection, render } from "astro:content";
-import BaseLayout from "../components/BaseLayout.astro";
+import BaseLayout from "@/components/BaseLayout.astro";
 
 type ReleaseEntry = CollectionEntry<"releases">;
 

--- a/apps/www/src/pages/docs/[...slug].astro
+++ b/apps/www/src/pages/docs/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getCollection, render } from "astro:content";
-import DocsLayout from "../../components/DocsLayout.astro";
+import DocsLayout from "@/components/DocsLayout.astro";
 
 type Props = {
   entry: CollectionEntry<"docs">;

--- a/apps/www/src/pages/docs/index.astro
+++ b/apps/www/src/pages/docs/index.astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
-import DocsLayout from "../../components/DocsLayout.astro";
+import DocsLayout from "@/components/DocsLayout.astro";
 
 type DocsEntry = CollectionEntry<"docs">;
 

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -1,15 +1,15 @@
 ---
-import BaseLayout from "../components/BaseLayout.astro";
-import CommandBlock from "../components/CommandBlock.astro";
-import FeatureGrid from "../components/FeatureGrid.astro";
+import BaseLayout from "@/components/BaseLayout.astro";
+import CommandBlock from "@/components/CommandBlock.astro";
+import FeatureGrid from "@/components/FeatureGrid.astro";
 import { Picture } from "astro:assets";
-import screenshotImage from "../assets/screenshot.webp";
+import screenshotImage from "@/assets/screenshot.webp";
 import {
   dockerRunCommand,
   productIntro,
   providers,
   site,
-} from "../data/product";
+} from "@/data/product";
 ---
 
 <BaseLayout description={productIntro}>

--- a/apps/www/src/pages/robots.txt.ts
+++ b/apps/www/src/pages/robots.txt.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { site as productSite } from "../data/product";
+import { site as productSite } from "@/data/product";
 
 const getRobotsTxt = (sitemapUrl: URL) => `User-agent: *
 Allow: /

--- a/apps/www/tsconfig.scripts.json
+++ b/apps/www/tsconfig.scripts.json
@@ -6,6 +6,9 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "strict": true,
     "types": ["node"]
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,25 @@ export default tseslint.config(
   {
     rules: {
       "no-console": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["./*", "../*"],
+              message:
+                "Use the package alias instead of a relative import path.",
+            },
+          ],
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ImportExpression[source.value=/^\\.{1,2}\\//]",
+          message: "Use the package alias instead of a relative import path.",
+        },
+      ],
     },
   },
   ...tseslint.configs.recommendedTypeChecked,

--- a/knip.json
+++ b/knip.json
@@ -11,10 +11,10 @@
       "project": ["src/**/*.{astro,mdx,ts}", "scripts/**/*.ts"]
     },
     "apps/server": {
+      "drizzle": false,
       "ignoreBinaries": ["eslint"],
       "paths": {
-        "#/*.js": ["./src/*.ts"],
-        "#/*": ["./src/*"]
+        "@/*": ["./src/*"]
       },
       "project": ["src/**/*.ts"]
     }

--- a/knip.json
+++ b/knip.json
@@ -12,6 +12,10 @@
     },
     "apps/server": {
       "ignoreBinaries": ["eslint"],
+      "paths": {
+        "#/*.js": ["./src/*.ts"],
+        "#/*": ["./src/*"]
+      },
       "project": ["src/**/*.ts"]
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Personal media clipper for Plex, Jellyfin, and local video files, featuring a React frontend and Express server.",
   "license": "MIT",
   "type": "module",
+  "imports": {
+    "#release/*.mjs": "./scripts/release/*.mjs"
+  },
   "packageManager": "pnpm@11.2.2",
   "engines": {
     "node": ">=20.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       drizzle-kit:
         specifier: 1.0.0-rc.4-273829f
         version: 1.0.0-rc.4-273829f
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.1(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
@@ -282,6 +285,10 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0-rc.6':
+    resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
@@ -308,9 +315,17 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.6':
+    resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -323,6 +338,11 @@ packages:
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-syntax-jsx@7.28.6':
@@ -352,6 +372,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0-rc.6':
+    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@base-ui/react@1.5.0':
     resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
@@ -1627,6 +1651,9 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -2793,6 +2820,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -3020,6 +3050,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  ast-kit@3.0.0-beta.1:
+    resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
+    engines: {node: '>=20.19.0'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -3048,6 +3082,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  birpc@4.0.0:
+    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -3070,6 +3107,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3403,6 +3444,15 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -3418,6 +3468,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -3708,6 +3762,10 @@ packages:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -3783,6 +3841,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -3807,6 +3868,10 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-without-cache@0.4.0:
+    resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4466,6 +4531,9 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
     peerDependencies:
@@ -4643,6 +4711,25 @@ packages:
 
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
+
+  rolldown-plugin-dts@0.25.2:
+    resolution: {integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0
+      typescript: ^5.0.0 || ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
 
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
@@ -4879,6 +4966,40 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsdown@0.22.1:
+    resolution: {integrity: sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.1
+      '@tsdown/exe': 0.22.1
+      '@vitejs/devtools': '*'
+      publint: ^0.3.8
+      tsx: '*'
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4925,6 +5046,9 @@ packages:
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
     engines: {node: '>=14'}
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -5547,6 +5671,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0-rc.6':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.3
@@ -5577,7 +5710,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@8.0.0-rc.6': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.6': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -5589,6 +5726,10 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@8.0.0-rc.6':
+    dependencies:
+      '@babel/types': 8.0.0-rc.6
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -5624,6 +5765,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@8.0.0-rc.6':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
 
   '@base-ui/react@1.5.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -6432,6 +6578,10 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7563,6 +7713,8 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/jsesc@2.5.1': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -7836,6 +7988,12 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
+  ast-kit@3.0.0-beta.1:
+    dependencies:
+      '@babel/parser': 8.0.0-rc.6
+      estree-walker: 3.0.3
+      pathe: 2.0.3
+
   astring@1.9.0: {}
 
   astro@6.3.8(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0):
@@ -7948,6 +8106,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.31: {}
 
+  birpc@4.0.0: {}
+
   blake3-wasm@2.1.5: {}
 
   body-parser@2.2.2:
@@ -7979,6 +8139,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bytes@3.1.2: {}
+
+  cac@7.0.0: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8173,6 +8335,10 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dts-resolver@3.0.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+    optionalDependencies:
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8189,6 +8355,8 @@ snapshots:
       '@emmetio/css-abbreviation': 2.1.8
 
   emoji-regex@8.0.0: {}
+
+  empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
 
@@ -8621,6 +8789,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-slugger@2.0.0: {}
 
   glob-parent@6.0.2:
@@ -8787,6 +8959,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hookable@6.1.1: {}
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -8808,6 +8982,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  import-without-cache@0.4.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -9711,6 +9887,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quansync@1.0.0: {}
+
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -9999,6 +10177,22 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  rolldown-plugin-dts@0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.2)(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
+      '@babel/parser': 8.0.0-rc.6
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 3.0.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.1
+      rolldown: 1.0.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
 
   rolldown@1.0.2:
     dependencies:
@@ -10307,6 +10501,32 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  tsdown@0.22.1(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3):
+    dependencies:
+      ansis: 4.3.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.2
+      rolldown-plugin-dts: 0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.2)(typescript@6.0.3)
+      semver: 7.8.1
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+    optionalDependencies:
+      tsx: 4.22.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - vue-tsc
+
   tslib@2.8.1: {}
 
   tsx@4.22.3:
@@ -10351,6 +10571,11 @@ snapshots:
   ultrahtml@1.6.0: {}
 
   unbash@3.0.0: {}
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
 
   uncrypto@0.1.3: {}
 

--- a/scripts/release/conventional.test.mjs
+++ b/scripts/release/conventional.test.mjs
@@ -10,7 +10,7 @@ import {
   nextPrereleaseNumber,
   parseConventionalTitle,
   releaseTypeForChange,
-} from "./conventional.mjs";
+} from "#release/conventional.mjs";
 
 void test("classifies conventional PR titles into release levels", () => {
   assert.equal(

--- a/scripts/release/create-github-release.test.mjs
+++ b/scripts/release/create-github-release.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { composeReleaseBody, parseArgs } from "./create-github-release.mjs";
+import {
+  composeReleaseBody,
+  parseArgs,
+} from "#release/create-github-release.mjs";
 
 const requiredArgs = [
   "--repository",

--- a/scripts/release/plan-release.mjs
+++ b/scripts/release/plan-release.mjs
@@ -13,7 +13,7 @@ import {
   parseGitLogMessages,
   parseSemverTag,
   summarizeChanges,
-} from "./conventional.mjs";
+} from "#release/conventional.mjs";
 
 const validChannels = new Set(["stable", "rc", "beta"]);
 


### PR DESCRIPTION
## Summary
- Replace authored internal relative imports with package aliases across frontend, server, www, release scripts, and server runtime code.
- Add ESLint guards for static and dynamic relative imports.
- Switch the server from Node package import conditions to tsdown bundling with @/... source aliases.
- Slim the Docker runner stage by copying the bundled server output instead of a deployed server node_modules tree.
- Omit backend sourcemaps from Docker images while keeping local server builds sourcemap-friendly.

## Validation
- pnpm preflight
- pnpm build
- NODE_ENV=production APP_KEY=production-smoke-test-key-with-at-least-32-chars CLIPARR_DATA_DIR=/tmp/cliparr-tsdown-smoke PORT=5137 node apps/server/dist/server.js + curl /api/health
- CLIPARR_SERVER_SOURCEMAP=false pnpm --filter @cliparr/server build
- docker build -t cliparr:tsdown-nosourcemap-smoke --build-arg CLIPARR_VERSION=tsdown-nosourcemap-smoke .
- docker run --rm --entrypoint ls cliparr:tsdown-nosourcemap-smoke -lh /app/apps/server/dist
- docker run --rm -p 5139:3000 -e APP_KEY=production-smoke-test-key-with-at-least-32-chars cliparr:tsdown-nosourcemap-smoke + curl /api/health

## Notes
- The smoke Docker image reports 352MB locally.
- /app/apps/server/dist contains only server.js; no server.js.map or sourceMappingURL footer is shipped.