### PR TITLE
feat(cliparr): improve mobile navigation and dashboard cards

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^19.2.6",
     "react-resizable-panels": "^4.11.2",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",

--- a/apps/frontend/src/components/DashboardMobileMenu.tsx
+++ b/apps/frontend/src/components/DashboardMobileMenu.tsx
@@ -1,0 +1,121 @@
+import { ExternalLink, Globe, LogOut, Menu } from "lucide-react";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+
+export const CLIPARR_WEBSITE_URL = "https://cliparr.dev/";
+export const CLIPARR_GITHUB_URL = "https://github.com/TechSquidTV/Cliparr";
+
+export function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 98 96"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M41.4395 69.3848C28.8066 67.8535 19.9062 58.7617 19.9062 46.9902C19.9062 42.2051 21.6289 37.0371 24.5 33.5918C23.2559 30.4336 23.4473 23.7344 24.8828 20.959C28.7109 20.4805 33.8789 22.4902 36.9414 25.2656C40.5781 24.1172 44.4062 23.543 49.0957 23.543C53.7852 23.543 57.6133 24.1172 61.0586 25.1699C64.0254 22.4902 69.2891 20.4805 73.1172 20.959C74.457 23.543 74.6484 30.2422 73.4043 33.4961C76.4668 37.1328 78.0937 42.0137 78.0937 46.9902C78.0937 58.7617 69.1934 67.6621 56.3691 69.2891C59.623 71.3945 61.8242 75.9883 61.8242 81.252L61.8242 91.2051C61.8242 94.0762 64.2168 95.7031 67.0879 94.5547C84.4102 87.9512 98 70.6289 98 49.1914C98 22.1074 75.9883 6.69539e-07 48.9043 4.309e-07C21.8203 1.92261e-07 -1.9479e-07 22.1074 -4.3343e-07 49.1914C-6.20631e-07 70.4375 13.4941 88.0469 31.6777 94.6504C34.2617 95.6074 36.75 93.8848 36.75 91.3008L36.75 83.6445C35.4102 84.2188 33.6875 84.6016 32.1562 84.6016C25.8398 84.6016 22.1074 81.1563 19.4277 74.7441C18.375 72.1602 17.2266 70.6289 15.0254 70.3418C13.877 70.2461 13.4941 69.7676 13.4941 69.1934C13.4941 68.0449 15.4082 67.1836 17.3223 67.1836C20.0977 67.1836 22.4902 68.9063 24.9785 72.4473C26.8926 75.2227 28.9023 76.4668 31.2949 76.4668C33.6875 76.4668 35.2187 75.6055 37.4199 73.4043C39.0469 71.7773 40.291 70.3418 41.4395 69.3848Z" />
+    </svg>
+  );
+}
+
+export function DashboardMobileMenu({
+  appVersion,
+  onLogout,
+}: {
+  appVersion: string;
+  onLogout: () => Promise<void> | void;
+}) {
+  const menuItemClassName =
+    "flex min-h-14 w-full items-center justify-between gap-3 px-4 text-base font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none";
+  const iconClassName =
+    "grid h-8 w-8 shrink-0 place-items-center rounded-full bg-muted text-muted-foreground";
+
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <button
+          type="button"
+          aria-label="Open dashboard menu"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:hidden"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+      </DrawerTrigger>
+      <DrawerContent className="border-border bg-background/95 pb-[max(1rem,env(safe-area-inset-bottom))] sm:hidden">
+        <DrawerTitle className="sr-only">Cliparr Menu</DrawerTitle>
+        <DrawerDescription className="sr-only">
+          Dashboard menu
+        </DrawerDescription>
+        <div className="px-4 pt-5">
+          <div className="overflow-hidden rounded-2xl border border-border bg-card">
+            <DrawerClose asChild>
+              <a
+                href={CLIPARR_WEBSITE_URL}
+                target="_blank"
+                rel="noreferrer"
+                className={menuItemClassName}
+              >
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className={iconClassName}>
+                    <Globe className="h-4 w-4" />
+                  </span>
+                  <span className="truncate">Website</span>
+                </span>
+                <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+              </a>
+            </DrawerClose>
+            <div className="mx-4 h-px bg-border" />
+            <DrawerClose asChild>
+              <a
+                href={CLIPARR_GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                className={menuItemClassName}
+              >
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className={iconClassName}>
+                    <GithubIcon className="h-4 w-4" />
+                  </span>
+                  <span className="truncate">GitHub</span>
+                </span>
+                <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+              </a>
+            </DrawerClose>
+          </div>
+
+          <div className="mt-3 overflow-hidden rounded-2xl border border-border bg-card">
+            <DrawerClose asChild>
+              <button
+                type="button"
+                onClick={() => void onLogout()}
+                className={menuItemClassName}
+              >
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className={iconClassName}>
+                    <LogOut className="h-4 w-4" />
+                  </span>
+                  <span className="truncate">Disconnect</span>
+                </span>
+              </button>
+            </DrawerClose>
+          </div>
+
+          {appVersion && (
+            <DrawerFooter className="border-t-0 px-4 pt-4 pb-0 text-center font-mono text-xs text-muted-foreground">
+              Cliparr {appVersion}
+            </DrawerFooter>
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -15,6 +15,12 @@ import {
   formatProviderName,
   ProviderGlyph,
 } from "@/components/providers/ProviderGlyph";
+import {
+  CLIPARR_GITHUB_URL,
+  CLIPARR_WEBSITE_URL,
+  DashboardMobileMenu,
+  GithubIcon,
+} from "@/components/DashboardMobileMenu";
 import type {
   CurrentlyPlayingItem,
   SourcePlaybackError,
@@ -27,24 +33,6 @@ interface Props {
   onOpenLocalVideo: () => void;
   onOpenSources: () => void;
   onLogout: () => Promise<void> | void;
-}
-
-const CLIPARR_WEBSITE_URL = "https://cliparr.dev/";
-const CLIPARR_GITHUB_URL = "https://github.com/TechSquidTV/Cliparr";
-
-function GithubIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 98 96"
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path d="M41.4395 69.3848C28.8066 67.8535 19.9062 58.7617 19.9062 46.9902C19.9062 42.2051 21.6289 37.0371 24.5 33.5918C23.2559 30.4336 23.4473 23.7344 24.8828 20.959C28.7109 20.4805 33.8789 22.4902 36.9414 25.2656C40.5781 24.1172 44.4062 23.543 49.0957 23.543C53.7852 23.543 57.6133 24.1172 61.0586 25.1699C64.0254 22.4902 69.2891 20.4805 73.1172 20.959C74.457 23.543 74.6484 30.2422 73.4043 33.4961C76.4668 37.1328 78.0937 42.0137 78.0937 46.9902C78.0937 58.7617 69.1934 67.6621 56.3691 69.2891C59.623 71.3945 61.8242 75.9883 61.8242 81.252L61.8242 91.2051C61.8242 94.0762 64.2168 95.7031 67.0879 94.5547C84.4102 87.9512 98 70.6289 98 49.1914C98 22.1074 75.9883 6.69539e-07 48.9043 4.309e-07C21.8203 1.92261e-07 -1.9479e-07 22.1074 -4.3343e-07 49.1914C-6.20631e-07 70.4375 13.4941 88.0469 31.6777 94.6504C34.2617 95.6074 36.75 93.8848 36.75 91.3008L36.75 83.6445C35.4102 84.2188 33.6875 84.6016 32.1562 84.6016C25.8398 84.6016 22.1074 81.1563 19.4277 74.7441C18.375 72.1602 17.2266 70.6289 15.0254 70.3418C13.877 70.2461 13.4941 69.7676 13.4941 69.1934C13.4941 68.0449 15.4082 67.1836 17.3223 67.1836C20.0977 67.1836 22.4902 68.9063 24.9785 72.4473C26.8926 75.2227 28.9023 76.4668 31.2949 76.4668C33.6875 76.4668 35.2187 75.6055 37.4199 73.4043C39.0469 71.7773 40.291 70.3418 41.4395 69.3848Z" />
-    </svg>
-  );
 }
 
 function errorMessage(err: unknown, fallback: string) {
@@ -201,24 +189,63 @@ export default function DashboardScreen({
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
       <div className="max-w-5xl mx-auto">
-        <header className="mb-10 flex flex-col gap-5 sm:mb-12 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <img src="/logo-light.svg" alt="Cliparr Logo" className="w-8 h-8" />
-            <div className="space-y-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <h1 className="text-2xl font-bold tracking-tight">Cliparr</h1>
-                {versionLabel && (
-                  <span className="rounded-full border border-border bg-card px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                    {versionLabel}
-                  </span>
-                )}
+        <header className="mb-8 space-y-4 sm:mb-12 sm:flex sm:items-center sm:justify-between sm:space-y-0">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <img
+                src="/logo-light.svg"
+                alt="Cliparr Logo"
+                className="w-8 h-8"
+              />
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="text-2xl font-bold tracking-tight">Cliparr</h1>
+                  {versionLabel && (
+                    <span className="hidden rounded-full border border-border bg-card px-2 py-0.5 text-xs font-medium text-muted-foreground sm:inline-flex">
+                      {versionLabel}
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Export clips from active playback sessions.
+                </p>
               </div>
-              <p className="text-sm text-muted-foreground">
-                Export clips from active playback sessions.
-              </p>
             </div>
+            <DashboardMobileMenu
+              appVersion={versionLabel}
+              onLogout={onLogout}
+            />
           </div>
-          <div className="flex flex-wrap items-center gap-3 sm:justify-end">
+          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.75rem] gap-2 sm:hidden">
+            <button
+              type="button"
+              onClick={onOpenLocalVideo}
+              className="inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
+            >
+              <FolderOpen className="h-4 w-4 shrink-0" />
+              <span className="truncate">Open Video</span>
+            </button>
+            <button
+              type="button"
+              onClick={onOpenSources}
+              className="inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
+            >
+              <Settings2 className="h-4 w-4 shrink-0" />
+              <span className="truncate">Sources</span>
+            </button>
+            <button
+              type="button"
+              onClick={fetchSessions}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              aria-label="Refresh sessions"
+              title="Refresh"
+            >
+              <RefreshCw
+                className={`h-5 w-5 ${loading ? "animate-spin text-primary" : ""}`}
+              />
+            </button>
+          </div>
+          <div className="hidden flex-wrap items-center gap-3 sm:flex sm:justify-end">
             <button
               type="button"
               onClick={onOpenLocalVideo}
@@ -239,6 +266,7 @@ export default function DashboardScreen({
               type="button"
               onClick={fetchSessions}
               className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+              aria-label="Refresh sessions"
               title="Refresh"
             >
               <RefreshCw

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -10,6 +10,7 @@ import {
   Video,
 } from "lucide-react";
 import { cliparrClient } from "@/api/cliparrClient";
+import { cn } from "@/lib/utils";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 import {
   formatProviderName,
@@ -21,6 +22,11 @@ import {
   DashboardMobileMenu,
   GithubIcon,
 } from "@/components/DashboardMobileMenu";
+import {
+  flattenDashboardPlaybackItems,
+  formatViewerSessionCount,
+} from "@/components/dashboardPlaybackItems";
+import type { DashboardPlaybackCardItem } from "@/components/dashboardPlaybackItems";
 import type {
   CurrentlyPlayingItem,
   SourcePlaybackError,
@@ -66,15 +72,22 @@ function sessionActionLabel(
 function ViewerAvatar({
   name,
   avatarUrl,
+  size = "md",
 }: {
   name: string;
   avatarUrl?: string;
+  size?: "sm" | "md";
 }) {
   const [imageFailed, setImageFailed] = useState(false);
   const label = name.trim().charAt(0).toUpperCase() || "?";
 
   return (
-    <div className="w-12 h-12 rounded-full bg-primary/10 text-primary flex items-center justify-center overflow-hidden text-lg font-semibold">
+    <div
+      className={cn(
+        "flex items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
+        size === "sm" ? "h-8 w-8 text-sm" : "h-12 w-12 text-lg",
+      )}
+    >
       {avatarUrl && !imageFailed ? (
         <img
           src={avatarUrl}
@@ -86,6 +99,116 @@ function ViewerAvatar({
         label
       )}
     </div>
+  );
+}
+
+function ViewerChip({
+  viewer,
+  sessionCount,
+  playerState,
+}: {
+  viewer: ViewerPlaybackGroup["viewer"];
+  sessionCount: number;
+  playerState: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2.5">
+      <ViewerAvatar name={viewer.name} avatarUrl={viewer.avatarUrl} size="sm" />
+      <div className="min-w-0">
+        <div className="truncate text-sm font-semibold text-foreground">
+          {viewer.name}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          <span className="capitalize">{playerState}</span>
+          <span aria-hidden="true"> · </span>
+          {formatViewerSessionCount(sessionCount)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardPlaybackCard({
+  card,
+  activeViewTransitionSessionId,
+  onSelectSession,
+}: {
+  card: DashboardPlaybackCardItem;
+  activeViewTransitionSessionId?: string | null;
+  onSelectSession: (session: CurrentlyPlayingItem) => void;
+}) {
+  const { session: mediaSession, viewer, viewerSessionCount } = card;
+  const canEdit = canEditSession(mediaSession);
+  const sourceLabel = formatSourceLabel(mediaSession.source);
+  const thumbnailViewTransitionName =
+    mediaSession.thumbUrl && mediaSession.id === activeViewTransitionSessionId
+      ? EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (canEdit) {
+          onSelectSession(mediaSession);
+        }
+      }}
+      disabled={!canEdit}
+      className="group relative flex flex-col overflow-hidden rounded-lg border border-border bg-card text-left text-card-foreground transition-all hover:border-primary/50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border"
+    >
+      <div className="relative aspect-video w-full bg-background">
+        {mediaSession.thumbUrl ? (
+          <img
+            src={mediaSession.thumbUrl}
+            alt={mediaSession.title}
+            className="h-full w-full object-cover opacity-80 transition-opacity group-hover:opacity-100"
+            style={
+              thumbnailViewTransitionName
+                ? {
+                    viewTransitionName: thumbnailViewTransitionName,
+                  }
+                : undefined
+            }
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <Video className="h-8 w-8 text-muted-foreground/50" />
+          </div>
+        )}
+        <div className="absolute inset-0 bg-linear-to-t from-card via-card/35 to-transparent" />
+        <div className="absolute top-3 left-3">
+          <span className="inline-flex max-w-[calc(100vw-7rem)] items-center gap-1.5 rounded-full bg-card/90 px-2.5 py-1 text-ui-label font-medium tracking-wide text-muted-foreground uppercase shadow-sm backdrop-blur-sm">
+            <ProviderGlyph
+              providerId={mediaSession.source.providerId}
+              providerName={sourceLabel}
+              className="h-3.5 w-3.5 shrink-0"
+            />
+            <span className="truncate">{sourceLabel}</span>
+          </span>
+        </div>
+        <div className="absolute bottom-3 left-3 right-3">
+          <div className="mb-1 text-xs font-medium text-primary">
+            {mediaSession.type.toUpperCase()}
+          </div>
+          <h3 className="truncate text-xl font-semibold md:text-base">
+            {mediaSession.title}
+          </h3>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col gap-3 p-3 md:p-4">
+        <ViewerChip
+          viewer={viewer}
+          sessionCount={viewerSessionCount}
+          playerState={mediaSession.playerState}
+        />
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span className="truncate">{mediaSession.playerTitle}</span>
+        </div>
+        <div className="flex w-full items-center justify-center rounded-lg bg-primary/10 py-2 text-sm font-medium text-primary transition-colors group-hover:bg-primary group-hover:text-primary-foreground">
+          {sessionActionLabel(mediaSession)}
+        </div>
+      </div>
+    </button>
   );
 }
 
@@ -179,7 +302,8 @@ export default function DashboardScreen({
     };
   }, []);
 
-  const hasPlayback = viewers.length > 0;
+  const playbackCards = flattenDashboardPlaybackItems(viewers);
+  const hasPlaybackCards = playbackCards.length > 0;
   const emptyMessage =
     sourceErrors.length > 0
       ? "No active playback on the available sources."
@@ -189,7 +313,7 @@ export default function DashboardScreen({
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
       <div className="max-w-5xl mx-auto">
-        <header className="mb-8 space-y-4 sm:mb-12 sm:flex sm:items-center sm:justify-between sm:space-y-0">
+        <header className="mb-5 space-y-4 sm:mb-12 sm:flex sm:items-center sm:justify-between sm:space-y-0">
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-center gap-3">
               <img
@@ -304,8 +428,10 @@ export default function DashboardScreen({
           </div>
         </header>
 
-        <div className="space-y-6">
-          <div>
+        <div
+          className={hasPlaybackCards ? "space-y-4 sm:space-y-6" : "space-y-6"}
+        >
+          <div className={hasPlaybackCards ? "sr-only" : ""}>
             <h2 className="text-xl font-semibold mb-2">Currently Playing</h2>
             <p className="text-muted-foreground text-sm">
               Active sessions across enabled sources.
@@ -320,7 +446,7 @@ export default function DashboardScreen({
 
           {!error && <WarningBanner sourceErrors={sourceErrors} />}
 
-          {!loading && !hasPlayback && !error && (
+          {!loading && !hasPlaybackCards && !error && (
             <div className="bg-card text-card-foreground border border-border rounded-2xl p-12 text-center">
               <div className="bg-background w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Play className="w-6 h-6 text-muted-foreground" />
@@ -334,109 +460,18 @@ export default function DashboardScreen({
             </div>
           )}
 
-          <div className="space-y-8">
-            {viewers.map((viewerGroup) => (
-              <section key={viewerGroup.viewer.id} className="space-y-4">
-                <div className="flex items-center gap-4">
-                  <ViewerAvatar
-                    name={viewerGroup.viewer.name}
-                    avatarUrl={viewerGroup.viewer.avatarUrl}
-                  />
-                  <div>
-                    <h3 className="text-lg font-semibold">
-                      {viewerGroup.viewer.name}
-                    </h3>
-                    <p className="text-sm text-muted-foreground">
-                      {viewerGroup.items.length} active{" "}
-                      {viewerGroup.items.length === 1 ? "session" : "sessions"}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                  {viewerGroup.items.map((mediaSession) => {
-                    const canEdit = canEditSession(mediaSession);
-                    const thumbnailViewTransitionName =
-                      mediaSession.thumbUrl &&
-                      mediaSession.id === activeViewTransitionSessionId
-                        ? EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME
-                        : undefined;
-
-                    return (
-                      <button
-                        key={mediaSession.id}
-                        onClick={() => {
-                          if (canEdit) {
-                            onSelectSession(mediaSession);
-                          }
-                        }}
-                        disabled={!canEdit}
-                        className="group relative bg-card text-card-foreground border border-border rounded-lg overflow-hidden hover:border-primary/50 transition-all text-left flex flex-col disabled:opacity-60 disabled:hover:border-border disabled:cursor-not-allowed"
-                      >
-                        <div className="aspect-video w-full bg-background relative">
-                          {mediaSession.thumbUrl ? (
-                            <img
-                              src={mediaSession.thumbUrl}
-                              alt={mediaSession.title}
-                              className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
-                              style={
-                                thumbnailViewTransitionName
-                                  ? {
-                                      viewTransitionName:
-                                        thumbnailViewTransitionName,
-                                    }
-                                  : undefined
-                              }
-                            />
-                          ) : (
-                            <div className="w-full h-full flex items-center justify-center">
-                              <Video className="w-8 h-8 text-muted-foreground/50" />
-                            </div>
-                          )}
-                          <div className="absolute inset-0 bg-linear-to-t from-card/95 via-card/20 to-transparent" />
-                          <div className="absolute top-3 left-3">
-                            <span className="inline-flex items-center gap-1.5 rounded-full bg-card/90 px-2.5 py-1 text-ui-label font-medium uppercase tracking-wide text-muted-foreground shadow-sm backdrop-blur-sm">
-                              <ProviderGlyph
-                                providerId={mediaSession.source.providerId}
-                                providerName={formatSourceLabel(
-                                  mediaSession.source,
-                                )}
-                                className="h-3.5 w-3.5"
-                              />
-                              {formatSourceLabel(mediaSession.source)}
-                            </span>
-                          </div>
-                          <div className="absolute bottom-3 left-3 right-3">
-                            <div className="text-xs font-medium text-primary mb-1">
-                              {mediaSession.type.toUpperCase()}
-                            </div>
-                            <h4 className="font-semibold truncate">
-                              {mediaSession.title}
-                            </h4>
-                          </div>
-                        </div>
-                        <div className="p-4 flex-1 flex flex-col justify-between gap-4">
-                          <div className="space-y-2 text-sm text-muted-foreground">
-                            <div className="flex items-center justify-between gap-3">
-                              <span className="truncate">
-                                {mediaSession.playerTitle}
-                              </span>
-                              <span className="shrink-0 capitalize">
-                                {mediaSession.playerState}
-                              </span>
-                            </div>
-                          </div>
-                          <div className="flex items-center justify-center w-full py-2 bg-primary/10 text-primary rounded-lg text-sm font-medium group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
-                            {sessionActionLabel(mediaSession)}
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-            ))}
-          </div>
+          {hasPlaybackCards && (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3">
+              {playbackCards.map((card) => (
+                <DashboardPlaybackCard
+                  key={card.session.id}
+                  card={card}
+                  activeViewTransitionSessionId={activeViewTransitionSessionId}
+                  onSelectSession={onSelectSession}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/dashboardPlaybackItems.ts
+++ b/apps/frontend/src/components/dashboardPlaybackItems.ts
@@ -1,0 +1,28 @@
+import type {
+  CurrentlyPlayingItem,
+  ViewerPlaybackGroup,
+} from "@/providers/types";
+
+type DashboardPlaybackViewer = ViewerPlaybackGroup["viewer"];
+
+export interface DashboardPlaybackCardItem {
+  session: CurrentlyPlayingItem;
+  viewer: DashboardPlaybackViewer;
+  viewerSessionCount: number;
+}
+
+export function flattenDashboardPlaybackItems(
+  viewers: ViewerPlaybackGroup[],
+): DashboardPlaybackCardItem[] {
+  return viewers.flatMap((viewerGroup) =>
+    viewerGroup.items.map((session) => ({
+      session,
+      viewer: viewerGroup.viewer,
+      viewerSessionCount: viewerGroup.items.length,
+    })),
+  );
+}
+
+export function formatViewerSessionCount(count: number) {
+  return `${count} active ${count === 1 ? "session" : "sessions"}`;
+}

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -3,6 +3,7 @@ import {
   Camera,
   Pause,
   Play,
+  SlidersHorizontal,
   Volume2,
   VolumeX,
   ZoomIn,
@@ -13,6 +14,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
 import { EditorEditableTimecode } from "@/components/editor/EditorEditableTimecode";
 import { EditorPreviewTimecode } from "@/components/editor/EditorPreviewTimecode";
 import {
@@ -20,7 +29,10 @@ import {
   formatTimecodeInput,
 } from "@/components/editor/editorUtils";
 
+type EditorControlsVariant = "desktop" | "mobile";
+
 interface EditorControlsProps {
+  variant?: EditorControlsVariant;
   playing: boolean;
   loadingPreview: boolean;
   togglePlay: () => void;
@@ -69,6 +81,7 @@ function ControlTooltip({
 }
 
 export function EditorControls({
+  variant = "desktop",
   playing,
   loadingPreview,
   togglePlay,
@@ -106,166 +119,271 @@ export function EditorControls({
     Math.min(Math.max(muted ? 0 : volume, 0), 1) * 100
   }%`;
   const framegrabDisabled = Boolean(framegrabDisabledReason);
+  const playControl = (
+    <ControlTooltip
+      label={
+        loadingPreview
+          ? "Preview is loading."
+          : playing
+            ? "Pause preview"
+            : "Play preview"
+      }
+      disabled={loadingPreview}
+    >
+      <button
+        type="button"
+        onClick={togglePlay}
+        disabled={loadingPreview}
+        aria-label={playing ? "Pause preview" : "Play preview"}
+        className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {playing ? (
+          <Pause className="h-4 w-4" />
+        ) : (
+          <Play className="ml-0.5 h-4 w-4" />
+        )}
+      </button>
+    </ControlTooltip>
+  );
+  const previewTimeControl = (
+    <EditorEditableTimecode
+      ariaLabel="preview time"
+      buttonClassName="rounded-[var(--radius-control)] px-1 text-foreground hover:bg-editor-control-hover focus-visible:ring-editor-accent/35"
+      disabled={!canEditPreviewTime}
+      onCommit={onPreviewTimeCommit}
+      value={currentTime}
+      valueLabel={`${formatTimecodeInput(currentTime)} of ${formatTimecodeInput(duration)}`}
+    >
+      <EditorPreviewTimecode
+        ariaHidden
+        currentTime={currentTime}
+        duration={duration}
+      />
+    </EditorEditableTimecode>
+  );
+  const volumeControl = (
+    <div className="flex items-center gap-2">
+      <ControlTooltip
+        label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
+      >
+        <button
+          type="button"
+          onClick={() => setMuted((current) => !current)}
+          className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+          aria-label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
+        >
+          {muted || volume === 0 ? (
+            <VolumeX className="h-4 w-4" />
+          ) : (
+            <Volume2 className="h-4 w-4" />
+          )}
+        </button>
+      </ControlTooltip>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={muted ? 0 : volume}
+        onChange={(event) => {
+          const nextVolume = Number(event.target.value);
+          setVolume(nextVolume);
+          setMuted(nextVolume === 0);
+        }}
+        className="cliparr-editor-range w-24 sm:w-28"
+        aria-label="Preview volume"
+        style={
+          {
+            "--cliparr-range-fill": volumeRangeFillPercent,
+          } as CSSProperties
+        }
+      />
+    </div>
+  );
+  const zoomControl = (
+    <div className="flex items-center overflow-hidden rounded-[var(--radius-control)] border border-editor-border bg-editor-control">
+      <ControlTooltip
+        label={canZoomOut ? "Zoom timeline out" : "Already fully zoomed out"}
+        disabled={!canZoomOut}
+      >
+        <button
+          type="button"
+          onClick={handleTimelineZoomOut}
+          disabled={!canZoomOut}
+          className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+          aria-label="Zoom timeline out"
+        >
+          <ZoomOut className="h-4 w-4" />
+        </button>
+      </ControlTooltip>
+      <ControlTooltip
+        label={canZoomIn ? "Zoom timeline in" : "Already fully zoomed in"}
+        disabled={!canZoomIn}
+      >
+        <button
+          type="button"
+          onClick={handleTimelineZoomIn}
+          disabled={!canZoomIn}
+          className="flex h-8 w-8 items-center justify-center border-l border-editor-border text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+          aria-label="Zoom timeline in"
+        >
+          <ZoomIn className="h-4 w-4" />
+        </button>
+      </ControlTooltip>
+    </div>
+  );
+  const framegrabControl = (
+    <ControlTooltip
+      label={framegrabDisabledReason ?? "Export current frame"}
+      disabled={framegrabDisabled}
+    >
+      <button
+        type="button"
+        onClick={onFramegrabClick}
+        disabled={framegrabDisabled}
+        className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+        aria-label="Export current preview frame"
+      >
+        <Camera className="h-4 w-4" />
+      </button>
+    </ControlTooltip>
+  );
+  const editableClipMetrics = (
+    <>
+      {clipMetrics.map((metric) => (
+        <div key={metric.label} className="flex items-center gap-2">
+          <span className="text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
+            {metric.label}
+          </span>
+          {metric.onCommit ? (
+            <EditorEditableTimecode
+              ariaLabel={`${metric.label} time`}
+              buttonClassName="rounded-[var(--radius-control)] px-1 font-mono text-sm font-semibold text-muted-foreground hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-editor-accent/35"
+              disabled={!canEditClipRange}
+              onCommit={metric.onCommit}
+              value={metric.value}
+            >
+              <span>{formatTime(metric.value)}</span>
+            </EditorEditableTimecode>
+          ) : (
+            <span
+              className={`font-mono text-sm font-semibold ${
+                metric.emphasized ? "text-foreground" : "text-muted-foreground"
+              }`}
+            >
+              {formatTime(metric.value)}
+            </span>
+          )}
+        </div>
+      ))}
+    </>
+  );
+
+  if (variant === "mobile") {
+    return (
+      <div className="border-b border-editor-border bg-editor-panel px-3 py-2">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+          <div className="[&_button]:h-10 [&_button]:w-10">{playControl}</div>
+          <div className="min-w-0 text-center text-sm font-medium">
+            {previewTimeControl}
+          </div>
+          <Drawer>
+            <DrawerTrigger asChild>
+              <button
+                type="button"
+                aria-label="More clip controls"
+                className="flex h-10 w-10 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+              >
+                <SlidersHorizontal className="h-4 w-4" />
+              </button>
+            </DrawerTrigger>
+            <DrawerContent className="border-editor-border bg-editor-panel text-sidebar-foreground">
+              <DrawerHeader className="border-b border-editor-border px-3 text-left">
+                <DrawerTitle>Clip Controls</DrawerTitle>
+                <DrawerDescription className="sr-only">
+                  Additional clip controls
+                </DrawerDescription>
+              </DrawerHeader>
+              <div className="cliparr-editor-scrollbar min-h-0 overflow-y-auto px-3 pb-4">
+                <section className="border-b border-editor-border py-3">
+                  <div className="mb-2 text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
+                    Playback
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm text-sidebar-foreground">
+                      Volume
+                    </span>
+                    <div className="[&_input]:w-36">{volumeControl}</div>
+                  </div>
+                </section>
+                <section className="border-b border-editor-border py-3">
+                  <div className="mb-2 text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
+                    Timeline
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm text-sidebar-foreground">
+                      Zoom
+                    </span>
+                    {zoomControl}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between gap-3">
+                    <span className="text-sm text-sidebar-foreground">
+                      Frame
+                    </span>
+                    {framegrabControl}
+                  </div>
+                </section>
+                <section className="py-3">
+                  <div className="mb-2 text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
+                    Clip Range
+                  </div>
+                  <div className="grid gap-2 text-right">
+                    {editableClipMetrics}
+                  </div>
+                </section>
+              </div>
+            </DrawerContent>
+          </Drawer>
+        </div>
+        <div className="mt-2 grid grid-cols-3 gap-1.5">
+          {clipMetrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="min-w-0 rounded-[var(--radius-control)] border border-editor-border bg-editor-control px-2 py-1.5"
+            >
+              <div className="truncate text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
+                {metric.label}
+              </div>
+              <div
+                className={`truncate font-mono text-xs font-semibold ${
+                  metric.emphasized
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {formatTime(metric.value)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="border-b border-editor-border bg-editor-panel px-3 py-2">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
         <div className="flex items-center gap-2.5">
-          <ControlTooltip
-            label={
-              loadingPreview
-                ? "Preview is loading."
-                : playing
-                  ? "Pause preview"
-                  : "Play preview"
-            }
-            disabled={loadingPreview}
-          >
-            <button
-              type="button"
-              onClick={togglePlay}
-              disabled={loadingPreview}
-              aria-label={playing ? "Pause preview" : "Play preview"}
-              className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {playing ? (
-                <Pause className="h-4 w-4" />
-              ) : (
-                <Play className="ml-0.5 h-4 w-4" />
-              )}
-            </button>
-          </ControlTooltip>
-          <EditorEditableTimecode
-            ariaLabel="preview time"
-            buttonClassName="rounded-[var(--radius-control)] px-1 text-foreground hover:bg-editor-control-hover focus-visible:ring-editor-accent/35"
-            disabled={!canEditPreviewTime}
-            onCommit={onPreviewTimeCommit}
-            value={currentTime}
-            valueLabel={`${formatTimecodeInput(currentTime)} of ${formatTimecodeInput(duration)}`}
-          >
-            <EditorPreviewTimecode
-              ariaHidden
-              currentTime={currentTime}
-              duration={duration}
-            />
-          </EditorEditableTimecode>
+          {playControl}
+          {previewTimeControl}
         </div>
         <div className="h-5 w-px bg-editor-border" />
-        <div className="flex items-center gap-2">
-          <ControlTooltip
-            label={muted || volume === 0 ? "Unmute preview" : "Mute preview"}
-          >
-            <button
-              type="button"
-              onClick={() => setMuted((current) => !current)}
-              className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
-              aria-label={
-                muted || volume === 0 ? "Unmute preview" : "Mute preview"
-              }
-            >
-              {muted || volume === 0 ? (
-                <VolumeX className="h-4 w-4" />
-              ) : (
-                <Volume2 className="h-4 w-4" />
-              )}
-            </button>
-          </ControlTooltip>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={muted ? 0 : volume}
-            onChange={(event) => {
-              const nextVolume = Number(event.target.value);
-              setVolume(nextVolume);
-              setMuted(nextVolume === 0);
-            }}
-            className="cliparr-editor-range w-24 sm:w-28"
-            aria-label="Preview volume"
-            style={
-              {
-                "--cliparr-range-fill": volumeRangeFillPercent,
-              } as CSSProperties
-            }
-          />
-        </div>
-        <div className="flex items-center overflow-hidden rounded-[var(--radius-control)] border border-editor-border bg-editor-control">
-          <ControlTooltip
-            label={
-              canZoomOut ? "Zoom timeline out" : "Already fully zoomed out"
-            }
-            disabled={!canZoomOut}
-          >
-            <button
-              type="button"
-              onClick={handleTimelineZoomOut}
-              disabled={!canZoomOut}
-              className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-              aria-label="Zoom timeline out"
-            >
-              <ZoomOut className="h-4 w-4" />
-            </button>
-          </ControlTooltip>
-          <ControlTooltip
-            label={canZoomIn ? "Zoom timeline in" : "Already fully zoomed in"}
-            disabled={!canZoomIn}
-          >
-            <button
-              type="button"
-              onClick={handleTimelineZoomIn}
-              disabled={!canZoomIn}
-              className="flex h-8 w-8 items-center justify-center border-l border-editor-border text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-              aria-label="Zoom timeline in"
-            >
-              <ZoomIn className="h-4 w-4" />
-            </button>
-          </ControlTooltip>
-        </div>
-        <ControlTooltip
-          label={framegrabDisabledReason ?? "Export current frame"}
-          disabled={framegrabDisabled}
-        >
-          <button
-            type="button"
-            onClick={onFramegrabClick}
-            disabled={framegrabDisabled}
-            className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
-            aria-label="Export current preview frame"
-          >
-            <Camera className="h-4 w-4" />
-          </button>
-        </ControlTooltip>
+        {volumeControl}
+        {zoomControl}
+        {framegrabControl}
         <div className="min-w-0 flex-1" />
         <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-right sm:gap-x-6">
-          {clipMetrics.map((metric) => (
-            <div key={metric.label} className="flex items-center gap-2">
-              <span className="text-ui-label font-semibold uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
-                {metric.label}
-              </span>
-              {metric.onCommit ? (
-                <EditorEditableTimecode
-                  ariaLabel={`${metric.label} time`}
-                  buttonClassName="rounded-[var(--radius-control)] px-1 font-mono text-sm font-semibold text-muted-foreground hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-editor-accent/35"
-                  disabled={!canEditClipRange}
-                  onCommit={metric.onCommit}
-                  value={metric.value}
-                >
-                  <span>{formatTime(metric.value)}</span>
-                </EditorEditableTimecode>
-              ) : (
-                <span
-                  className={`font-mono text-sm font-semibold ${
-                    metric.emphasized
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  {formatTime(metric.value)}
-                </span>
-              )}
-            </div>
-          ))}
+          {editableClipMetrics}
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -427,6 +427,7 @@ export default function EditorScreen({ session, onBack }: Props) {
   );
   const editorControls = (
     <EditorControls
+      variant={layoutVariant}
       playing={playing}
       loadingPreview={loadingPreview}
       togglePlay={togglePlay}

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { createElement, createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
+import { DashboardMobileMenu } from "@/components/DashboardMobileMenu";
 import { EditorControls } from "@/components/editor/EditorControls";
 import { EditorFramegrabDialog } from "@/components/editor/EditorFramegrabDialog";
 import { EditorPreview } from "@/components/editor/EditorPreview";
@@ -31,6 +32,17 @@ void test("renders local video dialog file picker workflow", () => {
   assert.match(markup, /Open Video/);
   assert.match(markup, /Local files stay in your browser/);
   assert.match(markup, /Choose File/);
+});
+
+void test("renders dashboard mobile menu trigger", () => {
+  const markup = renderToStaticMarkup(
+    createElement(DashboardMobileMenu, {
+      appVersion: "1.2.3",
+      onLogout: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /Open dashboard menu/);
 });
 
 void test("renders the editor thumbnail behind loading preview state", () => {
@@ -71,6 +83,43 @@ void test("keeps the editor thumbnail mounted after preview load for fade out", 
   assert.match(markup, /\/api\/media\/thumb\.jpg/);
   assert.match(markup, /transition-opacity/);
   assert.match(markup, /opacity-0/);
+});
+
+void test("renders mobile editor controls trigger and compact range summary", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(EditorControls, {
+        variant: "mobile",
+        playing: false,
+        loadingPreview: false,
+        togglePlay: () => undefined,
+        currentTime: 12,
+        duration: 120,
+        startTime: 10,
+        endTime: 20,
+        muted: false,
+        setMuted: () => undefined,
+        volume: 1,
+        setVolume: () => undefined,
+        handleTimelineZoomIn: () => undefined,
+        handleTimelineZoomOut: () => undefined,
+        canZoomIn: true,
+        canZoomOut: true,
+        onFramegrabClick: () => undefined,
+        framegrabDisabledReason: null,
+        onPreviewTimeCommit: () => undefined,
+        onStartTimeCommit: () => undefined,
+        onEndTimeCommit: () => undefined,
+      }),
+    ),
+  );
+
+  assert.match(markup, /More clip controls/);
+  assert.match(markup, />In</);
+  assert.match(markup, />Out</);
+  assert.match(markup, />Duration</);
 });
 
 void test("renders editor poster with the shared thumbnail view transition", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -4,7 +4,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createElement, createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import {
+  flattenDashboardPlaybackItems,
+  formatViewerSessionCount,
+} from "@/components/dashboardPlaybackItems";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
+import { DashboardPlaybackCard } from "@/components/DashboardScreen";
 import { DashboardMobileMenu } from "@/components/DashboardMobileMenu";
 import { EditorControls } from "@/components/editor/EditorControls";
 import { EditorFramegrabDialog } from "@/components/editor/EditorFramegrabDialog";
@@ -12,6 +17,54 @@ import { EditorPreview } from "@/components/editor/EditorPreview";
 import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
+import type { ViewerPlaybackGroup } from "@/providers/types";
+
+const dashboardPlaybackGroups: ViewerPlaybackGroup[] = [
+  {
+    viewer: {
+      id: "viewer-a",
+      providerId: "plex",
+      name: "TechSquidTV",
+    },
+    items: [
+      {
+        id: "session-a",
+        source: {
+          id: "source-a",
+          name: "Plex",
+          providerId: "plex",
+        },
+        title: "The Recordist",
+        type: "episode",
+        duration: 3600,
+        playerTitle: "Living Room",
+        playerState: "playing",
+      },
+    ],
+  },
+  {
+    viewer: {
+      id: "viewer-b",
+      providerId: "jellyfin",
+      name: "Guest",
+    },
+    items: [
+      {
+        id: "session-b",
+        source: {
+          id: "source-b",
+          name: "Jellyfin",
+          providerId: "jellyfin",
+        },
+        title: "Example Movie",
+        type: "movie",
+        duration: 5400,
+        playerTitle: "Phone",
+        playerState: "paused",
+      },
+    ],
+  },
+];
 
 void test("renders the provider auth completion screen", () => {
   const markup = renderToStaticMarkup(createElement(AuthCompleteScreen));
@@ -43,6 +96,42 @@ void test("renders dashboard mobile menu trigger", () => {
   );
 
   assert.match(markup, /Open dashboard menu/);
+});
+
+void test("flattens dashboard playback cards with viewer context", () => {
+  const cards = flattenDashboardPlaybackItems(dashboardPlaybackGroups);
+
+  assert.deepEqual(
+    cards.map((card) => [
+      card.viewer.name,
+      card.viewerSessionCount,
+      card.session.title,
+    ]),
+    [
+      ["TechSquidTV", 1, "The Recordist"],
+      ["Guest", 1, "Example Movie"],
+    ],
+  );
+  assert.equal(formatViewerSessionCount(1), "1 active session");
+  assert.equal(formatViewerSessionCount(2), "2 active sessions");
+});
+
+void test("renders dashboard playback cards with viewer context", () => {
+  const card = flattenDashboardPlaybackItems(dashboardPlaybackGroups)[0];
+  assert.ok(card);
+
+  const markup = renderToStaticMarkup(
+    createElement(DashboardPlaybackCard, {
+      card,
+      activeViewTransitionSessionId: null,
+      onSelectSession: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /TechSquidTV/);
+  assert.match(markup, /playing/);
+  assert.match(markup, /1 active session/);
+  assert.match(markup, /Living Room/);
 });
 
 void test("renders the editor thumbnail behind loading preview state", () => {

--- a/apps/frontend/src/components/providers/ProviderGlyph.tsx
+++ b/apps/frontend/src/components/providers/ProviderGlyph.tsx
@@ -1,7 +1,12 @@
 import { Film, Server } from "lucide-react";
-import plexLogoUrl from "@/assets/providers/plex.svg";
-import jellyfinLogoUrl from "@/assets/providers/jellyfin.svg";
 import { cn } from "@/lib/utils";
+
+const plexLogoUrl = new URL("../../assets/providers/plex.svg", import.meta.url)
+  .href;
+const jellyfinLogoUrl = new URL(
+  "../../assets/providers/jellyfin.svg",
+  import.meta.url,
+).href;
 
 export function formatProviderName(providerId: string) {
   return providerId

--- a/apps/frontend/src/components/ui/drawer.tsx
+++ b/apps/frontend/src/components/ui/drawer.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+import { cn } from "@/lib/utils";
+
+function Drawer({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return (
+    <DrawerPrimitive.Root
+      shouldScaleBackground={shouldScaleBackground}
+      {...props}
+    />
+  );
+}
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+const DrawerPortal = DrawerPrimitive.Portal;
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(function DrawerOverlay({ className, ...props }, ref) {
+  return (
+    <DrawerPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        "fixed inset-0 z-50 bg-foreground/40 backdrop-blur-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(function DrawerContent({ className, children, ...props }, ref) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85dvh] flex-col rounded-t-2xl border border-border bg-card text-card-foreground shadow-2xl outline-none",
+          className,
+        )}
+        {...props}
+      >
+        <DrawerPrimitive.Handle className="mx-auto mt-3 h-1.5 w-10 rounded-full bg-muted-foreground/35" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+});
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "grid gap-1.5 px-4 py-3 text-center sm:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "mt-auto flex flex-col gap-2 border-t border-border px-4 py-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(function DrawerTitle({ className, ...props }, ref) {
+  return (
+    <DrawerPrimitive.Title
+      ref={ref}
+      className={cn(
+        "text-sm font-semibold uppercase tracking-[var(--tracking-caps-md)] text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(function DrawerDescription({ className, ...props }, ref) {
+  return (
+    <DrawerPrimitive.Description
+      ref={ref}
+      className={cn("text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -5,11 +5,14 @@ const links = [
   { href: "/#features", label: "Features" },
   { href: "/docs", label: "Docs" },
   { href: "/changelog", label: "Releases" },
-  { href: site.githubUrl, label: "GitHub", className: "hidden sm:inline-flex" },
+  { href: site.githubUrl, label: "GitHub" },
 ];
+
+const mobileMenuId = "site-mobile-menu";
 ---
 
 <header
+  data-site-header
   class="sticky top-0 z-30 border-b border-border bg-background/88 backdrop-blur-xl"
 >
   <div
@@ -25,15 +28,84 @@ const links = [
         >{site.name}</span
       >
     </a>
+    <div class="flex items-center gap-2 sm:hidden">
+      <button
+        type="button"
+        data-theme-toggle
+        aria-label="Toggle color theme"
+        title="Toggle color theme"
+        class="focus-ring inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <svg
+          class="theme-toggle-icon theme-toggle-icon-moon h-4 w-4"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M21 14.2A8.5 8.5 0 0 1 9.8 3a7 7 0 1 0 11.2 11.2Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"></path>
+        </svg>
+        <svg
+          class="theme-toggle-icon theme-toggle-icon-sun h-4 w-4"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 4V2m0 20v-2m8-8h2M2 12h2m14.95-6.95 1.42-1.42M3.63 20.37l1.42-1.42m0-13.9L3.63 3.63m16.74 16.74-1.42-1.42M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"></path>
+        </svg>
+      </button>
+      <button
+        type="button"
+        data-mobile-nav-toggle
+        aria-label="Open navigation menu"
+        aria-controls={mobileMenuId}
+        aria-expanded="false"
+        class="focus-ring inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <svg
+          class="site-mobile-menu-icon-menu h-4 w-4"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 7h16M4 12h16M4 17h16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"></path>
+        </svg>
+        <svg
+          class="site-mobile-menu-icon-close h-4 w-4"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="m6 6 12 12M18 6 6 18"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"></path>
+        </svg>
+      </button>
+    </div>
     <nav
       aria-label="Primary navigation"
-      class="flex min-w-0 items-center gap-1 sm:gap-2"
+      class="hidden min-w-0 items-center gap-2 sm:flex"
     >
       {
         links.map((link) => (
           <a
             href={link.href}
-            class={`focus-ring rounded-full px-1.5 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground min-[380px]:px-2.5 sm:px-3 ${link.className ?? ""}`}
+            class="focus-ring rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             target={link.href.startsWith("http") ? "_blank" : undefined}
             rel={link.href.startsWith("http") ? "noreferrer" : undefined}
           >
@@ -83,4 +155,117 @@ const links = [
       </a>
     </nav>
   </div>
+  <div
+    id={mobileMenuId}
+    data-mobile-nav
+    hidden
+    class="border-t border-border bg-background/95 sm:hidden"
+  >
+    <nav aria-label="Mobile navigation" class="container-page grid gap-1 py-3">
+      {
+        links.map((link) => (
+          <a
+            href={link.href}
+            class="focus-ring flex min-h-11 items-center justify-between rounded-lg px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            target={link.href.startsWith("http") ? "_blank" : undefined}
+            rel={link.href.startsWith("http") ? "noreferrer" : undefined}
+          >
+            {link.label}
+            {link.href.startsWith("http") ? (
+              <svg
+                class="h-3.5 w-3.5 text-muted-foreground"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  d="M7 17 17 7M9 7h8v8"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            ) : null}
+          </a>
+        ))
+      }
+      <a
+        href="/docs/getting-started"
+        class="focus-ring mt-1 flex min-h-11 items-center justify-center rounded-lg bg-foreground px-4 text-sm font-semibold text-background transition-colors hover:bg-primary"
+      >
+        Get started
+      </a>
+    </nav>
+  </div>
 </header>
+
+<script is:inline>
+  (() => {
+    const initMobileNav = () => {
+      const header = document.querySelector("[data-site-header]");
+      if (!header) return;
+
+      const button = header.querySelector("[data-mobile-nav-toggle]");
+      const menu = header.querySelector("[data-mobile-nav]");
+      if (
+        !(button instanceof HTMLButtonElement) ||
+        !(menu instanceof HTMLElement)
+      ) {
+        return;
+      }
+
+      if (button.dataset.mobileNavBound === "true") {
+        menu.hidden = true;
+        button.setAttribute("aria-expanded", "false");
+        header.removeAttribute("data-mobile-nav-open");
+        return;
+      }
+
+      const setOpen = (open) => {
+        menu.hidden = !open;
+        button.setAttribute("aria-expanded", open ? "true" : "false");
+        button.setAttribute(
+          "aria-label",
+          open ? "Close navigation menu" : "Open navigation menu",
+        );
+        header.toggleAttribute("data-mobile-nav-open", open);
+      };
+
+      button.dataset.mobileNavBound = "true";
+      button.addEventListener("click", () => {
+        setOpen(button.getAttribute("aria-expanded") !== "true");
+      });
+      menu.addEventListener("click", (event) => {
+        if (event.target instanceof Element && event.target.closest("a")) {
+          setOpen(false);
+        }
+      });
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          setOpen(false);
+        }
+      });
+      document.addEventListener("click", (event) => {
+        if (
+          button.getAttribute("aria-expanded") === "true" &&
+          event.target instanceof Node &&
+          !header.contains(event.target)
+        ) {
+          setOpen(false);
+        }
+      });
+      setOpen(false);
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initMobileNav, {
+        once: true,
+      });
+    } else {
+      initMobileNav();
+    }
+
+    document.addEventListener("astro:page-load", initMobileNav);
+  })();
+</script>

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -312,6 +312,18 @@
     display: none;
   }
 
+  .site-mobile-menu-icon-close {
+    display: none;
+  }
+
+  [data-mobile-nav-toggle][aria-expanded="true"] .site-mobile-menu-icon-menu {
+    display: none;
+  }
+
+  [data-mobile-nav-toggle][aria-expanded="true"] .site-mobile-menu-icon-close {
+    display: block;
+  }
+
   :root[data-theme="dark"] .site-logo,
   :root[data-theme="dark"] .provider-logo {
     filter: none;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
@@ -5635,6 +5638,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -11608,6 +11617,15 @@ snapshots:
   uuid@14.0.0: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- improves mobile navigation in the frontend dashboard and www header
- moves secondary dashboard/editor controls into more native-feeling mobile menus/drawers
- flattens dashboard playback cards so viewer identity lives inside each card

## Validation

- `pnpm preflight`
- visual/browser screenshot verification skipped by request
