### PR TITLE
feat(frontend): add editor keyboard shortcuts

### DIFF
--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -7,6 +7,11 @@ import {
   roundTimelineTime,
 } from "@/components/editor/editorUtils";
 import {
+  EDITOR_LARGE_SEEK_SECONDS,
+  EDITOR_SMALL_SEEK_SECONDS,
+  resolveRelativeSeekTime,
+} from "@/components/editor/editorShortcutCommands";
+import {
   useEditorPlayback,
   type PlaybackFallbackInfo,
 } from "@/components/editor/useEditorPlayback";
@@ -253,7 +258,44 @@ export default function EditorScreen({ session, onBack }: Props) {
     },
     [duration, startTime, updateClipRange, warmClipSelection],
   );
+  const handleMarkInShortcut = useCallback(() => {
+    if (!duration || duration <= 0) return;
 
+    const nextStart = clampClipStartTime(currentTime, endTime, duration);
+    updateClipRange(nextStart, endTime);
+    void warmClipSelection(nextStart, endTime);
+  }, [currentTime, duration, endTime, updateClipRange, warmClipSelection]);
+  const handleMarkOutShortcut = useCallback(() => {
+    if (!duration || duration <= 0) return;
+
+    const nextEnd = clampClipEndTime(currentTime, startTime, duration);
+    updateClipRange(startTime, nextEnd);
+    void warmClipSelection(startTime, nextEnd);
+  }, [currentTime, duration, startTime, updateClipRange, warmClipSelection]);
+  const handleJumpToInShortcut = useCallback(() => {
+    if (!duration || duration <= 0) return;
+
+    void seekToTime(clampPlaybackTime(startTime, duration));
+  }, [duration, seekToTime, startTime]);
+  const handleJumpToOutShortcut = useCallback(() => {
+    if (!duration || duration <= 0) return;
+
+    void seekToTime(clampPlaybackTime(endTime, duration));
+  }, [duration, endTime, seekToTime]);
+  const seekByShortcut = useCallback(
+    (deltaSeconds: number) => {
+      if (!duration || duration <= 0) return;
+
+      void seekToTime(
+        resolveRelativeSeekTime({
+          currentTime,
+          deltaSeconds,
+          duration,
+        }),
+      );
+    },
+    [currentTime, duration, seekToTime],
+  );
   const {
     timelineRef,
     timelineWheelRegionRef,
@@ -317,7 +359,23 @@ export default function EditorScreen({ session, onBack }: Props) {
     updateClipRange,
   ]);
 
-  useEditorKeyboardShortcuts({ togglePlay });
+  useEditorKeyboardShortcuts({
+    togglePlay,
+    markIn: handleMarkInShortcut,
+    markOut: handleMarkOutShortcut,
+    jumpToIn: handleJumpToInShortcut,
+    jumpToOut: handleJumpToOutShortcut,
+    seekBackwardLarge: () => seekByShortcut(-EDITOR_LARGE_SEEK_SECONDS),
+    seekForwardLarge: () => seekByShortcut(EDITOR_LARGE_SEEK_SECONDS),
+    seekBackwardSmall: () => seekByShortcut(-EDITOR_SMALL_SEEK_SECONDS),
+    seekForwardSmall: () => seekByShortcut(EDITOR_SMALL_SEEK_SECONDS),
+    zoomOut: () => {
+      if (canZoomOut) handleTimelineZoomOut();
+    },
+    zoomIn: () => {
+      if (canZoomIn) handleTimelineZoomIn();
+    },
+  });
   const isDesktopLayout = useEditorDesktopLayout();
 
   const durationExportDisabledReason = !hasDuration

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -103,6 +103,7 @@ export default function EditorScreen({ session, onBack }: Props) {
     hlsFallbackInfo,
     sourceVideoDimensions,
     previewVideoDimensions,
+    frameStepSeconds,
     playbackReadyRange,
     volume,
     muted,
@@ -296,6 +297,20 @@ export default function EditorScreen({ session, onBack }: Props) {
     },
     [currentTime, duration, seekToTime],
   );
+  const stepFrameByShortcut = useCallback(
+    (direction: -1 | 1) => {
+      if (!duration || duration <= 0) return;
+
+      const nextTime = resolveRelativeSeekTime({
+        currentTime,
+        deltaSeconds: frameStepSeconds * direction,
+        duration,
+      });
+      pausePlayback();
+      void seekToTime(nextTime);
+    },
+    [currentTime, duration, frameStepSeconds, pausePlayback, seekToTime],
+  );
   const {
     timelineRef,
     timelineWheelRegionRef,
@@ -369,6 +384,8 @@ export default function EditorScreen({ session, onBack }: Props) {
     seekForwardLarge: () => seekByShortcut(EDITOR_LARGE_SEEK_SECONDS),
     seekBackwardSmall: () => seekByShortcut(-EDITOR_SMALL_SEEK_SECONDS),
     seekForwardSmall: () => seekByShortcut(EDITOR_SMALL_SEEK_SECONDS),
+    stepFrameBackward: () => stepFrameByShortcut(-1),
+    stepFrameForward: () => stepFrameByShortcut(1),
     zoomOut: () => {
       if (canZoomOut) handleTimelineZoomOut();
     },

--- a/apps/frontend/src/components/editor/editorShortcutCommands.test.ts
+++ b/apps/frontend/src/components/editor/editorShortcutCommands.test.ts
@@ -1,0 +1,125 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_EDITOR_FRAME_STEP_SECONDS,
+  resolveEditorShortcutCommand,
+  resolveRelativeSeekTime,
+  frameStepSecondsFromFrameRate,
+} from "@/components/editor/editorShortcutCommands";
+
+void test("resolves playback and mark shortcuts", () => {
+  assert.equal(resolveEditorShortcutCommand({ code: "Space" }), "toggle-play");
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "Space", repeat: true }),
+    null,
+  );
+  assert.equal(resolveEditorShortcutCommand({ code: "KeyI" }), "mark-in");
+  assert.equal(resolveEditorShortcutCommand({ code: "KeyO" }), "mark-out");
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "BracketLeft" }),
+    "mark-in",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "BracketRight" }),
+    "mark-out",
+  );
+});
+
+void test("resolves jump, seek, frame, and zoom shortcuts", () => {
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyI", shiftKey: true }),
+    "jump-to-in",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyO", shiftKey: true }),
+    "jump-to-out",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "ArrowLeft" }),
+    "seek-backward-large",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "ArrowRight", shiftKey: true }),
+    "seek-forward-small",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "PageUp" }),
+    "step-frame-backward",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "PageDown" }),
+    "step-frame-forward",
+  );
+  assert.equal(resolveEditorShortcutCommand({ code: "Minus" }), "zoom-out");
+  assert.equal(resolveEditorShortcutCommand({ code: "Equal" }), "zoom-in");
+});
+
+void test("resolves premiere frame-step aliases when K is held", () => {
+  const pressedCodes = new Set(["KeyK"]);
+
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyJ", pressedCodes }),
+    "step-frame-backward",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyL", pressedCodes }),
+    "step-frame-forward",
+  );
+  assert.equal(resolveEditorShortcutCommand({ code: "KeyJ" }), null);
+});
+
+void test("ignores shortcuts with browser and system modifiers", () => {
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyI", metaKey: true }),
+    null,
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyI", ctrlKey: true }),
+    null,
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyI", altKey: true }),
+    null,
+  );
+});
+
+void test("clamps relative editor seeks to the media duration", () => {
+  assert.equal(
+    resolveRelativeSeekTime({
+      currentTime: 20,
+      deltaSeconds: 30,
+      duration: 40,
+    }),
+    40,
+  );
+  assert.equal(
+    resolveRelativeSeekTime({
+      currentTime: 4,
+      deltaSeconds: -5,
+      duration: 40,
+    }),
+    0,
+  );
+  assert.equal(
+    resolveRelativeSeekTime({
+      currentTime: 10,
+      deltaSeconds: 5,
+      duration: 40,
+    }),
+    15,
+  );
+});
+
+void test("resolves frame-step seconds from detected frame rate", () => {
+  assert.equal(frameStepSecondsFromFrameRate(25), 0.04);
+  assert.equal(
+    frameStepSecondsFromFrameRate(0),
+    DEFAULT_EDITOR_FRAME_STEP_SECONDS,
+  );
+  assert.equal(
+    frameStepSecondsFromFrameRate(null),
+    DEFAULT_EDITOR_FRAME_STEP_SECONDS,
+  );
+});

--- a/apps/frontend/src/components/editor/editorShortcutCommands.ts
+++ b/apps/frontend/src/components/editor/editorShortcutCommands.ts
@@ -1,0 +1,106 @@
+export const EDITOR_LARGE_SEEK_SECONDS = 30;
+export const EDITOR_SMALL_SEEK_SECONDS = 5;
+export const DEFAULT_EDITOR_FRAME_STEP_SECONDS = 1 / 30;
+
+export type EditorShortcutCommand =
+  | "toggle-play"
+  | "mark-in"
+  | "mark-out"
+  | "jump-to-in"
+  | "jump-to-out"
+  | "seek-backward-large"
+  | "seek-forward-large"
+  | "seek-backward-small"
+  | "seek-forward-small"
+  | "step-frame-backward"
+  | "step-frame-forward"
+  | "zoom-out"
+  | "zoom-in";
+
+export interface EditorShortcutEvent {
+  code: string;
+  repeat?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  pressedCodes?: ReadonlySet<string>;
+}
+
+export function resolveEditorShortcutCommand({
+  code,
+  repeat = false,
+  shiftKey = false,
+  altKey = false,
+  ctrlKey = false,
+  metaKey = false,
+  pressedCodes,
+}: EditorShortcutEvent): EditorShortcutCommand | null {
+  if (altKey || ctrlKey || metaKey) {
+    return null;
+  }
+
+  const kHeld = pressedCodes?.has("KeyK") ?? false;
+  if (kHeld && code === "KeyJ") {
+    return "step-frame-backward";
+  }
+  if (kHeld && code === "KeyL") {
+    return "step-frame-forward";
+  }
+
+  switch (code) {
+    case "Space":
+      return repeat || shiftKey ? null : "toggle-play";
+    case "KeyI":
+      if (repeat) return null;
+      return shiftKey ? "jump-to-in" : "mark-in";
+    case "KeyO":
+      if (repeat) return null;
+      return shiftKey ? "jump-to-out" : "mark-out";
+    case "BracketLeft":
+      return repeat || shiftKey ? null : "mark-in";
+    case "BracketRight":
+      return repeat || shiftKey ? null : "mark-out";
+    case "ArrowLeft":
+      return shiftKey ? "seek-backward-small" : "seek-backward-large";
+    case "ArrowRight":
+      return shiftKey ? "seek-forward-small" : "seek-forward-large";
+    case "PageUp":
+      return "step-frame-backward";
+    case "PageDown":
+      return "step-frame-forward";
+    case "Minus":
+      return "zoom-out";
+    case "Equal":
+      return "zoom-in";
+    default:
+      return null;
+  }
+}
+
+export function resolveRelativeSeekTime({
+  currentTime,
+  deltaSeconds,
+  duration,
+}: {
+  currentTime: number;
+  deltaSeconds: number;
+  duration: number;
+}) {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+
+  const safeCurrentTime = Number.isFinite(currentTime) ? currentTime : 0;
+  const safeDeltaSeconds = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
+
+  return Math.min(duration, Math.max(0, safeCurrentTime + safeDeltaSeconds));
+}
+
+export function frameStepSecondsFromFrameRate(frameRate: number | null) {
+  if (!Number.isFinite(frameRate) || frameRate === null || frameRate <= 0) {
+    return DEFAULT_EDITOR_FRAME_STEP_SECONDS;
+  }
+
+  return 1 / frameRate;
+}

--- a/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
+++ b/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
@@ -1,36 +1,109 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import {
+  resolveEditorShortcutCommand,
+  type EditorShortcutCommand,
+} from "@/components/editor/editorShortcutCommands";
 
 interface UseEditorKeyboardShortcutsProps {
   togglePlay: () => void;
+  markIn?: () => void;
+  markOut?: () => void;
+  jumpToIn?: () => void;
+  jumpToOut?: () => void;
+  seekBackwardLarge?: () => void;
+  seekForwardLarge?: () => void;
+  seekBackwardSmall?: () => void;
+  seekForwardSmall?: () => void;
+  stepFrameBackward?: () => void;
+  stepFrameForward?: () => void;
+  zoomOut?: () => void;
+  zoomIn?: () => void;
 }
 
 export function useEditorKeyboardShortcuts({
   togglePlay,
+  markIn,
+  markOut,
+  jumpToIn,
+  jumpToOut,
+  seekBackwardLarge,
+  seekForwardLarge,
+  seekBackwardSmall,
+  seekForwardSmall,
+  stepFrameBackward,
+  stepFrameForward,
+  zoomOut,
+  zoomIn,
 }: UseEditorKeyboardShortcutsProps) {
+  const commandHandlersRef = useRef<
+    Partial<Record<EditorShortcutCommand, () => void>>
+  >({});
+
   useEffect(() => {
+    commandHandlersRef.current = {
+      "toggle-play": togglePlay,
+      "mark-in": markIn,
+      "mark-out": markOut,
+      "jump-to-in": jumpToIn,
+      "jump-to-out": jumpToOut,
+      "seek-backward-large": seekBackwardLarge,
+      "seek-forward-large": seekForwardLarge,
+      "seek-backward-small": seekBackwardSmall,
+      "seek-forward-small": seekForwardSmall,
+      "step-frame-backward": stepFrameBackward,
+      "step-frame-forward": stepFrameForward,
+      "zoom-out": zoomOut,
+      "zoom-in": zoomIn,
+    };
+  });
+
+  useEffect(() => {
+    const pressedCodes = new Set<string>();
+
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.code !== "Space") {
+      if (isInteractiveKeyboardTarget(event.target) || isModalDialogOpen()) {
         return;
       }
 
-      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
+      pressedCodes.add(event.code);
+      const command = resolveEditorShortcutCommand({
+        code: event.code,
+        repeat: event.repeat,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        pressedCodes,
+      });
+      const handler = command ? commandHandlersRef.current[command] : undefined;
 
-      if (isInteractiveKeyboardTarget(event.target)) {
+      if (!handler) {
         return;
       }
 
       event.preventDefault();
-      togglePlay();
+      event.stopPropagation();
+      handler();
+    }
+
+    function handleKeyUp(event: KeyboardEvent) {
+      pressedCodes.delete(event.code);
+    }
+
+    function handleBlur() {
+      pressedCodes.clear();
     }
 
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
     };
-  }, [togglePlay]);
+  }, []);
 }
 
 function isInteractiveKeyboardTarget(target: EventTarget | null) {
@@ -44,7 +117,19 @@ function isInteractiveKeyboardTarget(target: EventTarget | null) {
 
   return Boolean(
     target.closest(
-      'input, textarea, select, button, [contenteditable="true"], [role="slider"]',
+      'input, textarea, select, button, [contenteditable="true"], [role="slider"], [role="dialog"], [role="alertdialog"], dialog',
+    ),
+  );
+}
+
+function isModalDialogOpen() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return Boolean(
+    document.querySelector(
+      '[role="dialog"][aria-modal="true"], [role="alertdialog"][aria-modal="true"], dialog[open]',
     ),
   );
 }

--- a/apps/frontend/src/components/editor/useEditorPlayback.ts
+++ b/apps/frontend/src/components/editor/useEditorPlayback.ts
@@ -10,6 +10,7 @@ import type {
   CanvasSink,
   Input,
   InputTrack,
+  InputVideoTrack,
   WrappedAudioBuffer,
   WrappedCanvas,
 } from "mediabunny";
@@ -61,6 +62,10 @@ import {
 } from "@/components/editor/useEditorPlaybackWarmup";
 import { resolvePreviewPlaybackPlan } from "@/components/editor/editorPlaybackPlan";
 import { resetPlaybackReadyRangeWarmState } from "@/components/editor/editorPlaybackWarmupRange";
+import {
+  DEFAULT_EDITOR_FRAME_STEP_SECONDS,
+  frameStepSecondsFromFrameRate,
+} from "@/components/editor/editorShortcutCommands";
 import { getFrontendLogger, warnWithError } from "@/logging";
 
 export type { PlaybackFallbackInfo } from "@/components/editor/editorPlaybackSources";
@@ -191,6 +196,22 @@ async function ensurePlaybackCodecs() {
   await ensureMediabunnyCodecs();
 }
 
+async function detectFrameStepSeconds(
+  sourceVideoTrack: InputVideoTrack | null,
+  isLivePlayback: boolean,
+) {
+  if (!sourceVideoTrack) {
+    return DEFAULT_EDITOR_FRAME_STEP_SECONDS;
+  }
+
+  const stats = await sourceVideoTrack.computePacketStats(
+    120,
+    isLivePlayback ? { skipLiveWait: true } : undefined,
+  );
+
+  return frameStepSecondsFromFrameRate(stats.averagePacketRate);
+}
+
 export function useEditorPlayback({
   hlsSource,
   directSource,
@@ -229,6 +250,9 @@ export function useEditorPlayback({
     useState<VideoDimensions | null>(null);
   const [previewVideoDimensions, setPreviewVideoDimensions] =
     useState<VideoDimensions | null>(null);
+  const [frameStepSeconds, setFrameStepSeconds] = useState(
+    DEFAULT_EDITOR_FRAME_STEP_SECONDS,
+  );
   const [playbackReadyRange, setPlaybackReadyRange] =
     useState<PlaybackReadyRange | null>(null);
   const playbackLogger = useMemo(
@@ -866,6 +890,7 @@ export function useEditorPlayback({
       durationRef.current = resetDuration;
       setSourceVideoDimensions(null);
       setPreviewVideoDimensions(null);
+      setFrameStepSeconds(DEFAULT_EDITOR_FRAME_STEP_SECONDS);
       const resetCurrentTime = initialPlaybackTime(
         initialCurrentTime,
         resetDuration,
@@ -1100,9 +1125,30 @@ export function useEditorPlayback({
             setCurrentTime(nextCurrentTime);
             playbackTimeAtStartRef.current = nextCurrentTime;
 
-            const sourceDimensions = sourceVideoTrack
-              ? await getVideoTrackDimensions(sourceVideoTrack)
-              : null;
+            const [sourceDimensions, detectedFrameStepSeconds] =
+              await Promise.all([
+                sourceVideoTrack
+                  ? getVideoTrackDimensions(sourceVideoTrack)
+                  : Promise.resolve(null),
+                detectFrameStepSeconds(sourceVideoTrack, isLivePlayback).catch(
+                  (err: unknown) => {
+                    warnWithError(
+                      playbackLogger,
+                      err,
+                      "Could not detect editor playback frame rate.",
+                      {
+                        ...logEventFields(
+                          "editor.playback.frame_rate_detect",
+                          "failure",
+                        ),
+                        ...logErrorFields(err),
+                        "playback.source.label": playbackSource.label,
+                      },
+                    );
+                    return DEFAULT_EDITOR_FRAME_STEP_SECONDS;
+                  },
+                ),
+              ]);
             const previewDimensions =
               sourceDimensions ?? staticVideoFrame?.dimensions ?? null;
             const audioTrackSampleRate = previewAudioTrack
@@ -1112,6 +1158,7 @@ export function useEditorPlayback({
             if (sourceDimensions) {
               setSourceVideoDimensions(sourceDimensions);
             }
+            setFrameStepSeconds(detectedFrameStepSeconds);
 
             if (previewDimensions) {
               setPreviewVideoDimensions(previewDimensions);
@@ -1274,6 +1321,7 @@ export function useEditorPlayback({
     hlsFallbackInfo,
     sourceVideoDimensions,
     previewVideoDimensions,
+    frameStepSeconds,
     playbackReadyRange,
     volume,
     muted,

--- a/apps/www/src/content/docs/editor-shortcuts.mdx
+++ b/apps/www/src/content/docs/editor-shortcuts.mdx
@@ -5,7 +5,7 @@ section: editing-export
 order: 40
 ---
 
-The editor keeps keyboard shortcuts intentionally small so browser, form, and media controls stay predictable.
+The editor keeps keyboard shortcuts focused on preview playback, range marking, seeking, and timeline navigation so browser, form, and media controls stay predictable.
 
 ## Preview playback
 
@@ -13,7 +13,35 @@ The editor keeps keyboard shortcuts intentionally small so browser, form, and me
 | :------- | :------------------------- |
 | `Space`  | Play or pause the preview. |
 
-`Space` only controls preview playback when focus is not inside an interactive control. It is ignored while typing in inputs, using selects, pressing buttons, or adjusting sliders.
+Shortcuts only control the editor when focus is not inside an interactive control or dialog. They are ignored while typing in inputs, using selects, pressing buttons, or adjusting sliders.
+
+## Marking and seeking
+
+| Shortcut                | Action                                |
+| :---------------------- | :------------------------------------ |
+| `I` or `[`              | Set `In` to the current playhead.     |
+| `O` or `]`              | Set `Out` to the current playhead.    |
+| `Shift` + `I`           | Jump to `In`.                         |
+| `Shift` + `O`           | Jump to `Out`.                        |
+| `Left Arrow`            | Move the playhead back 30 seconds.    |
+| `Right Arrow`           | Move the playhead forward 30 seconds. |
+| `Shift` + `Left Arrow`  | Move the playhead back 5 seconds.     |
+| `Shift` + `Right Arrow` | Move the playhead forward 5 seconds.  |
+
+`I`, `O`, `Shift` + `I`, and `Shift` + `O` match Premiere-style mark and jump behavior. Bracket keys and arrow-key seeking are Cliparr conveniences.
+
+## Frame stepping and zoom
+
+| Shortcut       | Action                  |
+| :------------- | :---------------------- |
+| `Page Up`      | Step back one frame.    |
+| `Page Down`    | Step forward one frame. |
+| Hold `K` + `J` | Step back one frame.    |
+| Hold `K` + `L` | Step forward one frame. |
+| `-`            | Zoom the timeline out.  |
+| `=`            | Zoom the timeline in.   |
+
+`K` + `J`, `K` + `L`, `-`, and `=` preserve Premiere muscle memory. `Page Up` and `Page Down` are Cliparr-specific aliases for single-frame stepping.
 
 ## Editable timecodes
 
@@ -33,4 +61,6 @@ Most editor actions are controlled directly on screen:
 - Drag the timeline selection to move the clip range.
 - Drag selection edges to adjust `In` and `Out`.
 - Use the zoom buttons to change timeline scale.
+- Scroll the timeline to move horizontally.
+- Use `Ctrl`/`Cmd` + scroll over the timeline to zoom around the pointer.
 - Use the volume slider and mute button to control preview audio.

--- a/apps/www/src/content/docs/editor-shortcuts.mdx
+++ b/apps/www/src/content/docs/editor-shortcuts.mdx
@@ -1,19 +1,19 @@
 ---
 title: Editor shortcuts
-description: Keyboard behavior for preview playback and editable timecodes.
+description: Keyboard and pointer shortcuts for playback, marking, seeking, frame stepping, timeline zoom, and editable timecodes.
 section: editing-export
 order: 40
 ---
 
 The editor keeps keyboard shortcuts focused on preview playback, range marking, seeking, and timeline navigation so browser, form, and media controls stay predictable.
 
+Shortcuts only control the editor when focus is not inside an interactive control or dialog. They are ignored while typing in inputs, using selects, pressing buttons, adjusting sliders, or working inside export and framegrab dialogs.
+
 ## Preview playback
 
 | Shortcut | Action                     |
 | :------- | :------------------------- |
 | `Space`  | Play or pause the preview. |
-
-Shortcuts only control the editor when focus is not inside an interactive control or dialog. They are ignored while typing in inputs, using selects, pressing buttons, or adjusting sliders.
 
 ## Marking and seeking
 
@@ -30,6 +30,8 @@ Shortcuts only control the editor when focus is not inside an interactive contro
 
 `I`, `O`, `Shift` + `I`, and `Shift` + `O` match Premiere-style mark and jump behavior. Bracket keys and arrow-key seeking are Cliparr conveniences.
 
+Setting `In` or `Out` clamps the range to the media duration and keeps Cliparr's minimum clip length intact. Second-based seeking stays inside the media duration and resumes playback when the preview was already playing.
+
 ## Frame stepping and zoom
 
 | Shortcut       | Action                  |
@@ -42,6 +44,8 @@ Shortcuts only control the editor when focus is not inside an interactive contro
 | `=`            | Zoom the timeline in.   |
 
 `K` + `J`, `K` + `L`, `-`, and `=` preserve Premiere muscle memory. `Page Up` and `Page Down` are Cliparr-specific aliases for single-frame stepping.
+
+Frame stepping pauses the preview and moves by the active source video frame rate when Cliparr can detect it. If the frame rate is unavailable, Cliparr falls back to a 30 fps step.
 
 ## Editable timecodes
 


### PR DESCRIPTION
## Summary
- add editor keyboard command mapping for Premiere-style mark, seek, zoom, and frame-step shortcuts
- detect source video frame rate for frame stepping with a 30 fps fallback
- document editor keyboard and pointer shortcuts in the www docs

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint:types
- pnpm --filter @cliparr/www lint:types
- pnpm preflight