### PR TITLE
chore(cliparr): tighten dev log settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,10 @@ CLIPARR_DATA_DIR="./.cliparr-data"
 # Defaults to debug in development and info in production.
 # CLIPARR_LOG_LEVEL="debug"
 
-# CLIPARR_LOG_FORMAT: Optional server console log format.
-# pretty keeps the human terminal output; json/logfmt include structured fields.
+# CLIPARR_LOG_FORMAT: Optional production server console log format.
+# Development console logs are always JSON so structured fields are visible.
+# In production, pretty keeps human terminal output; json/logfmt include
+# structured fields.
 # Supported values: pretty, json, logfmt.
 # CLIPARR_LOG_FORMAT="pretty"
 

--- a/README.md
+++ b/README.md
@@ -85,18 +85,18 @@ volumes:
 
 <!-- CLIPARR_DOCS_SYNC:configuration:start -->
 
-| Variable                               | Description                                                                                                                        | Default      |
-| :------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------- |
-| `APP_KEY`                              | Required secret for credential encryption. Must be at least 32 characters long.                                                    | `-`          |
-| `PORT`                                 | Internal port for the Express server.                                                                                              | `3000`       |
-| `CLIPARR_DATA_DIR`                     | Directory for SQLite storage.                                                                                                      | `/data`      |
-| `CLIPARR_LOG_LEVEL`                    | Server log level. Supports trace, debug, info, warning, error, and fatal. Defaults to debug in development and info in production. | `debug/info` |
-| `CLIPARR_LOG_FORMAT`                   | Server console log format. Use json or logfmt to expose structured fields.                                                         | `pretty`     |
-| `CLIPARR_LOG_FILE`                     | Optional path for a rotating server log file. Relative paths resolve from the server working directory.                            | `-`          |
-| `CLIPARR_LOG_FILE_FORMAT`              | Optional log file format. Defaults to CLIPARR_LOG_FORMAT when set, otherwise json.                                                 | `json`       |
-| `CLIPARR_LOG_FILE_MAX_SIZE`            | Maximum size for each rotating server log file. Supports kb, mb, and gb suffixes.                                                  | `10mb`       |
-| `CLIPARR_LOG_FILE_MAX_FILES`           | Total number of rotating server log files to keep, including the active file.                                                      | `5`          |
-| `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to localhost or loopback. Use only for trusted self-hosted setups.                                | `false`      |
+| Variable                               | Description                                                                                                                        | Default                  |
+| :------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------------------- |
+| `APP_KEY`                              | Required secret for credential encryption. Must be at least 32 characters long.                                                    | `-`                      |
+| `PORT`                                 | Internal port for the Express server.                                                                                              | `3000`                   |
+| `CLIPARR_DATA_DIR`                     | Directory for SQLite storage.                                                                                                      | `/data`                  |
+| `CLIPARR_LOG_LEVEL`                    | Server log level. Supports trace, debug, info, warning, error, and fatal. Defaults to debug in development and info in production. | `debug/info`             |
+| `CLIPARR_LOG_FORMAT`                   | Production server console log format. Development console logs are always JSON.                                                    | `json dev / pretty prod` |
+| `CLIPARR_LOG_FILE`                     | Optional path for a rotating server log file. Relative paths resolve from the server working directory.                            | `-`                      |
+| `CLIPARR_LOG_FILE_FORMAT`              | Optional log file format. Defaults to CLIPARR_LOG_FORMAT when set, otherwise json.                                                 | `json`                   |
+| `CLIPARR_LOG_FILE_MAX_SIZE`            | Maximum size for each rotating server log file. Supports kb, mb, and gb suffixes.                                                  | `10mb`                   |
+| `CLIPARR_LOG_FILE_MAX_FILES`           | Total number of rotating server log files to keep, including the active file.                                                      | `5`                      |
+| `CLIPARR_ALLOW_LOOPBACK_JELLYFIN_URLS` | Allow Jellyfin URLs that resolve to localhost or loopback. Use only for trusted self-hosted setups.                                | `false`                  |
 
 <!-- CLIPARR_DOCS_SYNC:configuration:end -->
 

--- a/apps/frontend/src/logging.test.ts
+++ b/apps/frontend/src/logging.test.ts
@@ -1,0 +1,13 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveFrontendConsoleLogFormat } from "@/logging";
+
+void test("uses JSON console logs in development", () => {
+  assert.equal(resolveFrontendConsoleLogFormat({ PROD: false }), "json");
+});
+
+void test("keeps pretty console logs in production", () => {
+  assert.equal(resolveFrontendConsoleLogFormat({ PROD: true }), "pretty");
+});

--- a/apps/frontend/src/logging.ts
+++ b/apps/frontend/src/logging.ts
@@ -1,6 +1,7 @@
 import {
   configure,
   getConsoleSink,
+  getJsonLinesFormatter,
   getLogger,
   isLogLevel,
   type Logger,
@@ -12,7 +13,9 @@ const LOGTAPE_META_CATEGORY = ["logtape", "meta"] as const;
 
 let loggingConfigured: Promise<void> | undefined;
 
-interface ViteLoggingEnv {
+type FrontendLogFormat = "pretty" | "json";
+
+export interface ViteLoggingEnv {
   readonly VITE_CLIPARR_LOG_LEVEL?: string;
   readonly PROD: boolean;
 }
@@ -36,6 +39,22 @@ export function warnWithError(
   logger.warn(message, properties);
 }
 
+export function resolveFrontendConsoleLogFormat(
+  viteEnv: ViteLoggingEnv,
+): FrontendLogFormat {
+  return viteEnv.PROD ? "pretty" : "json";
+}
+
+function frontendConsoleSink(viteEnv: ViteLoggingEnv) {
+  if (resolveFrontendConsoleLogFormat(viteEnv) === "json") {
+    return getConsoleSink({
+      formatter: getJsonLinesFormatter({ properties: "flatten" }),
+    });
+  }
+
+  return getConsoleSink();
+}
+
 export function configureFrontendLogging() {
   if (loggingConfigured) {
     return loggingConfigured;
@@ -52,7 +71,7 @@ export function configureFrontendLogging() {
 
   loggingConfigured = configure({
     sinks: {
-      console: getConsoleSink(),
+      console: frontendConsoleSink(viteEnv),
     },
     loggers: [
       {

--- a/apps/server/src/logging.test.ts
+++ b/apps/server/src/logging.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   resolveLogFileMaxBytes,
   resolveLogFileMaxFiles,
+  resolveServerConsoleLogFormat,
   resolveServerLogFileConfig,
   resolveServerLogFormat,
 } from "@/logging";
@@ -16,6 +17,41 @@ void test("resolves supported server log formats", () => {
 void test("falls back to pretty for invalid server log formats", () => {
   assert.equal(resolveServerLogFormat(undefined), "pretty");
   assert.equal(resolveServerLogFormat("verbose"), "pretty");
+});
+
+void test("uses JSON console logs outside production", () => {
+  assert.equal(resolveServerConsoleLogFormat({}), "json");
+  assert.equal(
+    resolveServerConsoleLogFormat({
+      NODE_ENV: "development",
+      CLIPARR_LOG_FORMAT: "pretty",
+    }),
+    "json",
+  );
+  assert.equal(
+    resolveServerConsoleLogFormat({
+      NODE_ENV: "test",
+      CLIPARR_LOG_FORMAT: "logfmt",
+    }),
+    "json",
+  );
+});
+
+void test("uses configured console log format in production", () => {
+  assert.equal(
+    resolveServerConsoleLogFormat({
+      NODE_ENV: "production",
+      CLIPARR_LOG_FORMAT: "logfmt",
+    }),
+    "logfmt",
+  );
+  assert.equal(
+    resolveServerConsoleLogFormat({
+      NODE_ENV: "production",
+      CLIPARR_LOG_FORMAT: "verbose",
+    }),
+    "pretty",
+  );
 });
 
 void test("resolves rotating log file size limits", () => {

--- a/apps/server/src/logging.ts
+++ b/apps/server/src/logging.ts
@@ -107,6 +107,16 @@ export function resolveServerLogFormat(value: string | undefined) {
   return "pretty";
 }
 
+export function resolveServerConsoleLogFormat(
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  if (env.NODE_ENV !== "production") {
+    return "json";
+  }
+
+  return resolveServerLogFormat(env.CLIPARR_LOG_FORMAT);
+}
+
 export function resolveLogFileMaxBytes(value: string | undefined) {
   const trimmed = value?.trim().toLowerCase();
   if (!trimmed) {
@@ -262,7 +272,7 @@ function rotatingFileSink(config: ServerLogFileConfig) {
 
 function serverLogSinks(env: NodeJS.ProcessEnv = process.env) {
   const sinks: Record<string, Sink> = {
-    console: serverConsoleSink(resolveServerLogFormat(env.CLIPARR_LOG_FORMAT)),
+    console: serverConsoleSink(resolveServerConsoleLogFormat(env)),
   };
   const sinkNames = ["console"];
   const fileConfig = resolveServerLogFileConfig(env);

--- a/apps/www/src/content/docs/logging.mdx
+++ b/apps/www/src/content/docs/logging.mdx
@@ -12,9 +12,9 @@ import {
   structuredConsoleLoggingCommand,
 } from "@/data/product";
 
-Server logs default to `pretty`, the readable terminal format used during local development. Pretty logs show the timestamp, level, category, and message. They are easy to scan, but they intentionally do not print every structured field attached to the event.
+Development server logs are emitted as JSON Lines so every local console line includes Cliparr's structured LogTape fields. Frontend development logs use the same JSON format in the browser console.
 
-Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` when you want each console line to include Cliparr's structured LogTape fields, such as `event.name`, `event.outcome`, request data, provider IDs, media handle IDs, counts, durations, and error details. JSON is best for log collectors. logfmt is compact and readable in plain terminals.
+Production server logs default to `pretty`, the readable terminal format that shows the timestamp, level, category, and message. Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` in production when you want each console line to include structured fields such as `event.name`, `event.outcome`, request data, provider IDs, media handle IDs, counts, durations, and error details. JSON is best for log collectors. logfmt is compact and readable in plain terminals.
 
 <CommandBlock
   code={structuredConsoleLoggingCommand}
@@ -34,7 +34,7 @@ Set `CLIPARR_LOG_FILE` to write a second server log destination in addition to t
   lang="yaml"
 />
 
-Relative file paths resolve from the server working directory. In containers, prefer a path under `/data` so logs persist with the Cliparr volume. File logs default to JSON unless `CLIPARR_LOG_FILE_FORMAT` is set. If `CLIPARR_LOG_FILE_FORMAT` is omitted but `CLIPARR_LOG_FORMAT` is set, the file uses the console format.
+Relative file paths resolve from the server working directory. In containers, prefer a path under `/data` so logs persist with the Cliparr volume. File logs default to JSON unless `CLIPARR_LOG_FILE_FORMAT` is set. If `CLIPARR_LOG_FILE_FORMAT` is omitted but `CLIPARR_LOG_FORMAT` is set, the file uses that configured production log format.
 
 `CLIPARR_LOG_FILE_MAX_SIZE` accepts byte sizes with optional `b`, `kb`, `mb`, `gb`, `kib`, `mib`, or `gib` suffixes and defaults to `10mb`. `CLIPARR_LOG_FILE_MAX_FILES` defaults to `5` and includes the active file, so the default keeps `cliparr.log` plus up to four rotated files.
 

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -155,8 +155,8 @@ export const envVars = [
   {
     name: "CLIPARR_LOG_FORMAT",
     description:
-      "Server console log format. Use json or logfmt to expose structured fields.",
-    defaultValue: "pretty",
+      "Production server console log format. Development console logs are always JSON.",
+    defaultValue: "json dev / pretty prod",
     required: false,
   },
   {


### PR DESCRIPTION
## Summary

- Force server console logs to JSON outside production while preserving production `CLIPARR_LOG_FORMAT`.
- Use JSON Lines for frontend development LogTape console output.
- Update logging docs, `.env.example`, and README-generated configuration docs for the new dev/production behavior.

## Validation

- `pnpm preflight`
- `rg -n 'console\.' apps packages --glob '!node_modules' --glob '!dist' --glob '!*.lock' --glob '!*.mdx'`
