### PR TITLE
feat(server): add log format and file sink options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,33 @@ PORT="3000"
 # Docker uses /data and should mount it as a persistent volume.
 CLIPARR_DATA_DIR="./.cliparr-data"
 
+# CLIPARR_LOG_LEVEL: Optional server log level.
+# Supported values: trace, debug, info, warning, error, fatal.
+# Defaults to debug in development and info in production.
+# CLIPARR_LOG_LEVEL="debug"
+
+# CLIPARR_LOG_FORMAT: Optional server console log format.
+# pretty keeps the human terminal output; json/logfmt include structured fields.
+# Supported values: pretty, json, logfmt.
+# CLIPARR_LOG_FORMAT="pretty"
+
+# CLIPARR_LOG_FILE: Optional path for a rotating server log file.
+# Relative paths resolve from the server working directory.
+# CLIPARR_LOG_FILE="./.cliparr-data/cliparr.log"
+
+# CLIPARR_LOG_FILE_FORMAT: Optional format for CLIPARR_LOG_FILE.
+# Defaults to CLIPARR_LOG_FORMAT when set, otherwise json.
+# Supported values: pretty, json, logfmt.
+# CLIPARR_LOG_FILE_FORMAT="json"
+
+# CLIPARR_LOG_FILE_MAX_SIZE: Optional max size for each log file before rotation.
+# Supports b, kb, mb, gb, kib, mib, and gib suffixes. Defaults to 10mb.
+# CLIPARR_LOG_FILE_MAX_SIZE="10mb"
+
+# CLIPARR_LOG_FILE_MAX_FILES: Optional total number of rotating log files to keep,
+# including the active file. Defaults to 5.
+# CLIPARR_LOG_FILE_MAX_FILES="5"
+
 # PLEX_CLIENT_IDENTIFIER: Optional stable Plex client ID.
 # If omitted, Cliparr creates one at server startup.
 # PLEX_CLIENT_IDENTIFIER="cliparr-local"

--- a/README.md
+++ b/README.md
@@ -85,12 +85,18 @@ volumes:
 
 <!-- CLIPARR_DOCS_SYNC:configuration:start -->
 
-| Variable                               | Description                                                                                         | Default |
-| :------------------------------------- | :-------------------------------------------------------------------------------------------------- | :------ |
-| `APP_KEY`                              | Required secret for credential encryption. Must be at least 32 characters long.                     | `-`     |
-| `PORT`                                 | Internal port for the Express server.                                                               | `3000`  |
-| `CLIPARR_DATA_DIR`                     | Directory for SQLite storage.                                                                       | `/data` |
-| `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to localhost or loopback. Use only for trusted self-hosted setups. | `false` |
+| Variable                               | Description                                                                                                                        | Default      |
+| :------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------- |
+| `APP_KEY`                              | Required secret for credential encryption. Must be at least 32 characters long.                                                    | `-`          |
+| `PORT`                                 | Internal port for the Express server.                                                                                              | `3000`       |
+| `CLIPARR_DATA_DIR`                     | Directory for SQLite storage.                                                                                                      | `/data`      |
+| `CLIPARR_LOG_LEVEL`                    | Server log level. Supports trace, debug, info, warning, error, and fatal. Defaults to debug in development and info in production. | `debug/info` |
+| `CLIPARR_LOG_FORMAT`                   | Server console log format. Use json or logfmt to expose structured fields.                                                         | `pretty`     |
+| `CLIPARR_LOG_FILE`                     | Optional path for a rotating server log file. Relative paths resolve from the server working directory.                            | `-`          |
+| `CLIPARR_LOG_FILE_FORMAT`              | Optional log file format. Defaults to CLIPARR_LOG_FORMAT when set, otherwise json.                                                 | `json`       |
+| `CLIPARR_LOG_FILE_MAX_SIZE`            | Maximum size for each rotating server log file. Supports kb, mb, and gb suffixes.                                                  | `10mb`       |
+| `CLIPARR_LOG_FILE_MAX_FILES`           | Total number of rotating server log files to keep, including the active file.                                                      | `5`          |
+| `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to localhost or loopback. Use only for trusted self-hosted setups.                                | `false`      |
 
 <!-- CLIPARR_DOCS_SYNC:configuration:end -->
 

--- a/apps/server/src/logging.test.ts
+++ b/apps/server/src/logging.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveLogFileMaxBytes,
+  resolveLogFileMaxFiles,
+  resolveServerLogFileConfig,
+  resolveServerLogFormat,
+} from "@/logging";
+
+void test("resolves supported server log formats", () => {
+  assert.equal(resolveServerLogFormat("json"), "json");
+  assert.equal(resolveServerLogFormat("LOGFMT"), "logfmt");
+  assert.equal(resolveServerLogFormat(" pretty "), "pretty");
+});
+
+void test("falls back to pretty for invalid server log formats", () => {
+  assert.equal(resolveServerLogFormat(undefined), "pretty");
+  assert.equal(resolveServerLogFormat("verbose"), "pretty");
+});
+
+void test("resolves rotating log file size limits", () => {
+  assert.equal(resolveLogFileMaxBytes(undefined), 10 * 1024 * 1024);
+  assert.equal(resolveLogFileMaxBytes("128kb"), 128 * 1024);
+  assert.equal(resolveLogFileMaxBytes("2 MiB"), 2 * 1024 * 1024);
+  assert.equal(resolveLogFileMaxBytes("nope"), 10 * 1024 * 1024);
+});
+
+void test("resolves rotating log file count limits", () => {
+  assert.equal(resolveLogFileMaxFiles(undefined), 5);
+  assert.equal(resolveLogFileMaxFiles("1"), 1);
+  assert.equal(resolveLogFileMaxFiles("8"), 8);
+  assert.equal(resolveLogFileMaxFiles("0"), 5);
+});
+
+void test("resolves file logging only when a file path is configured", () => {
+  assert.equal(resolveServerLogFileConfig({}), undefined);
+
+  assert.deepEqual(
+    resolveServerLogFileConfig({
+      CLIPARR_LOG_FILE: "cliparr.log",
+      CLIPARR_LOG_FORMAT: "logfmt",
+      CLIPARR_LOG_FILE_MAX_SIZE: "1mb",
+      CLIPARR_LOG_FILE_MAX_FILES: "3",
+    }),
+    {
+      filePath: `${process.cwd()}/cliparr.log`,
+      format: "logfmt",
+      maxBytes: 1024 * 1024,
+      maxFiles: 3,
+    },
+  );
+});
+
+void test("defaults file logging to JSON when console format is unset", () => {
+  assert.equal(
+    resolveServerLogFileConfig({ CLIPARR_LOG_FILE: "cliparr.log" })?.format,
+    "json",
+  );
+});

--- a/apps/server/src/logging.ts
+++ b/apps/server/src/logging.ts
@@ -1,13 +1,22 @@
-import { randomUUID } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { NextFunction, Request, Response } from "express";
 import {
   configure,
+  fromAsyncSink,
   getConsoleSink,
+  getJsonLinesFormatter,
+  getLogfmtFormatter,
   getLogger,
+  getTextFormatter,
   isLogLevel,
   withContext,
   type Logger,
+  type Sink,
+  type TextFormatter,
 } from "@logtape/logtape";
 import {
   compactLogFields,
@@ -19,8 +28,28 @@ const SERVER_LOG_CATEGORY_PREFIX = ["cliparr", "server"] as const;
 // LogTape reserves this category for its own configuration and sink diagnostics.
 const LOGTAPE_META_CATEGORY = ["logtape", "meta"] as const;
 const SLOW_REQUEST_WARNING_MS = 10_000;
+const DEFAULT_LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_LOG_FILE_MAX_FILES = 5;
+const LOG_FILE_SIZE_UNITS = new Map([
+  ["b", 1],
+  ["kb", 1024],
+  ["kib", 1024],
+  ["mb", 1024 * 1024],
+  ["mib", 1024 * 1024],
+  ["gb", 1024 * 1024 * 1024],
+  ["gib", 1024 * 1024 * 1024],
+]);
 
 let loggingConfigured: Promise<void> | undefined;
+
+type ServerLogFormat = "pretty" | "json" | "logfmt";
+
+export interface ServerLogFileConfig {
+  readonly filePath: string;
+  readonly format: ServerLogFormat;
+  readonly maxBytes: number;
+  readonly maxFiles: number;
+}
 
 export function getServerLogger(category: string | readonly string[]) {
   const parts = typeof category === "string" ? [category] : [...category];
@@ -69,6 +98,183 @@ export function fatalWithError(
   logger.fatal(message, properties);
 }
 
+export function resolveServerLogFormat(value: string | undefined) {
+  const format = value?.trim().toLowerCase();
+  if (format === "json" || format === "logfmt" || format === "pretty") {
+    return format;
+  }
+
+  return "pretty";
+}
+
+export function resolveLogFileMaxBytes(value: string | undefined) {
+  const trimmed = value?.trim().toLowerCase();
+  if (!trimmed) {
+    return DEFAULT_LOG_FILE_MAX_BYTES;
+  }
+
+  const match = /^(\d+)(?:\s*(b|kb|kib|mb|mib|gb|gib))?$/.exec(trimmed);
+  if (!match) {
+    return DEFAULT_LOG_FILE_MAX_BYTES;
+  }
+
+  const unit = match[2] ?? "b";
+  const multiplier = LOG_FILE_SIZE_UNITS.get(unit);
+  const size = Number(match[1]) * (multiplier ?? 1);
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    return DEFAULT_LOG_FILE_MAX_BYTES;
+  }
+
+  return size;
+}
+
+export function resolveLogFileMaxFiles(value: string | undefined) {
+  const maxFiles = Number(value?.trim());
+  if (!Number.isSafeInteger(maxFiles) || maxFiles <= 0) {
+    return DEFAULT_LOG_FILE_MAX_FILES;
+  }
+
+  return maxFiles;
+}
+
+export function resolveServerLogFileConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ServerLogFileConfig | undefined {
+  const configuredPath = env.CLIPARR_LOG_FILE?.trim();
+  if (!configuredPath) {
+    return undefined;
+  }
+
+  return {
+    filePath: path.resolve(configuredPath),
+    format: resolveServerLogFormat(
+      env.CLIPARR_LOG_FILE_FORMAT ?? env.CLIPARR_LOG_FORMAT ?? "json",
+    ),
+    maxBytes: resolveLogFileMaxBytes(env.CLIPARR_LOG_FILE_MAX_SIZE),
+    maxFiles: resolveLogFileMaxFiles(env.CLIPARR_LOG_FILE_MAX_FILES),
+  };
+}
+
+function serverTextFormatter(format: ServerLogFormat): TextFormatter {
+  if (format === "json") {
+    return getJsonLinesFormatter({ properties: "flatten" });
+  }
+
+  if (format === "logfmt") {
+    return getLogfmtFormatter();
+  }
+
+  return getTextFormatter({ timestamp: "date-time-tz" });
+}
+
+function serverConsoleSink(format: ServerLogFormat) {
+  if (format === "pretty") {
+    return getConsoleSink();
+  }
+
+  return getConsoleSink({ formatter: serverTextFormatter(format) });
+}
+
+async function pathExists(filePath: string) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function rotatedLogFilePath(filePath: string, index: number) {
+  return `${filePath}.${index}`;
+}
+
+function rotatingFileSink(config: ServerLogFileConfig) {
+  const directory = path.dirname(config.filePath);
+  const formatter = serverTextFormatter(config.format);
+  let currentSize: number | undefined;
+  let directoryReady: Promise<void> | undefined;
+
+  async function ensureDirectory() {
+    directoryReady ??= fs
+      .mkdir(directory, { recursive: true })
+      .then(() => undefined);
+    await directoryReady;
+  }
+
+  async function logFileSize() {
+    if (currentSize !== undefined) {
+      return currentSize;
+    }
+
+    try {
+      currentSize = (await fs.stat(config.filePath)).size;
+    } catch {
+      currentSize = 0;
+    }
+
+    return currentSize;
+  }
+
+  async function rotateLogFiles() {
+    await ensureDirectory();
+
+    if (config.maxFiles <= 1) {
+      await fs.writeFile(config.filePath, "");
+      currentSize = 0;
+      return;
+    }
+
+    const oldestLog = rotatedLogFilePath(config.filePath, config.maxFiles - 1);
+    if (await pathExists(oldestLog)) {
+      await fs.unlink(oldestLog);
+    }
+
+    for (let index = config.maxFiles - 2; index >= 1; index -= 1) {
+      const source = rotatedLogFilePath(config.filePath, index);
+      if (await pathExists(source)) {
+        await fs.rename(source, rotatedLogFilePath(config.filePath, index + 1));
+      }
+    }
+
+    if (await pathExists(config.filePath)) {
+      await fs.rename(config.filePath, rotatedLogFilePath(config.filePath, 1));
+    }
+
+    currentSize = 0;
+  }
+
+  return fromAsyncSink(async (record) => {
+    const line = formatter(record);
+    const byteLength = Buffer.byteLength(line);
+
+    await ensureDirectory();
+    if (
+      (await logFileSize()) > 0 &&
+      currentSize! + byteLength > config.maxBytes
+    ) {
+      await rotateLogFiles();
+    }
+
+    await fs.appendFile(config.filePath, line);
+    currentSize = (currentSize ?? 0) + byteLength;
+  });
+}
+
+function serverLogSinks(env: NodeJS.ProcessEnv = process.env) {
+  const sinks: Record<string, Sink> = {
+    console: serverConsoleSink(resolveServerLogFormat(env.CLIPARR_LOG_FORMAT)),
+  };
+  const sinkNames = ["console"];
+  const fileConfig = resolveServerLogFileConfig(env);
+
+  if (fileConfig) {
+    sinks.file = rotatingFileSink(fileConfig);
+    sinkNames.push("file");
+  }
+
+  return { sinks, sinkNames };
+}
+
 export function configureLogging() {
   if (loggingConfigured) {
     return loggingConfigured;
@@ -81,20 +287,19 @@ export function configureLogging() {
       : process.env.NODE_ENV === "production"
         ? "info"
         : "debug";
+  const { sinks, sinkNames } = serverLogSinks();
 
   loggingConfigured = configure({
-    sinks: {
-      console: getConsoleSink(),
-    },
+    sinks,
     loggers: [
       {
         category: [...SERVER_LOG_CATEGORY_PREFIX],
-        sinks: ["console"],
+        sinks: sinkNames,
         lowestLevel,
       },
       {
         category: [...LOGTAPE_META_CATEGORY],
-        sinks: ["console"],
+        sinks: sinkNames,
         lowestLevel: "warning",
       },
     ],

--- a/apps/www/src/content/docs/configuration.mdx
+++ b/apps/www/src/content/docs/configuration.mdx
@@ -5,7 +5,29 @@ order: 20
 ---
 
 import Callout from "@/components/Callout.astro";
+import CommandBlock from "@/components/CommandBlock.astro";
 import EnvVarTable from "@/components/EnvVarTable.astro";
+
+const structuredConsoleLoggingCommand = `docker run -d \\
+  --name cliparr \\
+  -p 3000:3000 \\
+  -e APP_KEY="your-32-char-stable-random-secret" \\
+  -e CLIPARR_LOG_FORMAT=json \\
+  -v cliparr-data:/data \\
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+const rotatingFileLoggingCompose = `services:
+  cliparr:
+    image: ghcr.io/techsquidtv/cliparr:latest
+    environment:
+      - APP_KEY=replace-this-with-a-32-character-secure-random-string
+      - CLIPARR_LOG_FORMAT=pretty
+      - CLIPARR_LOG_FILE=/data/logs/cliparr.log
+      - CLIPARR_LOG_FILE_FORMAT=json
+      - CLIPARR_LOG_FILE_MAX_SIZE=10mb
+      - CLIPARR_LOG_FILE_MAX_FILES=5
+    volumes:
+      - cliparr-data:/data`;
 
 Cliparr only needs a few settings in production: a stable `APP_KEY` and a persistent data directory.
 
@@ -30,9 +52,38 @@ The default container data directory is `/data`. In production, mount that path 
 
 ## Logging
 
-Server logs default to readable terminal output. Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` when you want each console line to include the structured event fields used by Cliparr's LogTape events.
+Server logs default to `pretty`, the readable terminal format used during local development. Pretty logs show the timestamp, level, category, and message. They are easy to scan, but they intentionally do not print every structured field attached to the event.
 
-Set `CLIPARR_LOG_FILE` to write a second, rotating server log file. File logs default to JSON when no explicit format is configured, rotate at `CLIPARR_LOG_FILE_MAX_SIZE`, and keep `CLIPARR_LOG_FILE_MAX_FILES` total files including the active file.
+Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` when you want each console line to include Cliparr's structured LogTape fields, such as `event.name`, `event.outcome`, request data, provider IDs, media handle IDs, counts, durations, and error details. JSON is best for log collectors. logfmt is compact and readable in plain terminals.
+
+<CommandBlock
+  code={structuredConsoleLoggingCommand}
+  label="Structured console logs"
+  lang="bash"
+/>
+
+`CLIPARR_LOG_LEVEL` controls how much the server emits. Development defaults to `debug`; production defaults to `info`. Use `trace` only while chasing detailed media proxy or playback behavior because it can be noisy.
+
+### File logging
+
+Set `CLIPARR_LOG_FILE` to write a second server log destination in addition to the console. File logging is opt-in and rotates by size so diagnostics do not grow forever on long-running installs.
+
+<CommandBlock
+  code={rotatingFileLoggingCompose}
+  label="Rotating file logs"
+  lang="yaml"
+/>
+
+Relative file paths resolve from the server working directory. In containers, prefer a path under `/data` so logs persist with the Cliparr volume. File logs default to JSON unless `CLIPARR_LOG_FILE_FORMAT` is set. If `CLIPARR_LOG_FILE_FORMAT` is omitted but `CLIPARR_LOG_FORMAT` is set, the file uses the console format.
+
+`CLIPARR_LOG_FILE_MAX_SIZE` accepts byte sizes with optional `b`, `kb`, `mb`, `gb`, `kib`, `mib`, or `gib` suffixes and defaults to `10mb`. `CLIPARR_LOG_FILE_MAX_FILES` defaults to `5` and includes the active file, so the default keeps `cliparr.log` plus up to four rotated files.
+
+<Callout title="Sharing logs" tone="info">
+  Cliparr avoids logging tokens, credentials, raw auth URLs, subtitle text, and
+  full media metadata by default. Logs can still include source IDs, media
+  handle IDs, request paths, durations, status codes, and sanitized upstream
+  paths, so review them before posting publicly.
+</Callout>
 
 ## Clip metadata
 

--- a/apps/www/src/content/docs/configuration.mdx
+++ b/apps/www/src/content/docs/configuration.mdx
@@ -7,27 +7,10 @@ order: 20
 import Callout from "@/components/Callout.astro";
 import CommandBlock from "@/components/CommandBlock.astro";
 import EnvVarTable from "@/components/EnvVarTable.astro";
-
-const structuredConsoleLoggingCommand = `docker run -d \\
-  --name cliparr \\
-  -p 3000:3000 \\
-  -e APP_KEY="your-32-char-stable-random-secret" \\
-  -e CLIPARR_LOG_FORMAT=json \\
-  -v cliparr-data:/data \\
-  ghcr.io/techsquidtv/cliparr:latest`;
-
-const rotatingFileLoggingCompose = `services:
-  cliparr:
-    image: ghcr.io/techsquidtv/cliparr:latest
-    environment:
-      - APP_KEY=replace-this-with-a-32-character-secure-random-string
-      - CLIPARR_LOG_FORMAT=pretty
-      - CLIPARR_LOG_FILE=/data/logs/cliparr.log
-      - CLIPARR_LOG_FILE_FORMAT=json
-      - CLIPARR_LOG_FILE_MAX_SIZE=10mb
-      - CLIPARR_LOG_FILE_MAX_FILES=5
-    volumes:
-      - cliparr-data:/data`;
+import {
+  rotatingFileLoggingCompose,
+  structuredConsoleLoggingCommand,
+} from "@/data/product";
 
 Cliparr only needs a few settings in production: a stable `APP_KEY` and a persistent data directory.
 

--- a/apps/www/src/content/docs/configuration.mdx
+++ b/apps/www/src/content/docs/configuration.mdx
@@ -28,6 +28,12 @@ The editor uses browser WebCodecs. Supporting browsers require a secure context,
 
 The default container data directory is `/data`. In production, mount that path to a volume so SQLite state and encrypted provider credentials survive updates.
 
+## Logging
+
+Server logs default to readable terminal output. Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` when you want each console line to include the structured event fields used by Cliparr's LogTape events.
+
+Set `CLIPARR_LOG_FILE` to write a second, rotating server log file. File logs default to JSON when no explicit format is configured, rotate at `CLIPARR_LOG_FILE_MAX_SIZE`, and keep `CLIPARR_LOG_FILE_MAX_FILES` total files including the active file.
+
 ## Clip metadata
 
 Cliparr passes metadata to Mediabunny during export when the selected source includes `exportMetadata`. Local files and direct URLs may not have source metadata, so these fields are best-effort.

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -124,6 +124,48 @@ export const envVars = [
     required: false,
   },
   {
+    name: "CLIPARR_LOG_LEVEL",
+    description:
+      "Server log level. Supports trace, debug, info, warning, error, and fatal. Defaults to debug in development and info in production.",
+    defaultValue: "debug/info",
+    required: false,
+  },
+  {
+    name: "CLIPARR_LOG_FORMAT",
+    description:
+      "Server console log format. Use json or logfmt to expose structured fields.",
+    defaultValue: "pretty",
+    required: false,
+  },
+  {
+    name: "CLIPARR_LOG_FILE",
+    description:
+      "Optional path for a rotating server log file. Relative paths resolve from the server working directory.",
+    defaultValue: "-",
+    required: false,
+  },
+  {
+    name: "CLIPARR_LOG_FILE_FORMAT",
+    description:
+      "Optional log file format. Defaults to CLIPARR_LOG_FORMAT when set, otherwise json.",
+    defaultValue: "json",
+    required: false,
+  },
+  {
+    name: "CLIPARR_LOG_FILE_MAX_SIZE",
+    description:
+      "Maximum size for each rotating server log file. Supports kb, mb, and gb suffixes.",
+    defaultValue: "10mb",
+    required: false,
+  },
+  {
+    name: "CLIPARR_LOG_FILE_MAX_FILES",
+    description:
+      "Total number of rotating server log files to keep, including the active file.",
+    defaultValue: "5",
+    required: false,
+  },
+  {
     name: "CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS",
     description:
       "Allow Jellyfin URLs that resolve to localhost or loopback. Use only for trusted self-hosted setups.",

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -84,6 +84,27 @@ export const dockerComposeExample = `services:
 volumes:
   cliparr-data:`;
 
+export const structuredConsoleLoggingCommand = `docker run -d \\
+  --name cliparr \\
+  -p 3000:3000 \\
+  -e APP_KEY="your-32-char-stable-random-secret" \\
+  -e CLIPARR_LOG_FORMAT=json \\
+  -v cliparr-data:/data \\
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+export const rotatingFileLoggingCompose = `services:
+  cliparr:
+    image: ghcr.io/techsquidtv/cliparr:latest
+    environment:
+      - APP_KEY=replace-this-with-a-32-character-secure-random-string
+      - CLIPARR_LOG_FORMAT=pretty
+      - CLIPARR_LOG_FILE=/data/logs/cliparr.log
+      - CLIPARR_LOG_FILE_FORMAT=json
+      - CLIPARR_LOG_FILE_MAX_SIZE=10mb
+      - CLIPARR_LOG_FILE_MAX_FILES=5
+    volumes:
+      - cliparr-data:/data`;
+
 export const developmentSetupCommands = `git clone https://github.com/techsquidtv/cliparr.git
 cd cliparr
 cp .env.example .env


### PR DESCRIPTION
## Summary
- Add CLIPARR_LOG_FORMAT=pretty|json|logfmt for server console logs.
- Add optional CLIPARR_LOG_FILE output with size-based rotation and configurable file format/retention.
- Document the new logging env vars and cover env parsing with server tests.

## Validation
- pnpm preflight