### PR TITLE
feat(frontend): add framegrab export

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -27,6 +27,10 @@ flowchart TD
     C1 --> C3["exportMetadata"]
     C1 --> C4["subtitle burn-in processor"]
 
+    A --> H["EditorFramegrabDialog"]
+    H --> H1["framegrab canvas helpers"]
+    H --> C2
+
     D --> D1["timelineZoom helpers"]
 
     F["SourcesModal"] --> F1["useSourcesModalState"]
@@ -263,6 +267,9 @@ flowchart LR
     D --> K["Preview tracks for browser playback"]
     D --> L["Optional playbackReadyRange for HLS preview only"]
     L --> M["EditorTimeline Preview Ready overlay and note"]
+    D --> P["Preview canvas with optional subtitles"]
+    P --> Q["Framegrab dialog"]
+    Q --> R["PNG clipboard or image download"]
     B --> G["useEditorExport source selection"]
     C --> G
     F --> G

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -189,53 +189,53 @@ export function EditorControls({
               } as CSSProperties
             }
           />
-          <div className="ml-1 flex items-center overflow-hidden rounded-[var(--radius-control)] border border-editor-border bg-editor-control">
-            <ControlTooltip
-              label={
-                canZoomOut ? "Zoom timeline out" : "Already fully zoomed out"
-              }
-              disabled={!canZoomOut}
-            >
-              <button
-                type="button"
-                onClick={handleTimelineZoomOut}
-                disabled={!canZoomOut}
-                className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-                aria-label="Zoom timeline out"
-              >
-                <ZoomOut className="h-4 w-4" />
-              </button>
-            </ControlTooltip>
-            <ControlTooltip
-              label={canZoomIn ? "Zoom timeline in" : "Already fully zoomed in"}
-              disabled={!canZoomIn}
-            >
-              <button
-                type="button"
-                onClick={handleTimelineZoomIn}
-                disabled={!canZoomIn}
-                className="flex h-8 w-8 items-center justify-center border-l border-editor-border text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-                aria-label="Zoom timeline in"
-              >
-                <ZoomIn className="h-4 w-4" />
-              </button>
-            </ControlTooltip>
-          </div>
+        </div>
+        <div className="flex items-center overflow-hidden rounded-[var(--radius-control)] border border-editor-border bg-editor-control">
           <ControlTooltip
-            label={framegrabDisabledReason ?? "Export current frame"}
-            disabled={framegrabDisabled}
+            label={
+              canZoomOut ? "Zoom timeline out" : "Already fully zoomed out"
+            }
+            disabled={!canZoomOut}
           >
             <button
               type="button"
-              onClick={onFramegrabClick}
-              disabled={framegrabDisabled}
-              className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-              aria-label="Export current preview frame"
+              onClick={handleTimelineZoomOut}
+              disabled={!canZoomOut}
+              className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label="Zoom timeline out"
             >
-              <Camera className="h-4 w-4" />
+              <ZoomOut className="h-4 w-4" />
+            </button>
+          </ControlTooltip>
+          <ControlTooltip
+            label={canZoomIn ? "Zoom timeline in" : "Already fully zoomed in"}
+            disabled={!canZoomIn}
+          >
+            <button
+              type="button"
+              onClick={handleTimelineZoomIn}
+              disabled={!canZoomIn}
+              className="flex h-8 w-8 items-center justify-center border-l border-editor-border text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label="Zoom timeline in"
+            >
+              <ZoomIn className="h-4 w-4" />
             </button>
           </ControlTooltip>
         </div>
+        <ControlTooltip
+          label={framegrabDisabledReason ?? "Export current frame"}
+          disabled={framegrabDisabled}
+        >
+          <button
+            type="button"
+            onClick={onFramegrabClick}
+            disabled={framegrabDisabled}
+            className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+            aria-label="Export current preview frame"
+          >
+            <Camera className="h-4 w-4" />
+          </button>
+        </ControlTooltip>
         <div className="min-w-0 flex-1" />
         <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-right sm:gap-x-6">
           {clipMetrics.map((metric) => (

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,5 +1,13 @@
 import { useMemo, type CSSProperties, type ReactElement } from "react";
-import { Pause, Play, Volume2, VolumeX, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  Camera,
+  Pause,
+  Play,
+  Volume2,
+  VolumeX,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -28,6 +36,8 @@ interface EditorControlsProps {
   handleTimelineZoomOut: () => void;
   canZoomIn: boolean;
   canZoomOut: boolean;
+  onFramegrabClick: () => void;
+  framegrabDisabledReason: string | null;
   onPreviewTimeCommit: (time: number) => void | Promise<void>;
   onStartTimeCommit: (time: number) => void | Promise<void>;
   onEndTimeCommit: (time: number) => void | Promise<void>;
@@ -74,6 +84,8 @@ export function EditorControls({
   handleTimelineZoomOut,
   canZoomIn,
   canZoomOut,
+  onFramegrabClick,
+  framegrabDisabledReason,
   onPreviewTimeCommit,
   onStartTimeCommit,
   onEndTimeCommit,
@@ -93,6 +105,7 @@ export function EditorControls({
   const volumeRangeFillPercent = `${
     Math.min(Math.max(muted ? 0 : volume, 0), 1) * 100
   }%`;
+  const framegrabDisabled = Boolean(framegrabDisabledReason);
 
   return (
     <div className="border-b border-editor-border bg-editor-panel px-3 py-2">
@@ -208,6 +221,20 @@ export function EditorControls({
               </button>
             </ControlTooltip>
           </div>
+          <ControlTooltip
+            label={framegrabDisabledReason ?? "Export current frame"}
+            disabled={framegrabDisabled}
+          >
+            <button
+              type="button"
+              onClick={onFramegrabClick}
+              disabled={framegrabDisabled}
+              className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label="Export current preview frame"
+            >
+              <Camera className="h-4 w-4" />
+            </button>
+          </ControlTooltip>
         </div>
         <div className="min-w-0 flex-1" />
         <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-right sm:gap-x-6">

--- a/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialogSections.tsx
@@ -20,6 +20,10 @@ import {
   type ExportFileNameTemplateSettings,
 } from "@/lib/exportFileName";
 import type { ExportSourcePreference } from "@/components/editor/EditorExportDialog";
+import {
+  compactSelectTriggerClassName,
+  sectionLabelClassName,
+} from "@/components/editor/editorDialogStyles";
 import { formatTime } from "@/components/editor/editorUtils";
 
 interface VideoDimensions {
@@ -98,14 +102,6 @@ const templateOptions: ReadonlyArray<{
     description: "Used for episode exports with series metadata.",
   },
 ];
-
-function compactSelectTriggerClassName() {
-  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
-}
-
-function sectionLabelClassName() {
-  return "text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground";
-}
 
 export function formatOptionFor(format: ExportFormat) {
   return (

--- a/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
@@ -38,7 +38,7 @@ interface EditorFramegrabDialogProps {
   dimensions: {
     width: number;
     height: number;
-  };
+  } | null;
   selectedFormat: FramegrabImageFormat;
   onFormatChange: (format: FramegrabImageFormat) => void;
   selectedQuality: FramegrabImageQuality;
@@ -71,6 +71,7 @@ export function EditorFramegrabDialog({
 }: EditorFramegrabDialogProps) {
   const selectedFormatOption = framegrabFormatOptionFor(selectedFormat);
   const busy = processingAction !== null;
+  const hasFrame = dimensions !== null;
   const qualityDisabled = selectedFormat === "png";
 
   return (
@@ -153,7 +154,7 @@ export function EditorFramegrabDialog({
 
             <dl className="grid gap-2 text-sm sm:grid-cols-2">
               <div className="rounded-md border border-border bg-background px-3 py-2">
-                <dt className={sectionLabelClassName()}>Frame</dt>
+                <dt className={sectionLabelClassName()}>Time</dt>
                 <dd className="mt-1 font-mono text-xs text-foreground">
                   {formatTime(frameTime)}
                 </dd>
@@ -161,7 +162,9 @@ export function EditorFramegrabDialog({
               <div className="rounded-md border border-border bg-background px-3 py-2">
                 <dt className={sectionLabelClassName()}>Size</dt>
                 <dd className="mt-1 font-mono text-xs text-foreground">
-                  {dimensions.width} x {dimensions.height}
+                  {dimensions
+                    ? `${dimensions.width} x ${dimensions.height}`
+                    : "Unavailable"}
                 </dd>
               </div>
             </dl>
@@ -188,7 +191,7 @@ export function EditorFramegrabDialog({
         <button
           type="button"
           onClick={onCopy}
-          disabled={busy}
+          disabled={busy || !hasFrame}
           className={compactSecondaryButtonClasses}
         >
           {processingAction === "copy" ? (
@@ -202,7 +205,7 @@ export function EditorFramegrabDialog({
         <button
           type="button"
           onClick={onDownload}
-          disabled={busy}
+          disabled={busy || !hasFrame}
           className={`${compactPrimaryButtonClasses} w-44`}
         >
           {processingAction === "download" ? (

--- a/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
@@ -1,19 +1,18 @@
 import { Copy, Download, LoaderCircle } from "lucide-react";
-import type { FramegrabImageFormat } from "@/lib/framegrab";
+import type {
+  FramegrabImageFormat,
+  FramegrabImageQuality,
+} from "@/lib/framegrab";
 import {
   framegrabFormatOptionFor,
   framegrabImageFormatOptions,
+  framegrabImageQualityOptions,
 } from "@/lib/framegrab";
-import {
-  DialogClose,
-  DialogFooter,
-  DialogWindow,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogWindow } from "@/components/ui/dialog";
 import {
   compactPrimaryButtonClasses,
   compactSecondaryButtonClasses,
   destructiveAlertClasses,
-  primaryAlertClasses,
 } from "@/components/ui/control-styles";
 import {
   compactSelectTriggerClassName,
@@ -42,6 +41,8 @@ interface EditorFramegrabDialogProps {
   };
   selectedFormat: FramegrabImageFormat;
   onFormatChange: (format: FramegrabImageFormat) => void;
+  selectedQuality: FramegrabImageQuality;
+  onQualityChange: (quality: FramegrabImageQuality) => void;
   fileNamePreview: string;
   processingAction: FramegrabAction | null;
   error: string | null;
@@ -58,6 +59,8 @@ export function EditorFramegrabDialog({
   dimensions,
   selectedFormat,
   onFormatChange,
+  selectedQuality,
+  onQualityChange,
   fileNamePreview,
   processingAction,
   error,
@@ -68,6 +71,7 @@ export function EditorFramegrabDialog({
 }: EditorFramegrabDialogProps) {
   const selectedFormatOption = framegrabFormatOptionFor(selectedFormat);
   const busy = processingAction !== null;
+  const qualityDisabled = selectedFormat === "png";
 
   return (
     <DialogWindow
@@ -82,7 +86,6 @@ export function EditorFramegrabDialog({
     >
       <div className="space-y-4 overflow-y-auto p-4">
         {error ? <div className={destructiveAlertClasses}>{error}</div> : null}
-        {message ? <div className={primaryAlertClasses}>{message}</div> : null}
 
         <section className="rounded-md border border-border bg-card">
           <div className="border-b border-border px-3 py-2">
@@ -91,32 +94,62 @@ export function EditorFramegrabDialog({
           <div className="space-y-3 p-3">
             <div className="text-sm font-medium text-foreground">{title}</div>
 
-            <label className="block space-y-1.5">
-              <span className={sectionLabelClassName()}>Image Type</span>
-              <Select
-                value={selectedFormat}
-                onValueChange={(value) =>
-                  onFormatChange(value as FramegrabImageFormat)
-                }
-              >
-                <SelectTrigger
-                  size="sm"
-                  className={compactSelectTriggerClassName()}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="block space-y-1.5">
+                <span className={sectionLabelClassName()}>Image Type</span>
+                <Select
+                  value={selectedFormat}
+                  onValueChange={(value) =>
+                    onFormatChange(value as FramegrabImageFormat)
+                  }
                 >
-                  <SelectValue placeholder="Select image type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>Image Types</SelectLabel>
-                    {framegrabImageFormatOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label} {option.extension}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </label>
+                  <SelectTrigger
+                    size="sm"
+                    className={compactSelectTriggerClassName()}
+                  >
+                    <SelectValue placeholder="Select image type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Image Types</SelectLabel>
+                      {framegrabImageFormatOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label} {option.extension}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </label>
+
+              <label className="block space-y-1.5">
+                <span className={sectionLabelClassName()}>Quality</span>
+                <Select
+                  value={selectedQuality}
+                  onValueChange={(value) =>
+                    onQualityChange(value as FramegrabImageQuality)
+                  }
+                  disabled={qualityDisabled}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className={compactSelectTriggerClassName()}
+                  >
+                    <SelectValue placeholder="Select quality" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Quality</SelectLabel>
+                      {framegrabImageQualityOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </label>
+            </div>
 
             <dl className="grid gap-2 text-sm sm:grid-cols-2">
               <div className="rounded-md border border-border bg-background px-3 py-2">
@@ -144,9 +177,13 @@ export function EditorFramegrabDialog({
       </div>
 
       <DialogFooter className="border-t border-border bg-card px-4 py-3">
-        <DialogClose disabled={busy} className={compactSecondaryButtonClasses}>
-          Cancel
-        </DialogClose>
+        <span
+          role="status"
+          aria-live="polite"
+          className="flex min-h-8 min-w-0 flex-1 items-center truncate text-xs text-muted-foreground"
+        >
+          {message}
+        </span>
 
         <button
           type="button"
@@ -166,7 +203,7 @@ export function EditorFramegrabDialog({
           type="button"
           onClick={onDownload}
           disabled={busy}
-          className={compactPrimaryButtonClasses}
+          className={`${compactPrimaryButtonClasses} w-44`}
         >
           {processingAction === "download" ? (
             <LoaderCircle className="h-4 w-4 animate-spin" />

--- a/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
@@ -16,6 +16,10 @@ import {
   primaryAlertClasses,
 } from "@/components/ui/control-styles";
 import {
+  compactSelectTriggerClassName,
+  sectionLabelClassName,
+} from "@/components/editor/editorDialogStyles";
+import {
   Select,
   SelectContent,
   SelectGroup,
@@ -45,14 +49,6 @@ interface EditorFramegrabDialogProps {
   onClose: () => void;
   onCopy: () => void;
   onDownload: () => void;
-}
-
-function sectionLabelClassName() {
-  return "text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground";
-}
-
-function compactSelectTriggerClassName() {
-  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
 }
 
 export function EditorFramegrabDialog({

--- a/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorFramegrabDialog.tsx
@@ -1,0 +1,185 @@
+import { Copy, Download, LoaderCircle } from "lucide-react";
+import type { FramegrabImageFormat } from "@/lib/framegrab";
+import {
+  framegrabFormatOptionFor,
+  framegrabImageFormatOptions,
+} from "@/lib/framegrab";
+import {
+  DialogClose,
+  DialogFooter,
+  DialogWindow,
+} from "@/components/ui/dialog";
+import {
+  compactPrimaryButtonClasses,
+  compactSecondaryButtonClasses,
+  destructiveAlertClasses,
+  primaryAlertClasses,
+} from "@/components/ui/control-styles";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatTime } from "@/components/editor/editorUtils";
+
+type FramegrabAction = "copy" | "download";
+
+interface EditorFramegrabDialogProps {
+  isOpen: boolean;
+  title: string;
+  frameTime: number;
+  dimensions: {
+    width: number;
+    height: number;
+  };
+  selectedFormat: FramegrabImageFormat;
+  onFormatChange: (format: FramegrabImageFormat) => void;
+  fileNamePreview: string;
+  processingAction: FramegrabAction | null;
+  error: string | null;
+  message: string | null;
+  onClose: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+}
+
+function sectionLabelClassName() {
+  return "text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground";
+}
+
+function compactSelectTriggerClassName() {
+  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
+}
+
+export function EditorFramegrabDialog({
+  isOpen,
+  title,
+  frameTime,
+  dimensions,
+  selectedFormat,
+  onFormatChange,
+  fileNamePreview,
+  processingAction,
+  error,
+  message,
+  onClose,
+  onCopy,
+  onDownload,
+}: EditorFramegrabDialogProps) {
+  const selectedFormatOption = framegrabFormatOptionFor(selectedFormat);
+  const busy = processingAction !== null;
+
+  return (
+    <DialogWindow
+      open={isOpen}
+      onClose={onClose}
+      closeDisabled={busy}
+      closeLabel="Close frame export dialog"
+      title="Export Frame"
+      description="Download or copy the current preview frame."
+      popupClassName="max-w-lg"
+      headerClassName="bg-card"
+    >
+      <div className="space-y-4 overflow-y-auto p-4">
+        {error ? <div className={destructiveAlertClasses}>{error}</div> : null}
+        {message ? <div className={primaryAlertClasses}>{message}</div> : null}
+
+        <section className="rounded-md border border-border bg-card">
+          <div className="border-b border-border px-3 py-2">
+            <div className={sectionLabelClassName()}>Image</div>
+          </div>
+          <div className="space-y-3 p-3">
+            <div className="text-sm font-medium text-foreground">{title}</div>
+
+            <label className="block space-y-1.5">
+              <span className={sectionLabelClassName()}>Image Type</span>
+              <Select
+                value={selectedFormat}
+                onValueChange={(value) =>
+                  onFormatChange(value as FramegrabImageFormat)
+                }
+              >
+                <SelectTrigger
+                  size="sm"
+                  className={compactSelectTriggerClassName()}
+                >
+                  <SelectValue placeholder="Select image type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Image Types</SelectLabel>
+                    {framegrabImageFormatOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label} {option.extension}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </label>
+
+            <dl className="grid gap-2 text-sm sm:grid-cols-2">
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <dt className={sectionLabelClassName()}>Frame</dt>
+                <dd className="mt-1 font-mono text-xs text-foreground">
+                  {formatTime(frameTime)}
+                </dd>
+              </div>
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <dt className={sectionLabelClassName()}>Size</dt>
+                <dd className="mt-1 font-mono text-xs text-foreground">
+                  {dimensions.width} x {dimensions.height}
+                </dd>
+              </div>
+            </dl>
+
+            <div className="rounded-md border border-border bg-background px-3 py-2">
+              <div className={sectionLabelClassName()}>Filename</div>
+              <div className="mt-1 break-all font-mono text-ui-label text-foreground">
+                {fileNamePreview}
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <DialogFooter className="border-t border-border bg-card px-4 py-3">
+        <DialogClose disabled={busy} className={compactSecondaryButtonClasses}>
+          Cancel
+        </DialogClose>
+
+        <button
+          type="button"
+          onClick={onCopy}
+          disabled={busy}
+          className={compactSecondaryButtonClasses}
+        >
+          {processingAction === "copy" ? (
+            <LoaderCircle className="h-4 w-4 animate-spin" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+          Copy Image
+        </button>
+
+        <button
+          type="button"
+          onClick={onDownload}
+          disabled={busy}
+          className={compactPrimaryButtonClasses}
+        >
+          {processingAction === "download" ? (
+            <LoaderCircle className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+          Download {selectedFormatOption.label}
+        </button>
+      </DialogFooter>
+    </DialogWindow>
+  );
+}

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -1,16 +1,8 @@
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import {
   clampClipEndTime,
   clampClipStartTime,
   clampPlaybackTime,
-  errorMessage,
   MIN_CLIP_SECONDS,
   roundTimelineTime,
 } from "@/components/editor/editorUtils";
@@ -38,16 +30,9 @@ import {
   EditorPreviewPane,
   EditorTimelinePane,
 } from "@/components/editor/EditorLayout";
+import { useEditorFramegrab } from "@/components/editor/useEditorFramegrab";
 import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
 import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
-import { buildFramegrabFileName } from "@/lib/exportFileName";
-import { downloadBlob } from "@/lib/downloadBlob";
-import {
-  cloneCanvasFrame,
-  copyFramegrabCanvasToClipboard,
-  encodeFramegrabCanvas,
-  type FramegrabImageFormat,
-} from "@/lib/framegrab";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
 const EditorExportDialog = lazy(() =>
@@ -67,17 +52,6 @@ interface Props {
   onBack: () => void;
 }
 
-interface CapturedFramegrab {
-  canvas: HTMLCanvasElement;
-  time: number;
-  dimensions: {
-    width: number;
-    height: number;
-  };
-}
-
-type FramegrabAction = "copy" | "download";
-
 export default function EditorScreen({ session, onBack }: Props) {
   const initialClipRange = buildInitialClipRange(
     session.duration,
@@ -87,16 +61,6 @@ export default function EditorScreen({ session, onBack }: Props) {
   const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
   const [exportDialogMounted, setExportDialogMounted] = useState(false);
-  const [framegrabDialogMounted, setFramegrabDialogMounted] = useState(false);
-  const [capturedFramegrab, setCapturedFramegrab] =
-    useState<CapturedFramegrab | null>(null);
-  const [framegrabDialogOpen, setFramegrabDialogOpen] = useState(false);
-  const [framegrabFormat, setFramegrabFormat] =
-    useState<FramegrabImageFormat>("png");
-  const [framegrabAction, setFramegrabAction] =
-    useState<FramegrabAction | null>(null);
-  const [framegrabError, setFramegrabError] = useState<string | null>(null);
-  const [framegrabMessage, setFramegrabMessage] = useState<string | null>(null);
   const {
     subtitleTracks,
     selectedSubtitleTrack,
@@ -200,6 +164,17 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitleCues,
     subtitleStyleSettings,
   });
+  const framegrab = useEditorFramegrab({
+    session,
+    canvasRef,
+    currentTime,
+    loadingPreview,
+    loadingPreviewFrame,
+    previewVideoDimensions,
+    subtitleEnabled,
+    subtitleLoading,
+    subtitleError,
+  });
   const playbackFallbackReason = buildPlaybackFallbackReason({
     activeSourceLabel,
     hasHlsSource: Boolean(session.hlsSource),
@@ -215,150 +190,6 @@ export default function EditorScreen({ session, onBack }: Props) {
       setExportDialogMounted(true);
     }
   }, [exportDialogOpen]);
-
-  useEffect(() => {
-    if (framegrabDialogOpen) {
-      setFramegrabDialogMounted(true);
-    }
-  }, [framegrabDialogOpen]);
-
-  const framegrabFileName = useMemo(
-    () =>
-      buildFramegrabFileName({
-        title: session.title,
-        sessionType: session.type,
-        metadata: session.exportMetadata,
-        frameTime: capturedFramegrab?.time ?? currentTime,
-        format: framegrabFormat,
-      }),
-    [
-      capturedFramegrab?.time,
-      currentTime,
-      framegrabFormat,
-      session.exportMetadata,
-      session.title,
-      session.type,
-    ],
-  );
-
-  const framegrabDisabledReason = useMemo(() => {
-    if (loadingPreview || loadingPreviewFrame) {
-      return "Preview frame is loading.";
-    }
-
-    if (subtitleEnabled && subtitleLoading) {
-      return "Subtitles are still loading.";
-    }
-
-    if (subtitleEnabled && subtitleError) {
-      return subtitleError;
-    }
-
-    if (!previewVideoDimensions) {
-      return "No preview frame available.";
-    }
-
-    return null;
-  }, [
-    loadingPreview,
-    loadingPreviewFrame,
-    previewVideoDimensions,
-    subtitleEnabled,
-    subtitleError,
-    subtitleLoading,
-  ]);
-
-  const handleOpenFramegrabDialog = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      setFramegrabError("No preview frame is available yet.");
-      return;
-    }
-
-    try {
-      const clonedCanvas = cloneCanvasFrame(canvas);
-      setCapturedFramegrab({
-        canvas: clonedCanvas,
-        time: currentTime,
-        dimensions: {
-          width: clonedCanvas.width,
-          height: clonedCanvas.height,
-        },
-      });
-      setFramegrabError(null);
-      setFramegrabMessage(null);
-      setFramegrabDialogOpen(true);
-    } catch (err) {
-      setFramegrabError(errorMessage(err));
-    }
-  }, [canvasRef, currentTime]);
-
-  const handleCloseFramegrabDialog = useCallback(() => {
-    if (framegrabAction) {
-      return;
-    }
-
-    setFramegrabDialogOpen(false);
-    setCapturedFramegrab(null);
-    setFramegrabError(null);
-    setFramegrabMessage(null);
-  }, [framegrabAction]);
-
-  const handleFramegrabFormatChange = useCallback(
-    (nextFormat: FramegrabImageFormat) => {
-      setFramegrabFormat(nextFormat);
-      setFramegrabError(null);
-      setFramegrabMessage(null);
-    },
-    [],
-  );
-
-  const handleCopyFramegrab = useCallback(async () => {
-    if (!capturedFramegrab || framegrabAction) {
-      return;
-    }
-
-    setFramegrabAction("copy");
-    setFramegrabError(null);
-    setFramegrabMessage(null);
-
-    try {
-      await copyFramegrabCanvasToClipboard(capturedFramegrab.canvas);
-      setFramegrabMessage("Copied to clipboard.");
-    } catch (err) {
-      setFramegrabError(errorMessage(err));
-    } finally {
-      setFramegrabAction(null);
-    }
-  }, [capturedFramegrab, framegrabAction]);
-
-  const handleDownloadFramegrab = useCallback(async () => {
-    if (!capturedFramegrab || framegrabAction) {
-      return;
-    }
-
-    setFramegrabAction("download");
-    setFramegrabError(null);
-    setFramegrabMessage(null);
-
-    try {
-      const blob = await encodeFramegrabCanvas(
-        capturedFramegrab.canvas,
-        framegrabFormat,
-      );
-      downloadBlob(blob, framegrabFileName.fullName);
-      setFramegrabMessage("Download started.");
-    } catch (err) {
-      setFramegrabError(errorMessage(err));
-    } finally {
-      setFramegrabAction(null);
-    }
-  }, [
-    capturedFramegrab,
-    framegrabAction,
-    framegrabFileName.fullName,
-    framegrabFormat,
-  ]);
 
   const updateClipRange = useCallback(
     (nextStart: number, nextEnd: number) => {
@@ -536,8 +367,8 @@ export default function EditorScreen({ session, onBack }: Props) {
       handleTimelineZoomOut={handleTimelineZoomOut}
       canZoomIn={canZoomIn}
       canZoomOut={canZoomOut}
-      onFramegrabClick={handleOpenFramegrabDialog}
-      framegrabDisabledReason={framegrabDisabledReason}
+      onFramegrabClick={framegrab.openDialog}
+      framegrabDisabledReason={framegrab.disabledReason}
       onPreviewTimeCommit={handlePreviewTimeCommit}
       onStartTimeCommit={handleStartTimeCommit}
       onEndTimeCommit={handleEndTimeCommit}
@@ -718,22 +549,22 @@ export default function EditorScreen({ session, onBack }: Props) {
         </Suspense>
       )}
 
-      {framegrabDialogMounted && capturedFramegrab && (
+      {framegrab.dialogMounted && framegrab.capturedFramegrab && (
         <Suspense fallback={null}>
           <EditorFramegrabDialog
-            isOpen={framegrabDialogOpen}
+            isOpen={framegrab.dialogOpen}
             title={session.title}
-            frameTime={capturedFramegrab.time}
-            dimensions={capturedFramegrab.dimensions}
-            selectedFormat={framegrabFormat}
-            onFormatChange={handleFramegrabFormatChange}
-            fileNamePreview={framegrabFileName.fullName}
-            processingAction={framegrabAction}
-            error={framegrabError}
-            message={framegrabMessage}
-            onClose={handleCloseFramegrabDialog}
-            onCopy={() => void handleCopyFramegrab()}
-            onDownload={() => void handleDownloadFramegrab()}
+            frameTime={framegrab.capturedFramegrab.time}
+            dimensions={framegrab.capturedFramegrab.dimensions}
+            selectedFormat={framegrab.format}
+            onFormatChange={framegrab.handleFormatChange}
+            fileNamePreview={framegrab.fileName.fullName}
+            processingAction={framegrab.action}
+            error={framegrab.error}
+            message={framegrab.message}
+            onClose={framegrab.closeDialog}
+            onCopy={() => void framegrab.copyFramegrab()}
+            onDownload={() => void framegrab.downloadFramegrab()}
           />
         </Suspense>
       )}

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -41,6 +41,7 @@ import {
 import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
 import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
 import { buildFramegrabFileName } from "@/lib/exportFileName";
+import { downloadBlob } from "@/lib/downloadBlob";
 import {
   cloneCanvasFrame,
   copyFramegrabCanvasToClipboard,
@@ -345,14 +346,7 @@ export default function EditorScreen({ session, onBack }: Props) {
         capturedFramegrab.canvas,
         framegrabFormat,
       );
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = framegrabFileName.fullName;
-      document.body.append(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, framegrabFileName.fullName);
       setFramegrabMessage("Download started.");
     } catch (err) {
       setFramegrabError(errorMessage(err));

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -549,27 +549,28 @@ export default function EditorScreen({ session, onBack }: Props) {
         </Suspense>
       )}
 
-      {framegrab.dialogMounted && framegrab.capturedFramegrab && (
-        <Suspense fallback={null}>
-          <EditorFramegrabDialog
-            isOpen={framegrab.dialogOpen}
-            title={session.title}
-            frameTime={framegrab.capturedFramegrab.time}
-            dimensions={framegrab.capturedFramegrab.dimensions}
-            selectedFormat={framegrab.format}
-            onFormatChange={framegrab.handleFormatChange}
-            selectedQuality={framegrab.quality}
-            onQualityChange={framegrab.handleQualityChange}
-            fileNamePreview={framegrab.fileName.fullName}
-            processingAction={framegrab.action}
-            error={framegrab.error}
-            message={framegrab.message}
-            onClose={framegrab.closeDialog}
-            onCopy={() => void framegrab.copyFramegrab()}
-            onDownload={() => void framegrab.downloadFramegrab()}
-          />
-        </Suspense>
-      )}
+      {framegrab.dialogMounted &&
+        (framegrab.capturedFramegrab || framegrab.error) && (
+          <Suspense fallback={null}>
+            <EditorFramegrabDialog
+              isOpen={framegrab.dialogOpen}
+              title={session.title}
+              frameTime={framegrab.capturedFramegrab?.time ?? currentTime}
+              dimensions={framegrab.capturedFramegrab?.dimensions ?? null}
+              selectedFormat={framegrab.format}
+              onFormatChange={framegrab.handleFormatChange}
+              selectedQuality={framegrab.quality}
+              onQualityChange={framegrab.handleQualityChange}
+              fileNamePreview={framegrab.fileName.fullName}
+              processingAction={framegrab.action}
+              error={framegrab.error}
+              message={framegrab.message}
+              onClose={framegrab.closeDialog}
+              onCopy={() => void framegrab.copyFramegrab()}
+              onDownload={() => void framegrab.downloadFramegrab()}
+            />
+          </Suspense>
+        )}
     </div>
   );
 }

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -1,8 +1,16 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   clampClipEndTime,
   clampClipStartTime,
   clampPlaybackTime,
+  errorMessage,
   MIN_CLIP_SECONDS,
   roundTimelineTime,
 } from "@/components/editor/editorUtils";
@@ -32,6 +40,13 @@ import {
 } from "@/components/editor/EditorLayout";
 import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
 import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
+import { buildFramegrabFileName } from "@/lib/exportFileName";
+import {
+  cloneCanvasFrame,
+  copyFramegrabCanvasToClipboard,
+  encodeFramegrabCanvas,
+  type FramegrabImageFormat,
+} from "@/lib/framegrab";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
 const EditorExportDialog = lazy(() =>
@@ -40,10 +55,27 @@ const EditorExportDialog = lazy(() =>
   })),
 );
 
+const EditorFramegrabDialog = lazy(() =>
+  import("@/components/editor/EditorFramegrabDialog").then((module) => ({
+    default: module.EditorFramegrabDialog,
+  })),
+);
+
 interface Props {
   session: EditorSession;
   onBack: () => void;
 }
+
+interface CapturedFramegrab {
+  canvas: HTMLCanvasElement;
+  time: number;
+  dimensions: {
+    width: number;
+    height: number;
+  };
+}
+
+type FramegrabAction = "copy" | "download";
 
 export default function EditorScreen({ session, onBack }: Props) {
   const initialClipRange = buildInitialClipRange(
@@ -54,6 +86,16 @@ export default function EditorScreen({ session, onBack }: Props) {
   const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
   const [exportDialogMounted, setExportDialogMounted] = useState(false);
+  const [framegrabDialogMounted, setFramegrabDialogMounted] = useState(false);
+  const [capturedFramegrab, setCapturedFramegrab] =
+    useState<CapturedFramegrab | null>(null);
+  const [framegrabDialogOpen, setFramegrabDialogOpen] = useState(false);
+  const [framegrabFormat, setFramegrabFormat] =
+    useState<FramegrabImageFormat>("png");
+  const [framegrabAction, setFramegrabAction] =
+    useState<FramegrabAction | null>(null);
+  const [framegrabError, setFramegrabError] = useState<string | null>(null);
+  const [framegrabMessage, setFramegrabMessage] = useState<string | null>(null);
   const {
     subtitleTracks,
     selectedSubtitleTrack,
@@ -172,6 +214,157 @@ export default function EditorScreen({ session, onBack }: Props) {
       setExportDialogMounted(true);
     }
   }, [exportDialogOpen]);
+
+  useEffect(() => {
+    if (framegrabDialogOpen) {
+      setFramegrabDialogMounted(true);
+    }
+  }, [framegrabDialogOpen]);
+
+  const framegrabFileName = useMemo(
+    () =>
+      buildFramegrabFileName({
+        title: session.title,
+        sessionType: session.type,
+        metadata: session.exportMetadata,
+        frameTime: capturedFramegrab?.time ?? currentTime,
+        format: framegrabFormat,
+      }),
+    [
+      capturedFramegrab?.time,
+      currentTime,
+      framegrabFormat,
+      session.exportMetadata,
+      session.title,
+      session.type,
+    ],
+  );
+
+  const framegrabDisabledReason = useMemo(() => {
+    if (loadingPreview || loadingPreviewFrame) {
+      return "Preview frame is loading.";
+    }
+
+    if (subtitleEnabled && subtitleLoading) {
+      return "Subtitles are still loading.";
+    }
+
+    if (subtitleEnabled && subtitleError) {
+      return subtitleError;
+    }
+
+    if (!previewVideoDimensions) {
+      return "No preview frame available.";
+    }
+
+    return null;
+  }, [
+    loadingPreview,
+    loadingPreviewFrame,
+    previewVideoDimensions,
+    subtitleEnabled,
+    subtitleError,
+    subtitleLoading,
+  ]);
+
+  const handleOpenFramegrabDialog = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      setFramegrabError("No preview frame is available yet.");
+      return;
+    }
+
+    try {
+      const clonedCanvas = cloneCanvasFrame(canvas);
+      setCapturedFramegrab({
+        canvas: clonedCanvas,
+        time: currentTime,
+        dimensions: {
+          width: clonedCanvas.width,
+          height: clonedCanvas.height,
+        },
+      });
+      setFramegrabError(null);
+      setFramegrabMessage(null);
+      setFramegrabDialogOpen(true);
+    } catch (err) {
+      setFramegrabError(errorMessage(err));
+    }
+  }, [canvasRef, currentTime]);
+
+  const handleCloseFramegrabDialog = useCallback(() => {
+    if (framegrabAction) {
+      return;
+    }
+
+    setFramegrabDialogOpen(false);
+    setCapturedFramegrab(null);
+    setFramegrabError(null);
+    setFramegrabMessage(null);
+  }, [framegrabAction]);
+
+  const handleFramegrabFormatChange = useCallback(
+    (nextFormat: FramegrabImageFormat) => {
+      setFramegrabFormat(nextFormat);
+      setFramegrabError(null);
+      setFramegrabMessage(null);
+    },
+    [],
+  );
+
+  const handleCopyFramegrab = useCallback(async () => {
+    if (!capturedFramegrab || framegrabAction) {
+      return;
+    }
+
+    setFramegrabAction("copy");
+    setFramegrabError(null);
+    setFramegrabMessage(null);
+
+    try {
+      await copyFramegrabCanvasToClipboard(capturedFramegrab.canvas);
+      setFramegrabMessage("Copied to clipboard.");
+    } catch (err) {
+      setFramegrabError(errorMessage(err));
+    } finally {
+      setFramegrabAction(null);
+    }
+  }, [capturedFramegrab, framegrabAction]);
+
+  const handleDownloadFramegrab = useCallback(async () => {
+    if (!capturedFramegrab || framegrabAction) {
+      return;
+    }
+
+    setFramegrabAction("download");
+    setFramegrabError(null);
+    setFramegrabMessage(null);
+
+    try {
+      const blob = await encodeFramegrabCanvas(
+        capturedFramegrab.canvas,
+        framegrabFormat,
+      );
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = framegrabFileName.fullName;
+      document.body.append(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setFramegrabMessage("Download started.");
+    } catch (err) {
+      setFramegrabError(errorMessage(err));
+    } finally {
+      setFramegrabAction(null);
+    }
+  }, [
+    capturedFramegrab,
+    framegrabAction,
+    framegrabFileName.fullName,
+    framegrabFormat,
+  ]);
 
   const updateClipRange = useCallback(
     (nextStart: number, nextEnd: number) => {
@@ -349,6 +542,8 @@ export default function EditorScreen({ session, onBack }: Props) {
       handleTimelineZoomOut={handleTimelineZoomOut}
       canZoomIn={canZoomIn}
       canZoomOut={canZoomOut}
+      onFramegrabClick={handleOpenFramegrabDialog}
+      framegrabDisabledReason={framegrabDisabledReason}
       onPreviewTimeCommit={handlePreviewTimeCommit}
       onStartTimeCommit={handleStartTimeCommit}
       onEndTimeCommit={handleEndTimeCommit}
@@ -525,6 +720,26 @@ export default function EditorScreen({ session, onBack }: Props) {
             onResetFileNameTemplate={handleResetFileNameTemplate}
             onClose={handleCloseExportDialog}
             onExport={() => void handleExport()}
+          />
+        </Suspense>
+      )}
+
+      {framegrabDialogMounted && capturedFramegrab && (
+        <Suspense fallback={null}>
+          <EditorFramegrabDialog
+            isOpen={framegrabDialogOpen}
+            title={session.title}
+            frameTime={capturedFramegrab.time}
+            dimensions={capturedFramegrab.dimensions}
+            selectedFormat={framegrabFormat}
+            onFormatChange={handleFramegrabFormatChange}
+            fileNamePreview={framegrabFileName.fullName}
+            processingAction={framegrabAction}
+            error={framegrabError}
+            message={framegrabMessage}
+            onClose={handleCloseFramegrabDialog}
+            onCopy={() => void handleCopyFramegrab()}
+            onDownload={() => void handleDownloadFramegrab()}
           />
         </Suspense>
       )}

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -558,6 +558,8 @@ export default function EditorScreen({ session, onBack }: Props) {
             dimensions={framegrab.capturedFramegrab.dimensions}
             selectedFormat={framegrab.format}
             onFormatChange={framegrab.handleFormatChange}
+            selectedQuality={framegrab.quality}
+            onQualityChange={framegrab.handleQualityChange}
             fileNamePreview={framegrab.fileName.fullName}
             processingAction={framegrab.action}
             error={framegrab.error}

--- a/apps/frontend/src/components/editor/editorDialogStyles.ts
+++ b/apps/frontend/src/components/editor/editorDialogStyles.ts
@@ -1,0 +1,7 @@
+export function compactSelectTriggerClassName() {
+  return "h-8 w-full min-w-0 rounded-md border-border bg-background px-2.5 text-xs font-medium shadow-none focus-visible:ring-2";
+}
+
+export function sectionLabelClassName() {
+  return "text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground";
+}

--- a/apps/frontend/src/components/editor/useEditorExport.ts
+++ b/apps/frontend/src/components/editor/useEditorExport.ts
@@ -13,6 +13,7 @@ import {
   type ExportFileNameTemplateKind,
   type ExportFileNameTemplateSettings,
 } from "@/lib/exportFileName";
+import { downloadBlob } from "@/lib/downloadBlob";
 import {
   isHlsEditorMediaSource,
   sourceDisplayLabel,
@@ -337,15 +338,7 @@ export function useEditorExport({
         subtitleStyleSettings,
         onProgress: setProgress,
       });
-      const url = URL.createObjectURL(blob);
-
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = fileName.fullName;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+      downloadBlob(blob, fileName.fullName);
       setExportDialogOpen(false);
 
       exportLogger.info("Editor export completed.", {

--- a/apps/frontend/src/components/editor/useEditorFramegrab.ts
+++ b/apps/frontend/src/components/editor/useEditorFramegrab.ts
@@ -7,8 +7,10 @@ import { buildFramegrabFileName } from "@/lib/exportFileName";
 import {
   cloneCanvasFrame,
   copyFramegrabCanvasToClipboard,
+  DEFAULT_FRAMEGRAB_IMAGE_QUALITY,
   encodeFramegrabCanvas,
   type FramegrabImageFormat,
+  type FramegrabImageQuality,
 } from "@/lib/framegrab";
 
 interface VideoDimensions {
@@ -52,6 +54,9 @@ export function useEditorFramegrab({
     useState<CapturedFramegrab | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [format, setFormat] = useState<FramegrabImageFormat>("png");
+  const [quality, setQuality] = useState<FramegrabImageQuality>(
+    DEFAULT_FRAMEGRAB_IMAGE_QUALITY,
+  );
   const [action, setAction] = useState<FramegrabAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -150,6 +155,15 @@ export function useEditorFramegrab({
     setMessage(null);
   }, []);
 
+  const handleQualityChange = useCallback(
+    (nextQuality: FramegrabImageQuality) => {
+      setQuality(nextQuality);
+      setError(null);
+      setMessage(null);
+    },
+    [],
+  );
+
   const copyFramegrab = useCallback(async () => {
     if (!capturedFramegrab || action) {
       return;
@@ -182,6 +196,7 @@ export function useEditorFramegrab({
       const blob = await encodeFramegrabCanvas(
         capturedFramegrab.canvas,
         format,
+        quality,
       );
       downloadBlob(blob, fileName.fullName);
       setMessage("Download started.");
@@ -190,13 +205,14 @@ export function useEditorFramegrab({
     } finally {
       setAction(null);
     }
-  }, [action, capturedFramegrab, fileName.fullName, format]);
+  }, [action, capturedFramegrab, fileName.fullName, format, quality]);
 
   return {
     dialogMounted,
     capturedFramegrab,
     dialogOpen,
     format,
+    quality,
     action,
     error,
     message,
@@ -205,6 +221,7 @@ export function useEditorFramegrab({
     openDialog,
     closeDialog,
     handleFormatChange,
+    handleQualityChange,
     copyFramegrab,
     downloadFramegrab,
   };

--- a/apps/frontend/src/components/editor/useEditorFramegrab.ts
+++ b/apps/frontend/src/components/editor/useEditorFramegrab.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RefObject } from "react";
+import { errorMessage } from "@/components/editor/editorUtils";
+import type { EditorSession } from "@/lib/editorMedia";
+import { downloadBlob } from "@/lib/downloadBlob";
+import { buildFramegrabFileName } from "@/lib/exportFileName";
+import {
+  cloneCanvasFrame,
+  copyFramegrabCanvasToClipboard,
+  encodeFramegrabCanvas,
+  type FramegrabImageFormat,
+} from "@/lib/framegrab";
+
+interface VideoDimensions {
+  width: number;
+  height: number;
+}
+
+interface CapturedFramegrab {
+  canvas: HTMLCanvasElement;
+  time: number;
+  dimensions: VideoDimensions;
+}
+
+type FramegrabAction = "copy" | "download";
+
+interface UseEditorFramegrabProps {
+  session: EditorSession;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  currentTime: number;
+  loadingPreview: boolean;
+  loadingPreviewFrame: boolean;
+  previewVideoDimensions: VideoDimensions | null;
+  subtitleEnabled: boolean;
+  subtitleLoading: boolean;
+  subtitleError: string | null;
+}
+
+export function useEditorFramegrab({
+  session,
+  canvasRef,
+  currentTime,
+  loadingPreview,
+  loadingPreviewFrame,
+  previewVideoDimensions,
+  subtitleEnabled,
+  subtitleLoading,
+  subtitleError,
+}: UseEditorFramegrabProps) {
+  const [dialogMounted, setDialogMounted] = useState(false);
+  const [capturedFramegrab, setCapturedFramegrab] =
+    useState<CapturedFramegrab | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [format, setFormat] = useState<FramegrabImageFormat>("png");
+  const [action, setAction] = useState<FramegrabAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (dialogOpen) {
+      setDialogMounted(true);
+    }
+  }, [dialogOpen]);
+
+  const fileName = useMemo(
+    () =>
+      buildFramegrabFileName({
+        title: session.title,
+        sessionType: session.type,
+        metadata: session.exportMetadata,
+        frameTime: capturedFramegrab?.time ?? currentTime,
+        format,
+      }),
+    [
+      capturedFramegrab?.time,
+      currentTime,
+      format,
+      session.exportMetadata,
+      session.title,
+      session.type,
+    ],
+  );
+
+  const disabledReason = useMemo(() => {
+    if (loadingPreview || loadingPreviewFrame) {
+      return "Preview frame is loading.";
+    }
+
+    if (subtitleEnabled && subtitleLoading) {
+      return "Subtitles are still loading.";
+    }
+
+    if (subtitleEnabled && subtitleError) {
+      return subtitleError;
+    }
+
+    if (!previewVideoDimensions) {
+      return "No preview frame available.";
+    }
+
+    return null;
+  }, [
+    loadingPreview,
+    loadingPreviewFrame,
+    previewVideoDimensions,
+    subtitleEnabled,
+    subtitleError,
+    subtitleLoading,
+  ]);
+
+  const openDialog = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      setError("No preview frame is available yet.");
+      return;
+    }
+
+    try {
+      const clonedCanvas = cloneCanvasFrame(canvas);
+      setCapturedFramegrab({
+        canvas: clonedCanvas,
+        time: currentTime,
+        dimensions: {
+          width: clonedCanvas.width,
+          height: clonedCanvas.height,
+        },
+      });
+      setError(null);
+      setMessage(null);
+      setDialogOpen(true);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  }, [canvasRef, currentTime]);
+
+  const closeDialog = useCallback(() => {
+    if (action) {
+      return;
+    }
+
+    setDialogOpen(false);
+    setCapturedFramegrab(null);
+    setError(null);
+    setMessage(null);
+  }, [action]);
+
+  const handleFormatChange = useCallback((nextFormat: FramegrabImageFormat) => {
+    setFormat(nextFormat);
+    setError(null);
+    setMessage(null);
+  }, []);
+
+  const copyFramegrab = useCallback(async () => {
+    if (!capturedFramegrab || action) {
+      return;
+    }
+
+    setAction("copy");
+    setError(null);
+    setMessage(null);
+
+    try {
+      await copyFramegrabCanvasToClipboard(capturedFramegrab.canvas);
+      setMessage("Copied to clipboard.");
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setAction(null);
+    }
+  }, [action, capturedFramegrab]);
+
+  const downloadFramegrab = useCallback(async () => {
+    if (!capturedFramegrab || action) {
+      return;
+    }
+
+    setAction("download");
+    setError(null);
+    setMessage(null);
+
+    try {
+      const blob = await encodeFramegrabCanvas(
+        capturedFramegrab.canvas,
+        format,
+      );
+      downloadBlob(blob, fileName.fullName);
+      setMessage("Download started.");
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setAction(null);
+    }
+  }, [action, capturedFramegrab, fileName.fullName, format]);
+
+  return {
+    dialogMounted,
+    capturedFramegrab,
+    dialogOpen,
+    format,
+    action,
+    error,
+    message,
+    fileName,
+    disabledReason,
+    openDialog,
+    closeDialog,
+    handleFormatChange,
+    copyFramegrab,
+    downloadFramegrab,
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorFramegrab.ts
+++ b/apps/frontend/src/components/editor/useEditorFramegrab.ts
@@ -99,12 +99,19 @@ export function useEditorFramegrab({
       return subtitleError;
     }
 
-    if (!previewVideoDimensions) {
+    const canvas = canvasRef.current;
+    if (
+      !previewVideoDimensions ||
+      !canvas ||
+      canvas.width <= 0 ||
+      canvas.height <= 0
+    ) {
       return "No preview frame available.";
     }
 
     return null;
   }, [
+    canvasRef,
     loadingPreview,
     loadingPreviewFrame,
     previewVideoDimensions,
@@ -116,7 +123,11 @@ export function useEditorFramegrab({
   const openDialog = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
+      setCapturedFramegrab(null);
       setError("No preview frame is available yet.");
+      setMessage(null);
+      setDialogMounted(true);
+      setDialogOpen(true);
       return;
     }
 
@@ -134,7 +145,11 @@ export function useEditorFramegrab({
       setMessage(null);
       setDialogOpen(true);
     } catch (err) {
+      setCapturedFramegrab(null);
       setError(errorMessage(err));
+      setMessage(null);
+      setDialogMounted(true);
+      setDialogOpen(true);
     }
   }, [canvasRef, currentTime]);
 

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -125,6 +125,14 @@ void test("renders the editor framegrab camera control", () => {
   );
 
   assert.match(markup, /Export current preview frame/);
+  assert(
+    markup.indexOf('aria-label="Zoom timeline out"') <
+      markup.indexOf('aria-label="Zoom timeline in"'),
+  );
+  assert(
+    markup.indexOf('aria-label="Zoom timeline in"') <
+      markup.indexOf('aria-label="Export current preview frame"'),
+  );
 });
 
 void test("renders the framegrab export dialog actions", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -5,8 +5,11 @@ import test from "node:test";
 import { createElement, createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
+import { EditorControls } from "@/components/editor/EditorControls";
+import { EditorFramegrabDialog } from "@/components/editor/EditorFramegrabDialog";
 import { EditorPreview } from "@/components/editor/EditorPreview";
 import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
 void test("renders the provider auth completion screen", () => {
@@ -89,4 +92,66 @@ void test("renders editor poster with the shared thumbnail view transition", () 
     markup,
     new RegExp(`view-transition-name:${EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME}`),
   );
+});
+
+void test("renders the editor framegrab camera control", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(EditorControls, {
+        playing: false,
+        loadingPreview: false,
+        togglePlay: () => undefined,
+        currentTime: 12,
+        duration: 120,
+        startTime: 10,
+        endTime: 20,
+        muted: false,
+        setMuted: () => undefined,
+        volume: 1,
+        setVolume: () => undefined,
+        handleTimelineZoomIn: () => undefined,
+        handleTimelineZoomOut: () => undefined,
+        canZoomIn: true,
+        canZoomOut: true,
+        onFramegrabClick: () => undefined,
+        framegrabDisabledReason: null,
+        onPreviewTimeCommit: () => undefined,
+        onStartTimeCommit: () => undefined,
+        onEndTimeCommit: () => undefined,
+      }),
+    ),
+  );
+
+  assert.match(markup, /Export current preview frame/);
+});
+
+void test("renders the framegrab export dialog actions", () => {
+  const markup = renderToStaticMarkup(
+    createElement(EditorFramegrabDialog, {
+      isOpen: true,
+      title: "Example Movie",
+      frameTime: 61.2,
+      dimensions: {
+        width: 1920,
+        height: 1080,
+      },
+      selectedFormat: "png",
+      onFormatChange: () => undefined,
+      fileNamePreview: "Example Movie [frame 01m01s].png",
+      processingAction: null,
+      error: null,
+      message: null,
+      onClose: () => undefined,
+      onCopy: () => undefined,
+      onDownload: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /Export Frame/);
+  assert.match(markup, /Image Type/);
+  assert.match(markup, /Copy Image/);
+  assert.match(markup, /Download PNG/);
+  assert.match(markup, /Example Movie \[frame 01m01s\]\.png/);
 });

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -162,6 +162,7 @@ void test("renders the framegrab export dialog actions", () => {
   assert.match(markup, /Export Frame/);
   assert.match(markup, /Image Type/);
   assert.match(markup, /Quality/);
+  assert.match(markup, />Time</);
   assert.match(markup, /Copy Image/);
   assert.match(markup, /Download PNG/);
   assert.doesNotMatch(markup, />Cancel</);
@@ -171,4 +172,30 @@ void test("renders the framegrab export dialog actions", () => {
   assert.doesNotMatch(markup, /sr-only/);
   assert.match(markup, /Copied to clipboard\./);
   assert.match(markup, /Example Movie \[01m01s\]\.png/);
+});
+
+void test("renders framegrab capture errors without a captured canvas", () => {
+  const markup = renderToStaticMarkup(
+    createElement(EditorFramegrabDialog, {
+      isOpen: true,
+      title: "Example Movie",
+      frameTime: 61.2,
+      dimensions: null,
+      selectedFormat: "png",
+      onFormatChange: () => undefined,
+      selectedQuality: "high",
+      onQualityChange: () => undefined,
+      fileNamePreview: "Example Movie [01m01s].png",
+      processingAction: null,
+      error: "No preview frame is available yet.",
+      message: null,
+      onClose: () => undefined,
+      onCopy: () => undefined,
+      onDownload: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /No preview frame is available yet\./);
+  assert.match(markup, /Unavailable/);
+  assert.match(markup, /disabled/);
 });

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -139,10 +139,12 @@ void test("renders the framegrab export dialog actions", () => {
       },
       selectedFormat: "png",
       onFormatChange: () => undefined,
-      fileNamePreview: "Example Movie [frame 01m01s].png",
+      selectedQuality: "high",
+      onQualityChange: () => undefined,
+      fileNamePreview: "Example Movie [01m01s].png",
       processingAction: null,
       error: null,
-      message: null,
+      message: "Copied to clipboard.",
       onClose: () => undefined,
       onCopy: () => undefined,
       onDownload: () => undefined,
@@ -151,7 +153,14 @@ void test("renders the framegrab export dialog actions", () => {
 
   assert.match(markup, /Export Frame/);
   assert.match(markup, /Image Type/);
+  assert.match(markup, /Quality/);
   assert.match(markup, /Copy Image/);
   assert.match(markup, /Download PNG/);
-  assert.match(markup, /Example Movie \[frame 01m01s\]\.png/);
+  assert.doesNotMatch(markup, />Cancel</);
+  assert.match(markup, /w-44/);
+  assert.match(markup, /role="status"/);
+  assert.match(markup, /aria-live="polite"/);
+  assert.doesNotMatch(markup, /sr-only/);
+  assert.match(markup, /Copied to clipboard\./);
+  assert.match(markup, /Example Movie \[01m01s\]\.png/);
 });

--- a/apps/frontend/src/lib/downloadBlob.ts
+++ b/apps/frontend/src/lib/downloadBlob.ts
@@ -1,0 +1,10 @@
+export function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/apps/frontend/src/lib/exportFileName.test.ts
+++ b/apps/frontend/src/lib/exportFileName.test.ts
@@ -144,8 +144,8 @@ void test("builds framegrab filenames with shared metadata cleanup", () => {
       format: "png",
     }),
     {
-      baseName: "Movie With Bad Characters (1999) [frame 01m01s]",
-      fullName: "Movie With Bad Characters (1999) [frame 01m01s].png",
+      baseName: "Movie With Bad Characters (1999) [01m01s]",
+      fullName: "Movie With Bad Characters (1999) [01m01s].png",
       templateKind: "movie",
     },
   );
@@ -166,8 +166,8 @@ void test("builds framegrab filenames with shared metadata cleanup", () => {
       format: "jpg",
     }),
     {
-      baseName: "Example Show - S01E02 - Pilot [frame 01h01m02s]",
-      fullName: "Example Show - S01E02 - Pilot [frame 01h01m02s].jpg",
+      baseName: "Example Show - S01E02 - Pilot [01h01m02s]",
+      fullName: "Example Show - S01E02 - Pilot [01h01m02s].jpg",
       templateKind: "episode",
     },
   );
@@ -180,7 +180,7 @@ void test("builds framegrab filenames with shared metadata cleanup", () => {
       frameTime: 0,
       format: "webp",
     }).fullName,
-    "Still [frame 00m00s].webp",
+    "Still [00m00s].webp",
   );
 });
 

--- a/apps/frontend/src/lib/exportFileName.test.ts
+++ b/apps/frontend/src/lib/exportFileName.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildExportFileName,
+  buildFramegrabFileName,
   defaultExportFileNameTemplates,
   getExportFileNameTemplateTokens,
   loadExportFileNameTemplates,
@@ -125,6 +126,61 @@ void test("builds episode filenames and falls back when episode numbers are abse
       fullName: "Example Show - Standalone - demo - mkv -.mkv",
       templateKind: "episode",
     },
+  );
+});
+
+void test("builds framegrab filenames with shared metadata cleanup", () => {
+  assert.deepEqual(
+    buildFramegrabFileName({
+      title: "Fallback: Title",
+      sessionType: "movie",
+      metadata: {
+        providerId: "local",
+        itemType: "movie",
+        sourceTitle: "Movie / With: Bad * Characters?",
+        year: 1999,
+      },
+      frameTime: 61.2,
+      format: "png",
+    }),
+    {
+      baseName: "Movie With Bad Characters (1999) [frame 01m01s]",
+      fullName: "Movie With Bad Characters (1999) [frame 01m01s].png",
+      templateKind: "movie",
+    },
+  );
+
+  assert.deepEqual(
+    buildFramegrabFileName({
+      title: "Pilot",
+      sessionType: "episode",
+      metadata: {
+        providerId: "demo",
+        itemType: "episode",
+        title: "Pilot",
+        showTitle: "Example Show",
+        seasonNumber: 1,
+        episodeNumber: 2,
+      },
+      frameTime: 3661.6,
+      format: "jpg",
+    }),
+    {
+      baseName: "Example Show - S01E02 - Pilot [frame 01h01m02s]",
+      fullName: "Example Show - S01E02 - Pilot [frame 01h01m02s].jpg",
+      templateKind: "episode",
+    },
+  );
+
+  assert.equal(
+    buildFramegrabFileName({
+      title: "Still",
+      sessionType: "video",
+      metadata: undefined,
+      frameTime: 0,
+      format: "webp",
+    }).fullName,
+    "Still [frame 00m00s].webp",
   );
 });
 

--- a/apps/frontend/src/lib/exportFileName.ts
+++ b/apps/frontend/src/lib/exportFileName.ts
@@ -1,5 +1,6 @@
 import type { MediaExportMetadata } from "@/providers/types";
-import type { ExportFormat } from "@/lib/exportClip";
+import type { ExportFormat } from "@/lib/exportTypes";
+import type { FramegrabImageFormat } from "@/lib/framegrab";
 
 export type ExportFileNameTemplateKind = "movie" | "episode";
 
@@ -18,6 +19,24 @@ interface BuildExportFileNameOptions {
   templates: ExportFileNameTemplateSettings;
 }
 
+interface BuildFramegrabFileNameOptions {
+  title: string;
+  sessionType?: string;
+  metadata?: MediaExportMetadata;
+  frameTime: number;
+  format: FramegrabImageFormat;
+}
+
+interface TemplateValuesOptions {
+  title: string;
+  sessionType?: string;
+  metadata?: MediaExportMetadata;
+  startTime: number;
+  endTime: number;
+  frameTime?: number;
+  format: string;
+}
+
 const EXPORT_FILE_NAME_TEMPLATE_STORAGE_KEY =
   "cliparr.export.filename-templates.v1";
 
@@ -31,6 +50,11 @@ const DEFAULT_MOVIE_EXPORT_FILE_NAME_TEMPLATE =
 const DEFAULT_EPISODE_EXPORT_FILE_NAME_TEMPLATE =
   "{show_title} - {episode_code} - {title} [{clip_start}-{clip_end}]";
 
+const DEFAULT_MOVIE_FRAMEGRAB_FILE_NAME_TEMPLATE =
+  "{source_title} ({year}) [frame {frame_time}]";
+const DEFAULT_EPISODE_FRAMEGRAB_FILE_NAME_TEMPLATE =
+  "{show_title} - {episode_code} - {title} [frame {frame_time}]";
+
 type ExportFileNameTemplateToken =
   | "title"
   | "source_title"
@@ -43,6 +67,7 @@ type ExportFileNameTemplateToken =
   | "clip_start"
   | "clip_end"
   | "clip_range"
+  | "frame_time"
   | "provider"
   | "item_type"
   | "format";
@@ -190,14 +215,7 @@ export function buildExportFileName({
     endTime,
     format,
   });
-  const resolved = template.replace(/\{([a-z_]+)\}/gi, (_, token: string) => {
-    const normalizedToken = token.toLowerCase() as ExportFileNameTemplateToken;
-    const replacement = Object.hasOwn(values, normalizedToken)
-      ? values[normalizedToken]
-      : "";
-
-    return replacement ?? "";
-  });
+  const resolved = resolveTemplate(template, values);
 
   const baseName =
     sanitizeFileName(cleanupResolvedTemplate(resolved)) || "cliparr export";
@@ -209,17 +227,61 @@ export function buildExportFileName({
   };
 }
 
+export function buildFramegrabFileName({
+  title,
+  sessionType,
+  metadata,
+  frameTime,
+  format,
+}: BuildFramegrabFileNameOptions) {
+  const templateKind = resolveExportFileNameTemplateKind(sessionType, metadata);
+  const template =
+    templateKind === "episode"
+      ? DEFAULT_EPISODE_FRAMEGRAB_FILE_NAME_TEMPLATE
+      : DEFAULT_MOVIE_FRAMEGRAB_FILE_NAME_TEMPLATE;
+  const values = templateValues({
+    title,
+    sessionType,
+    metadata,
+    startTime: frameTime,
+    endTime: frameTime,
+    frameTime,
+    format,
+  });
+  const resolved = resolveTemplate(template, values);
+  const baseName =
+    sanitizeFileName(cleanupResolvedTemplate(resolved)) || "cliparr frame";
+
+  return {
+    baseName,
+    fullName: `${baseName}.${format}`,
+    templateKind,
+  };
+}
+
+function resolveTemplate(
+  template: string,
+  values: Record<ExportFileNameTemplateToken, string>,
+) {
+  return template.replace(/\{([a-z_]+)\}/gi, (_, token: string) => {
+    const normalizedToken = token.toLowerCase() as ExportFileNameTemplateToken;
+    const replacement = Object.hasOwn(values, normalizedToken)
+      ? values[normalizedToken]
+      : "";
+
+    return replacement ?? "";
+  });
+}
+
 function templateValues({
   title,
   sessionType,
   metadata,
   startTime,
   endTime,
+  frameTime,
   format,
-}: Omit<BuildExportFileNameOptions, "templates">): Record<
-  ExportFileNameTemplateToken,
-  string
-> {
+}: TemplateValuesOptions): Record<ExportFileNameTemplateToken, string> {
   const seasonNumber = nonNegativeInteger(metadata?.seasonNumber);
   const episodeNumber = nonNegativeInteger(metadata?.episodeNumber);
   const itemType =
@@ -251,6 +313,7 @@ function templateValues({
     clip_start: formatTemplateTime(startTime),
     clip_end: formatTemplateTime(endTime),
     clip_range: `${formatTemplateTime(startTime)} to ${formatTemplateTime(endTime)}`,
+    frame_time: formatTemplateTime(frameTime ?? startTime),
     provider: sanitizeTemplateValue(firstText(metadata?.providerId)),
     item_type: sanitizeTemplateValue(itemType),
     format: sanitizeTemplateValue(format),

--- a/apps/frontend/src/lib/exportFileName.ts
+++ b/apps/frontend/src/lib/exportFileName.ts
@@ -1,6 +1,9 @@
 import type { MediaExportMetadata } from "@/providers/types";
 import type { ExportFormat } from "@/lib/exportTypes";
-import type { FramegrabImageFormat } from "@/lib/framegrab";
+import {
+  framegrabExtensionFor,
+  type FramegrabImageFormat,
+} from "@/lib/framegrab";
 
 export type ExportFileNameTemplateKind = "movie" | "episode";
 
@@ -254,7 +257,7 @@ export function buildFramegrabFileName({
 
   return {
     baseName,
-    fullName: `${baseName}.${format}`,
+    fullName: `${baseName}${framegrabExtensionFor(format)}`,
     templateKind,
   };
 }

--- a/apps/frontend/src/lib/exportFileName.ts
+++ b/apps/frontend/src/lib/exportFileName.ts
@@ -54,9 +54,9 @@ const DEFAULT_EPISODE_EXPORT_FILE_NAME_TEMPLATE =
   "{show_title} - {episode_code} - {title} [{clip_start}-{clip_end}]";
 
 const DEFAULT_MOVIE_FRAMEGRAB_FILE_NAME_TEMPLATE =
-  "{source_title} ({year}) [frame {frame_time}]";
+  "{source_title} ({year}) [{frame_time}]";
 const DEFAULT_EPISODE_FRAMEGRAB_FILE_NAME_TEMPLATE =
-  "{show_title} - {episode_code} - {title} [frame {frame_time}]";
+  "{show_title} - {episode_code} - {title} [{frame_time}]";
 
 type ExportFileNameTemplateToken =
   | "title"

--- a/apps/frontend/src/lib/framegrab.test.ts
+++ b/apps/frontend/src/lib/framegrab.test.ts
@@ -10,6 +10,7 @@ import {
   framegrabImageQualityOptions,
   framegrabMimeTypeFor,
   framegrabQualityOptionFor,
+  resolveFramegrabCloneDimensions,
 } from "@/lib/framegrab";
 
 void test("exposes framegrab image format metadata", () => {
@@ -42,4 +43,50 @@ void test("exposes framegrab quality metadata", () => {
   });
   assert.equal(framegrabQualityOptionFor("balanced").quality, 0.82);
   assert.equal(framegrabQualityOptionFor("compact").quality, 0.68);
+});
+
+void test("resolves framegrab clone dimensions from rendered preview size", () => {
+  assert.deepEqual(
+    resolveFramegrabCloneDimensions({
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      renderedWidth: 960,
+      renderedHeight: 540,
+      devicePixelRatio: 2,
+    }),
+    {
+      width: 1920,
+      height: 1080,
+    },
+  );
+
+  assert.deepEqual(
+    resolveFramegrabCloneDimensions({
+      sourceWidth: 1280,
+      sourceHeight: 720,
+      renderedWidth: 900,
+      renderedHeight: 506.25,
+      devicePixelRatio: 2,
+    }),
+    {
+      width: 1800,
+      height: 1013,
+    },
+  );
+});
+
+void test("falls back to source dimensions when rendered size is unavailable", () => {
+  assert.deepEqual(
+    resolveFramegrabCloneDimensions({
+      sourceWidth: 1280.4,
+      sourceHeight: 719.6,
+      renderedWidth: 0,
+      renderedHeight: 0,
+      devicePixelRatio: 2,
+    }),
+    {
+      width: 1280,
+      height: 720,
+    },
+  );
 });

--- a/apps/frontend/src/lib/framegrab.test.ts
+++ b/apps/frontend/src/lib/framegrab.test.ts
@@ -10,7 +10,6 @@ import {
   framegrabImageQualityOptions,
   framegrabMimeTypeFor,
   framegrabQualityOptionFor,
-  resolveFramegrabCloneDimensions,
 } from "@/lib/framegrab";
 
 void test("exposes framegrab image format metadata", () => {
@@ -43,50 +42,4 @@ void test("exposes framegrab quality metadata", () => {
   });
   assert.equal(framegrabQualityOptionFor("balanced").quality, 0.82);
   assert.equal(framegrabQualityOptionFor("compact").quality, 0.68);
-});
-
-void test("resolves framegrab clone dimensions from rendered preview size", () => {
-  assert.deepEqual(
-    resolveFramegrabCloneDimensions({
-      sourceWidth: 1920,
-      sourceHeight: 1080,
-      renderedWidth: 960,
-      renderedHeight: 540,
-      devicePixelRatio: 2,
-    }),
-    {
-      width: 1920,
-      height: 1080,
-    },
-  );
-
-  assert.deepEqual(
-    resolveFramegrabCloneDimensions({
-      sourceWidth: 1280,
-      sourceHeight: 720,
-      renderedWidth: 900,
-      renderedHeight: 506.25,
-      devicePixelRatio: 2,
-    }),
-    {
-      width: 1800,
-      height: 1013,
-    },
-  );
-});
-
-void test("falls back to source dimensions when rendered size is unavailable", () => {
-  assert.deepEqual(
-    resolveFramegrabCloneDimensions({
-      sourceWidth: 1280.4,
-      sourceHeight: 719.6,
-      renderedWidth: 0,
-      renderedHeight: 0,
-      devicePixelRatio: 2,
-    }),
-    {
-      width: 1280,
-      height: 720,
-    },
-  );
 });

--- a/apps/frontend/src/lib/framegrab.test.ts
+++ b/apps/frontend/src/lib/framegrab.test.ts
@@ -1,0 +1,29 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FRAMEGRAB_IMAGE_QUALITY,
+  framegrabExtensionFor,
+  framegrabFormatOptionFor,
+  framegrabImageFormatOptions,
+  framegrabMimeTypeFor,
+} from "@/lib/framegrab";
+
+void test("exposes framegrab image format metadata", () => {
+  assert.equal(FRAMEGRAB_IMAGE_QUALITY, 0.92);
+  assert.deepEqual(
+    framegrabImageFormatOptions.map((option) => option.value),
+    ["png", "jpg", "webp"],
+  );
+  assert.equal(framegrabMimeTypeFor("png"), "image/png");
+  assert.equal(framegrabMimeTypeFor("jpg"), "image/jpeg");
+  assert.equal(framegrabMimeTypeFor("webp"), "image/webp");
+  assert.equal(framegrabExtensionFor("jpg"), ".jpg");
+  assert.deepEqual(framegrabFormatOptionFor("webp"), {
+    value: "webp",
+    label: "WEBP",
+    extension: ".webp",
+    mimeType: "image/webp",
+  });
+});

--- a/apps/frontend/src/lib/framegrab.test.ts
+++ b/apps/frontend/src/lib/framegrab.test.ts
@@ -3,15 +3,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  FRAMEGRAB_IMAGE_QUALITY,
+  DEFAULT_FRAMEGRAB_IMAGE_QUALITY,
   framegrabExtensionFor,
   framegrabFormatOptionFor,
   framegrabImageFormatOptions,
+  framegrabImageQualityOptions,
   framegrabMimeTypeFor,
+  framegrabQualityOptionFor,
 } from "@/lib/framegrab";
 
 void test("exposes framegrab image format metadata", () => {
-  assert.equal(FRAMEGRAB_IMAGE_QUALITY, 0.92);
+  assert.equal(DEFAULT_FRAMEGRAB_IMAGE_QUALITY, "high");
   assert.deepEqual(
     framegrabImageFormatOptions.map((option) => option.value),
     ["png", "jpg", "webp"],
@@ -26,4 +28,18 @@ void test("exposes framegrab image format metadata", () => {
     extension: ".webp",
     mimeType: "image/webp",
   });
+});
+
+void test("exposes framegrab quality metadata", () => {
+  assert.deepEqual(
+    framegrabImageQualityOptions.map((option) => option.value),
+    ["high", "balanced", "compact"],
+  );
+  assert.deepEqual(framegrabQualityOptionFor("high"), {
+    value: "high",
+    label: "High",
+    quality: 0.92,
+  });
+  assert.equal(framegrabQualityOptionFor("balanced").quality, 0.82);
+  assert.equal(framegrabQualityOptionFor("compact").quality, 0.68);
 });

--- a/apps/frontend/src/lib/framegrab.test.ts
+++ b/apps/frontend/src/lib/framegrab.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   DEFAULT_FRAMEGRAB_IMAGE_QUALITY,
+  encodeFramegrabCanvas,
   framegrabExtensionFor,
   framegrabFormatOptionFor,
   framegrabImageFormatOptions,
@@ -11,6 +12,8 @@ import {
   framegrabMimeTypeFor,
   framegrabQualityOptionFor,
 } from "@/lib/framegrab";
+
+type ToBlobCallback = (blob: Blob | null) => void;
 
 void test("exposes framegrab image format metadata", () => {
   assert.equal(DEFAULT_FRAMEGRAB_IMAGE_QUALITY, "high");
@@ -42,4 +45,39 @@ void test("exposes framegrab quality metadata", () => {
   });
   assert.equal(framegrabQualityOptionFor("balanced").quality, 0.82);
   assert.equal(framegrabQualityOptionFor("compact").quality, 0.68);
+});
+
+void test("encodes framegrabs with the requested MIME type and quality", async () => {
+  let requestedMimeType: string | undefined;
+  let requestedQuality: number | undefined;
+  const canvas = {
+    toBlob(
+      callback: ToBlobCallback,
+      mimeType?: string,
+      quality?: number,
+    ): void {
+      requestedMimeType = mimeType;
+      requestedQuality = quality;
+      callback(new Blob(["frame"], { type: "image/webp" }));
+    },
+  } as unknown as HTMLCanvasElement;
+
+  const blob = await encodeFramegrabCanvas(canvas, "webp", "balanced");
+
+  assert.equal(blob.type, "image/webp");
+  assert.equal(requestedMimeType, "image/webp");
+  assert.equal(requestedQuality, 0.82);
+});
+
+void test("rejects browser MIME fallback during framegrab encoding", async () => {
+  const canvas = {
+    toBlob(callback: ToBlobCallback): void {
+      callback(new Blob(["frame"], { type: "image/png" }));
+    },
+  } as unknown as HTMLCanvasElement;
+
+  await assert.rejects(
+    encodeFramegrabCanvas(canvas, "webp"),
+    /Could not encode the frame image as image\/webp\./,
+  );
 });

--- a/apps/frontend/src/lib/framegrab.ts
+++ b/apps/frontend/src/lib/framegrab.ts
@@ -14,6 +14,19 @@ export interface FramegrabImageQualityOption {
   quality: number;
 }
 
+export interface ResolveFramegrabCloneDimensionsOptions {
+  sourceWidth: number;
+  sourceHeight: number;
+  renderedWidth?: number;
+  renderedHeight?: number;
+  devicePixelRatio?: number;
+}
+
+export interface FramegrabCloneDimensions {
+  width: number;
+  height: number;
+}
+
 export const DEFAULT_FRAMEGRAB_IMAGE_QUALITY: FramegrabImageQuality = "high";
 
 export const framegrabImageFormatOptions: readonly FramegrabImageFormatOption[] =
@@ -79,20 +92,55 @@ export function framegrabQualityOptionFor(quality: FramegrabImageQuality) {
   );
 }
 
+export function resolveFramegrabCloneDimensions({
+  sourceWidth,
+  sourceHeight,
+  renderedWidth,
+  renderedHeight,
+  devicePixelRatio,
+}: ResolveFramegrabCloneDimensionsOptions): FramegrabCloneDimensions {
+  const fallbackDimensions = {
+    width: Math.max(0, Math.round(sourceWidth)),
+    height: Math.max(0, Math.round(sourceHeight)),
+  };
+  const displayWidth = positiveFiniteNumber(renderedWidth);
+  const displayHeight = positiveFiniteNumber(renderedHeight);
+  if (!displayWidth || !displayHeight) {
+    return fallbackDimensions;
+  }
+
+  const pixelRatio = Math.max(1, positiveFiniteNumber(devicePixelRatio) ?? 1);
+  const width = Math.max(1, Math.round(displayWidth * pixelRatio));
+  const height = Math.max(1, Math.round(displayHeight * pixelRatio));
+
+  return { width, height };
+}
+
 export function cloneCanvasFrame(sourceCanvas: HTMLCanvasElement) {
   if (sourceCanvas.width <= 0 || sourceCanvas.height <= 0) {
     throw new Error("No preview frame is available yet.");
   }
 
+  const displayBounds = sourceCanvas.getBoundingClientRect();
+  const dimensions = resolveFramegrabCloneDimensions({
+    sourceWidth: sourceCanvas.width,
+    sourceHeight: sourceCanvas.height,
+    renderedWidth: displayBounds.width,
+    renderedHeight: displayBounds.height,
+    devicePixelRatio:
+      typeof window === "undefined" ? undefined : window.devicePixelRatio,
+  });
   const canvas = document.createElement("canvas");
-  canvas.width = sourceCanvas.width;
-  canvas.height = sourceCanvas.height;
+  canvas.width = dimensions.width;
+  canvas.height = dimensions.height;
 
   const context = canvas.getContext("2d");
   if (!context) {
     throw new Error("Could not create a framegrab canvas.");
   }
 
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = "high";
   context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height);
   return canvas;
 }
@@ -143,4 +191,10 @@ export async function copyFramegrabCanvasToClipboard(
       [blob.type]: blob,
     }),
   ]);
+}
+
+function positiveFiniteNumber(value: number | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
 }

--- a/apps/frontend/src/lib/framegrab.ts
+++ b/apps/frontend/src/lib/framegrab.ts
@@ -1,4 +1,5 @@
 export type FramegrabImageFormat = "png" | "jpg" | "webp";
+export type FramegrabImageQuality = "high" | "balanced" | "compact";
 
 export interface FramegrabImageFormatOption {
   value: FramegrabImageFormat;
@@ -7,7 +8,13 @@ export interface FramegrabImageFormatOption {
   mimeType: string;
 }
 
-export const FRAMEGRAB_IMAGE_QUALITY = 0.92;
+export interface FramegrabImageQualityOption {
+  value: FramegrabImageQuality;
+  label: string;
+  quality: number;
+}
+
+export const DEFAULT_FRAMEGRAB_IMAGE_QUALITY: FramegrabImageQuality = "high";
 
 export const framegrabImageFormatOptions: readonly FramegrabImageFormatOption[] =
   [
@@ -31,6 +38,25 @@ export const framegrabImageFormatOptions: readonly FramegrabImageFormatOption[] 
     },
   ];
 
+export const framegrabImageQualityOptions: readonly FramegrabImageQualityOption[] =
+  [
+    {
+      value: "high",
+      label: "High",
+      quality: 0.92,
+    },
+    {
+      value: "balanced",
+      label: "Balanced",
+      quality: 0.82,
+    },
+    {
+      value: "compact",
+      label: "Compact",
+      quality: 0.68,
+    },
+  ];
+
 export function framegrabFormatOptionFor(format: FramegrabImageFormat) {
   return (
     framegrabImageFormatOptions.find((option) => option.value === format) ??
@@ -44,6 +70,13 @@ export function framegrabMimeTypeFor(format: FramegrabImageFormat) {
 
 export function framegrabExtensionFor(format: FramegrabImageFormat) {
   return framegrabFormatOptionFor(format).extension;
+}
+
+export function framegrabQualityOptionFor(quality: FramegrabImageQuality) {
+  return (
+    framegrabImageQualityOptions.find((option) => option.value === quality) ??
+    framegrabImageQualityOptions[0]
+  );
 }
 
 export function cloneCanvasFrame(sourceCanvas: HTMLCanvasElement) {
@@ -67,10 +100,14 @@ export function cloneCanvasFrame(sourceCanvas: HTMLCanvasElement) {
 export function encodeFramegrabCanvas(
   canvas: HTMLCanvasElement,
   format: FramegrabImageFormat,
+  imageQuality: FramegrabImageQuality = DEFAULT_FRAMEGRAB_IMAGE_QUALITY,
 ) {
   return new Promise<Blob>((resolve, reject) => {
     const mimeType = framegrabMimeTypeFor(format);
-    const quality = format === "png" ? undefined : FRAMEGRAB_IMAGE_QUALITY;
+    const quality =
+      format === "png"
+        ? undefined
+        : framegrabQualityOptionFor(imageQuality).quality;
 
     canvas.toBlob(
       (blob) => {

--- a/apps/frontend/src/lib/framegrab.ts
+++ b/apps/frontend/src/lib/framegrab.ts
@@ -116,6 +116,11 @@ export function encodeFramegrabCanvas(
           return;
         }
 
+        if (blob.type.toLowerCase() !== mimeType) {
+          reject(new Error(`Could not encode the frame image as ${mimeType}.`));
+          return;
+        }
+
         resolve(blob);
       },
       mimeType,

--- a/apps/frontend/src/lib/framegrab.ts
+++ b/apps/frontend/src/lib/framegrab.ts
@@ -1,0 +1,109 @@
+export type FramegrabImageFormat = "png" | "jpg" | "webp";
+
+export interface FramegrabImageFormatOption {
+  value: FramegrabImageFormat;
+  label: string;
+  extension: string;
+  mimeType: string;
+}
+
+export const FRAMEGRAB_IMAGE_QUALITY = 0.92;
+
+export const framegrabImageFormatOptions: readonly FramegrabImageFormatOption[] =
+  [
+    {
+      value: "png",
+      label: "PNG",
+      extension: ".png",
+      mimeType: "image/png",
+    },
+    {
+      value: "jpg",
+      label: "JPEG",
+      extension: ".jpg",
+      mimeType: "image/jpeg",
+    },
+    {
+      value: "webp",
+      label: "WEBP",
+      extension: ".webp",
+      mimeType: "image/webp",
+    },
+  ];
+
+export function framegrabFormatOptionFor(format: FramegrabImageFormat) {
+  return (
+    framegrabImageFormatOptions.find((option) => option.value === format) ??
+    framegrabImageFormatOptions[0]
+  );
+}
+
+export function framegrabMimeTypeFor(format: FramegrabImageFormat) {
+  return framegrabFormatOptionFor(format).mimeType;
+}
+
+export function framegrabExtensionFor(format: FramegrabImageFormat) {
+  return framegrabFormatOptionFor(format).extension;
+}
+
+export function cloneCanvasFrame(sourceCanvas: HTMLCanvasElement) {
+  if (sourceCanvas.width <= 0 || sourceCanvas.height <= 0) {
+    throw new Error("No preview frame is available yet.");
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = sourceCanvas.width;
+  canvas.height = sourceCanvas.height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Could not create a framegrab canvas.");
+  }
+
+  context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height);
+  return canvas;
+}
+
+export function encodeFramegrabCanvas(
+  canvas: HTMLCanvasElement,
+  format: FramegrabImageFormat,
+) {
+  return new Promise<Blob>((resolve, reject) => {
+    const mimeType = framegrabMimeTypeFor(format);
+    const quality = format === "png" ? undefined : FRAMEGRAB_IMAGE_QUALITY;
+
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Could not encode the frame image."));
+          return;
+        }
+
+        resolve(blob);
+      },
+      mimeType,
+      quality,
+    );
+  });
+}
+
+export async function copyFramegrabCanvasToClipboard(
+  canvas: HTMLCanvasElement,
+) {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.clipboard?.write ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    throw new Error(
+      "Clipboard image copying is not available in this browser.",
+    );
+  }
+
+  const blob = await encodeFramegrabCanvas(canvas, "png");
+  await navigator.clipboard.write([
+    new ClipboardItem({
+      [blob.type]: blob,
+    }),
+  ]);
+}

--- a/apps/frontend/src/lib/framegrab.ts
+++ b/apps/frontend/src/lib/framegrab.ts
@@ -14,19 +14,6 @@ export interface FramegrabImageQualityOption {
   quality: number;
 }
 
-export interface ResolveFramegrabCloneDimensionsOptions {
-  sourceWidth: number;
-  sourceHeight: number;
-  renderedWidth?: number;
-  renderedHeight?: number;
-  devicePixelRatio?: number;
-}
-
-export interface FramegrabCloneDimensions {
-  width: number;
-  height: number;
-}
-
 export const DEFAULT_FRAMEGRAB_IMAGE_QUALITY: FramegrabImageQuality = "high";
 
 export const framegrabImageFormatOptions: readonly FramegrabImageFormatOption[] =
@@ -92,55 +79,20 @@ export function framegrabQualityOptionFor(quality: FramegrabImageQuality) {
   );
 }
 
-export function resolveFramegrabCloneDimensions({
-  sourceWidth,
-  sourceHeight,
-  renderedWidth,
-  renderedHeight,
-  devicePixelRatio,
-}: ResolveFramegrabCloneDimensionsOptions): FramegrabCloneDimensions {
-  const fallbackDimensions = {
-    width: Math.max(0, Math.round(sourceWidth)),
-    height: Math.max(0, Math.round(sourceHeight)),
-  };
-  const displayWidth = positiveFiniteNumber(renderedWidth);
-  const displayHeight = positiveFiniteNumber(renderedHeight);
-  if (!displayWidth || !displayHeight) {
-    return fallbackDimensions;
-  }
-
-  const pixelRatio = Math.max(1, positiveFiniteNumber(devicePixelRatio) ?? 1);
-  const width = Math.max(1, Math.round(displayWidth * pixelRatio));
-  const height = Math.max(1, Math.round(displayHeight * pixelRatio));
-
-  return { width, height };
-}
-
 export function cloneCanvasFrame(sourceCanvas: HTMLCanvasElement) {
   if (sourceCanvas.width <= 0 || sourceCanvas.height <= 0) {
     throw new Error("No preview frame is available yet.");
   }
 
-  const displayBounds = sourceCanvas.getBoundingClientRect();
-  const dimensions = resolveFramegrabCloneDimensions({
-    sourceWidth: sourceCanvas.width,
-    sourceHeight: sourceCanvas.height,
-    renderedWidth: displayBounds.width,
-    renderedHeight: displayBounds.height,
-    devicePixelRatio:
-      typeof window === "undefined" ? undefined : window.devicePixelRatio,
-  });
   const canvas = document.createElement("canvas");
-  canvas.width = dimensions.width;
-  canvas.height = dimensions.height;
+  canvas.width = sourceCanvas.width;
+  canvas.height = sourceCanvas.height;
 
   const context = canvas.getContext("2d");
   if (!context) {
     throw new Error("Could not create a framegrab canvas.");
   }
 
-  context.imageSmoothingEnabled = true;
-  context.imageSmoothingQuality = "high";
   context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height);
   return canvas;
 }
@@ -191,10 +143,4 @@ export async function copyFramegrabCanvasToClipboard(
       [blob.type]: blob,
     }),
   ]);
-}
-
-function positiveFiniteNumber(value: number | undefined) {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? value
-    : undefined;
 }

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveSubtitleLayerBounds } from "@/lib/subtitles/renderSubtitleCue";
+
+void test("resolves subtitle supersampling bounds with stroke and shadow padding", () => {
+  assert.deepEqual(
+    resolveSubtitleLayerBounds({
+      canvasWidth: 1920,
+      canvasHeight: 1080,
+      centerX: 960,
+      startY: 900,
+      maxLineWidth: 840,
+      totalHeight: 96,
+      strokeWidth: 6,
+      shadowBlur: 8,
+      shadowOffsetY: 5,
+    }),
+    {
+      left: 527,
+      top: 887,
+      width: 866,
+      height: 127,
+    },
+  );
+});
+
+void test("clamps subtitle supersampling bounds to the target canvas", () => {
+  assert.deepEqual(
+    resolveSubtitleLayerBounds({
+      canvasWidth: 640,
+      canvasHeight: 360,
+      centerX: 320,
+      startY: 330,
+      maxLineWidth: 760,
+      totalHeight: 80,
+      strokeWidth: 4,
+      shadowBlur: 12,
+      shadowOffsetY: 8,
+    }),
+    {
+      left: 0,
+      top: 314,
+      width: 640,
+      height: 46,
+    },
+  );
+});

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
@@ -2,7 +2,90 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveSubtitleLayerBounds } from "@/lib/subtitles/renderSubtitleCue";
+import {
+  renderSubtitleCue,
+  resolveSubtitleLayerBounds,
+} from "@/lib/subtitles/renderSubtitleCue";
+import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
+
+class FakeCanvasContext {
+  canvas: { ownerDocument: { createElement: () => FakeCanvas } };
+  fillStyle = "";
+  font = "10px initial";
+  imageSmoothingEnabled = false;
+  imageSmoothingQuality = "low";
+  lineJoin = "miter";
+  lineWidth = 1;
+  miterLimit = 10;
+  shadowBlur = 0;
+  shadowColor = "";
+  shadowOffsetX = 0;
+  shadowOffsetY = 0;
+  strokeStyle = "";
+  textAlign = "start";
+  textBaseline = "alphabetic";
+  private stateStack: string[] = [];
+
+  constructor(ownerDocument: { createElement: () => FakeCanvas }) {
+    this.canvas = { ownerDocument };
+  }
+
+  save() {
+    this.stateStack.push(this.font);
+  }
+
+  restore() {
+    const font = this.stateStack.pop();
+    if (font) {
+      this.font = font;
+    }
+  }
+
+  measureText(text: string) {
+    return { width: text.length * 12 };
+  }
+
+  drawImage() {
+    return undefined;
+  }
+
+  fillText() {
+    return undefined;
+  }
+
+  strokeText() {
+    return undefined;
+  }
+}
+
+class FakeCanvas {
+  width = 0;
+  height = 0;
+  private ownerDocument: { createElement: () => FakeCanvas };
+
+  constructor(ownerDocument?: { createElement: () => FakeCanvas }) {
+    this.ownerDocument = ownerDocument ?? {
+      createElement: () => new FakeCanvas(),
+    };
+  }
+
+  getContext() {
+    return new FakeCanvasContext(this.ownerDocument);
+  }
+}
+
+const subtitleStyle: SubtitleStyleSettings = {
+  fontFamily: "Inter, sans-serif",
+  fontSize: 48,
+  fontColor: "#ffffff",
+  lineHeight: 1.2,
+  strokeWidth: 6,
+  strokeColor: "#000000",
+  shadowBlur: 8,
+  shadowColor: "rgba(0, 0, 0, 0.7)",
+  shadowOffsetY: 4,
+  bottomMargin: 96,
+};
 
 void test("resolves subtitle supersampling bounds with stroke and shadow padding", () => {
   assert.deepEqual(
@@ -46,4 +129,26 @@ void test("clamps subtitle supersampling bounds to the target canvas", () => {
       height: 46,
     },
   );
+});
+
+void test("rendering subtitles preserves the caller canvas font", () => {
+  const ownerDocument = { createElement: () => new FakeCanvas(ownerDocument) };
+  const context = new FakeCanvasContext(ownerDocument);
+  context.font = "16px caller";
+
+  renderSubtitleCue(
+    context as unknown as CanvasRenderingContext2D,
+    {
+      id: "cue-1",
+      startTime: 0,
+      endTime: 2,
+      text: "Hello there",
+      lines: ["Hello there"],
+    },
+    subtitleStyle,
+    1920,
+    1080,
+  );
+
+  assert.equal(context.font, "16px caller");
 });

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -5,10 +5,26 @@ interface SubtitleLayout {
   fontSize: number;
   lineHeight: number;
   wrappedLines: string[];
+  lineWidths: number[];
+}
+
+interface SubtitleLayerBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface SubtitleLayer {
+  canvas: HTMLCanvasElement;
+  bounds: SubtitleLayerBounds;
 }
 
 const subtitleLayoutCache = new Map<string, SubtitleLayout>();
 const SUBTITLE_LAYOUT_CACHE_LIMIT = 120;
+const subtitleLayerCache = new Map<string, SubtitleLayer>();
+const SUBTITLE_LAYER_CACHE_LIMIT = 8;
+const SUBTITLE_SUPERSAMPLE_SCALE = 2;
 
 function scaledValue(value: number, canvasHeight: number) {
   return value * (canvasHeight / 1080);
@@ -91,11 +107,15 @@ function cachedSubtitleLayout(
   const wrappedLines = cue.lines.flatMap((line) =>
     wrapLine(context, line, maxWidth),
   );
+  const lineWidths = wrappedLines.map(
+    (line) => context.measureText(line).width,
+  );
   const layout: SubtitleLayout = {
     font,
     fontSize,
     lineHeight: fontSize * style.lineHeight,
     wrappedLines,
+    lineWidths,
   };
 
   subtitleLayoutCache.set(key, layout);
@@ -107,6 +127,287 @@ function cachedSubtitleLayout(
   }
 
   return layout;
+}
+
+export function resolveSubtitleLayerBounds({
+  canvasWidth,
+  canvasHeight,
+  centerX,
+  startY,
+  maxLineWidth,
+  totalHeight,
+  strokeWidth,
+  shadowBlur,
+  shadowOffsetY,
+}: {
+  canvasWidth: number;
+  canvasHeight: number;
+  centerX: number;
+  startY: number;
+  maxLineWidth: number;
+  totalHeight: number;
+  strokeWidth: number;
+  shadowBlur: number;
+  shadowOffsetY: number;
+}): SubtitleLayerBounds {
+  const strokePadding = strokeWidth / 2;
+  const padX = Math.ceil(strokePadding + shadowBlur + 2);
+  const padTop = Math.ceil(
+    strokePadding + shadowBlur + Math.max(0, -shadowOffsetY) + 2,
+  );
+  const padBottom = Math.ceil(
+    strokePadding + shadowBlur + Math.max(0, shadowOffsetY) + 2,
+  );
+  const halfWidth = Math.max(1, maxLineWidth) / 2;
+  const left = Math.max(0, Math.floor(centerX - halfWidth - padX));
+  const top = Math.max(0, Math.floor(startY - padTop));
+  const right = Math.min(canvasWidth, Math.ceil(centerX + halfWidth + padX));
+  const bottom = Math.min(
+    canvasHeight,
+    Math.ceil(startY + totalHeight + padBottom),
+  );
+
+  return {
+    left,
+    top,
+    width: Math.max(1, right - left),
+    height: Math.max(1, bottom - top),
+  };
+}
+
+function cueLayerKey({
+  cue,
+  style,
+  canvasWidth,
+  canvasHeight,
+  fontSize,
+  strokeWidth,
+  shadowBlur,
+  shadowOffsetY,
+  bottomMargin,
+}: {
+  cue: SubtitleCue;
+  style: SubtitleStyleSettings;
+  canvasWidth: number;
+  canvasHeight: number;
+  fontSize: number;
+  strokeWidth: number;
+  shadowBlur: number;
+  shadowOffsetY: number;
+  bottomMargin: number;
+}) {
+  return JSON.stringify([
+    cue.id,
+    cue.startTime,
+    cue.endTime,
+    cue.lines,
+    canvasWidth,
+    canvasHeight,
+    fontSize,
+    style.fontFamily,
+    style.fontColor,
+    style.lineHeight,
+    style.strokeColor,
+    strokeWidth,
+    style.shadowColor,
+    shadowBlur,
+    shadowOffsetY,
+    bottomMargin,
+    SUBTITLE_SUPERSAMPLE_SCALE,
+  ]);
+}
+
+function cacheSubtitleLayer(key: string, layer: SubtitleLayer) {
+  subtitleLayerCache.set(key, layer);
+  if (subtitleLayerCache.size > SUBTITLE_LAYER_CACHE_LIMIT) {
+    const oldestKey = subtitleLayerCache.keys().next().value;
+    if (oldestKey) {
+      subtitleLayerCache.delete(oldestKey);
+    }
+  }
+}
+
+function renderSupersampledSubtitleLayer({
+  context,
+  cue,
+  style,
+  layout,
+  canvasWidth,
+  canvasHeight,
+  strokeWidth,
+  shadowBlur,
+  shadowOffsetY,
+  bottomMargin,
+}: {
+  context: CanvasRenderingContext2D;
+  cue: SubtitleCue;
+  style: SubtitleStyleSettings;
+  layout: SubtitleLayout;
+  canvasWidth: number;
+  canvasHeight: number;
+  strokeWidth: number;
+  shadowBlur: number;
+  shadowOffsetY: number;
+  bottomMargin: number;
+}): SubtitleLayer | null {
+  const key = cueLayerKey({
+    cue,
+    style,
+    canvasWidth,
+    canvasHeight,
+    fontSize: layout.fontSize,
+    strokeWidth,
+    shadowBlur,
+    shadowOffsetY,
+    bottomMargin,
+  });
+  const cached = subtitleLayerCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
+  const startY = canvasHeight - bottomMargin - totalHeight;
+  const centerX = canvasWidth / 2;
+  const maxLineWidth = Math.max(1, ...layout.lineWidths);
+  const bounds = resolveSubtitleLayerBounds({
+    canvasWidth,
+    canvasHeight,
+    centerX,
+    startY,
+    maxLineWidth,
+    totalHeight,
+    strokeWidth,
+    shadowBlur,
+    shadowOffsetY,
+  });
+  const ownerDocument = context.canvas.ownerDocument;
+  if (!ownerDocument) {
+    return null;
+  }
+
+  const layerCanvas = ownerDocument.createElement("canvas");
+  layerCanvas.width = Math.max(
+    1,
+    Math.ceil(bounds.width * SUBTITLE_SUPERSAMPLE_SCALE),
+  );
+  layerCanvas.height = Math.max(
+    1,
+    Math.ceil(bounds.height * SUBTITLE_SUPERSAMPLE_SCALE),
+  );
+
+  const layerContext = layerCanvas.getContext("2d");
+  if (!layerContext) {
+    return null;
+  }
+
+  const scale = SUBTITLE_SUPERSAMPLE_SCALE;
+  const localX = (centerX - bounds.left) * scale;
+  const localStartY = (startY - bounds.top) * scale;
+  const scaledLineHeight = layout.lineHeight * scale;
+
+  layerContext.save();
+  layerContext.font = `700 ${layout.fontSize * scale}px ${style.fontFamily}`;
+  layerContext.textAlign = "center";
+  layerContext.textBaseline = "top";
+  layerContext.lineJoin = "round";
+  layerContext.miterLimit = 2;
+
+  if (strokeWidth > 0) {
+    layerContext.strokeStyle = style.strokeColor;
+    layerContext.lineWidth = strokeWidth * scale;
+    layerContext.shadowColor = "transparent";
+
+    layout.wrappedLines.forEach((line, index) => {
+      layerContext.strokeText(
+        line,
+        localX,
+        localStartY + scaledLineHeight * index,
+      );
+    });
+  }
+
+  layerContext.fillStyle = style.fontColor;
+  layerContext.shadowColor = style.shadowColor;
+  layerContext.shadowBlur = shadowBlur * scale;
+  layerContext.shadowOffsetX = 0;
+  layerContext.shadowOffsetY = shadowOffsetY * scale;
+
+  layout.wrappedLines.forEach((line, index) => {
+    layerContext.fillText(line, localX, localStartY + scaledLineHeight * index);
+  });
+
+  layerContext.restore();
+
+  const layer = {
+    canvas: layerCanvas,
+    bounds,
+  };
+  cacheSubtitleLayer(key, layer);
+  return layer;
+}
+
+function drawSubtitleLayer(
+  context: CanvasRenderingContext2D,
+  layer: SubtitleLayer,
+) {
+  context.save();
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = "high";
+  context.drawImage(
+    layer.canvas,
+    layer.bounds.left,
+    layer.bounds.top,
+    layer.bounds.width,
+    layer.bounds.height,
+  );
+  context.restore();
+}
+
+function drawDirectSubtitleText({
+  context,
+  layout,
+  style,
+  canvasWidth,
+  canvasHeight,
+  strokeWidth,
+  shadowBlur,
+  shadowOffsetY,
+  bottomMargin,
+}: {
+  context: CanvasRenderingContext2D;
+  layout: SubtitleLayout;
+  style: SubtitleStyleSettings;
+  canvasWidth: number;
+  canvasHeight: number;
+  strokeWidth: number;
+  shadowBlur: number;
+  shadowOffsetY: number;
+  bottomMargin: number;
+}) {
+  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
+  const startY = canvasHeight - bottomMargin - totalHeight;
+  const x = canvasWidth / 2;
+
+  if (strokeWidth > 0) {
+    context.strokeStyle = style.strokeColor;
+    context.lineWidth = strokeWidth;
+    context.shadowColor = "transparent";
+
+    layout.wrappedLines.forEach((line, index) => {
+      context.strokeText(line, x, startY + layout.lineHeight * index);
+    });
+  }
+
+  context.fillStyle = style.fontColor;
+  context.shadowColor = style.shadowColor;
+  context.shadowBlur = shadowBlur;
+  context.shadowOffsetX = 0;
+  context.shadowOffsetY = shadowOffsetY;
+
+  layout.wrappedLines.forEach((line, index) => {
+    context.fillText(line, x, startY + layout.lineHeight * index);
+  });
 }
 
 export function renderSubtitleCue(
@@ -147,29 +448,33 @@ export function renderSubtitleCue(
     return;
   }
 
-  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
-  const startY = canvasHeight - bottomMargin - totalHeight;
-  const x = canvasWidth / 2;
-
-  if (strokeWidth > 0) {
-    context.strokeStyle = style.strokeColor;
-    context.lineWidth = strokeWidth;
-    context.shadowColor = "transparent";
-
-    layout.wrappedLines.forEach((line, index) => {
-      context.strokeText(line, x, startY + layout.lineHeight * index);
+  const layer = renderSupersampledSubtitleLayer({
+    context,
+    cue,
+    style,
+    layout,
+    canvasWidth,
+    canvasHeight,
+    strokeWidth,
+    shadowBlur,
+    shadowOffsetY,
+    bottomMargin,
+  });
+  if (layer) {
+    drawSubtitleLayer(context, layer);
+  } else {
+    drawDirectSubtitleText({
+      context,
+      layout,
+      style,
+      canvasWidth,
+      canvasHeight,
+      strokeWidth,
+      shadowBlur,
+      shadowOffsetY,
+      bottomMargin,
     });
   }
-
-  context.fillStyle = style.fontColor;
-  context.shadowColor = style.shadowColor;
-  context.shadowBlur = shadowBlur;
-  context.shadowOffsetX = 0;
-  context.shadowOffsetY = shadowOffsetY;
-
-  layout.wrappedLines.forEach((line, index) => {
-    context.fillText(line, x, startY + layout.lineHeight * index);
-  });
 
   context.restore();
 }

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -103,13 +103,22 @@ function cachedSubtitleLayout(
   }
 
   const font = `700 ${fontSize}px ${style.fontFamily}`;
-  context.font = font;
-  const wrappedLines = cue.lines.flatMap((line) =>
-    wrapLine(context, line, maxWidth),
-  );
-  const lineWidths = wrappedLines.map(
-    (line) => context.measureText(line).width,
-  );
+  const { wrappedLines, lineWidths } = (() => {
+    context.save();
+    try {
+      context.font = font;
+      const wrappedLines = cue.lines.flatMap((line) =>
+        wrapLine(context, line, maxWidth),
+      );
+      return {
+        wrappedLines,
+        lineWidths: wrappedLines.map((line) => context.measureText(line).width),
+      };
+    } finally {
+      context.restore();
+    }
+  })();
+
   const layout: SubtitleLayout = {
     font,
     fontSize,


### PR DESCRIPTION
## Summary
- add a separate camera control after the timeline zoom buttons that captures the current editor preview canvas
- add a compact frame export dialog with PNG/JPEG/WEBP downloads, PNG clipboard copy, fixed-width download action, and JPEG/WEBP quality presets
- reuse export metadata naming for framegrabs while using timestamp-only framegrab suffixes like [22m39s]
- keep framegrabs at the source preview canvas dimensions to avoid image distortion
- supersample subtitle text rendering on a transparent layer before compositing so subtitles look smoother in preview, framegrabs, and burned exports

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint
- pnpm preflight