### PR TITLE
feat(cliparr)!: change default production port to 7171

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # Generate one with: openssl rand -base64 32
 APP_KEY=""
 
-# PORT: Express server port.
-PORT="3000"
+# PORT: Optional Express server port override.
+# Defaults to 7171 in production and 3000 in development.
+# PORT="7171"
 
 # CLIPARR_DATA_DIR: Directory where Cliparr stores its required SQLite database.
 # Docker uses /data and should mount it as a persistent volume.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,13 +87,13 @@ jobs:
           docker run \
             --detach \
             --name cliparr-smoke \
-            --publish 3000:3000 \
+            --publish 7171:7171 \
             --env APP_KEY="cliparr-smoke-test-key-with-at-least-32-characters" \
             --volume cliparr-smoke-data:/data \
             cliparr:smoke
 
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://127.0.0.1:3000/api/health > "${health_file}"; then
+            if curl --fail --silent --show-error http://127.0.0.1:7171/api/health > "${health_file}"; then
               break
             fi
             sleep 1
@@ -103,7 +103,7 @@ jobs:
           grep -q '"status":"ok"' "${health_file}"
           grep -q '"database":"ok"' "${health_file}"
 
-          curl --fail --silent --show-error http://127.0.0.1:3000/ > "${index_file}"
+          curl --fail --silent --show-error http://127.0.0.1:7171/ > "${index_file}"
           grep -q '<div id="root"></div>' "${index_file}"
 
       - name: Show smoke-test logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,13 +123,13 @@ jobs:
           docker run \
             --detach \
             --name cliparr-smoke \
-            --publish 3000:3000 \
+            --publish 7171:7171 \
             --env APP_KEY="cliparr-smoke-test-key-with-at-least-32-characters" \
             --volume cliparr-smoke-data:/data \
             cliparr:smoke
 
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://127.0.0.1:3000/api/health > "${health_file}"; then
+            if curl --fail --silent --show-error http://127.0.0.1:7171/api/health > "${health_file}"; then
               break
             fi
             sleep 1
@@ -140,7 +140,7 @@ jobs:
           grep -q '"database":"ok"' "${health_file}"
           grep -q '"version":"${{ steps.plan.outputs.tag }}"' "${health_file}"
 
-          curl --fail --silent --show-error http://127.0.0.1:3000/ > "${index_file}"
+          curl --fail --silent --show-error http://127.0.0.1:7171/ > "${index_file}"
           grep -q '<div id="root"></div>' "${index_file}"
 
       - name: Show smoke-test logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ LABEL org.opencontainers.image.title="Cliparr" \
   org.opencontainers.image.licenses="MIT"
 
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=7171
 ENV CLIPARR_DATA_DIR=/data
 ENV CLIPARR_VERSION=$CLIPARR_VERSION
 
@@ -61,9 +61,9 @@ USER node
 
 VOLUME ["/data"]
 
-EXPOSE 3000
+EXPOSE 7171
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD ["node", "-e", "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/api/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
+  CMD ["node", "-e", "fetch('http://127.0.0.1:' + (process.env.PORT || 7171) + '/api/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
 
 CMD ["node", "apps/server/dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The fastest way to get Cliparr running is via the GitHub Container Registry.
 ```bash
 docker run -d \
   --name cliparr \
-  -p 3000:3000 \
+  -p 7171:7171 \
   -e APP_KEY="your-32-char-stable-random-secret" \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
@@ -69,7 +69,7 @@ services:
     image: ghcr.io/techsquidtv/cliparr:latest
     container_name: cliparr
     ports:
-      - "3000:3000"
+      - "7171:7171"
     environment:
       - APP_KEY=replace-this-with-a-32-character-secure-random-string
     volumes:
@@ -87,7 +87,7 @@ volumes:
 | Variable                               | Description                                                                                                                        | Default                  |
 | :------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------------------- |
 | `APP_KEY`                              | Required secret for credential encryption. Must be at least 32 characters long.                                                    | `-`                      |
-| `PORT`                                 | Internal port for the Express server.                                                                                              | `3000`                   |
+| `PORT`                                 | Internal port for the Express server.                                                                                              | `7171 prod / 3000 dev`   |
 | `CLIPARR_DATA_DIR`                     | Directory for SQLite storage.                                                                                                      | `/data`                  |
 | `CLIPARR_LOG_LEVEL`                    | Server log level. Supports trace, debug, info, warning, error, and fatal. Defaults to debug in development and info in production. | `debug/info`             |
 | `CLIPARR_LOG_FORMAT`                   | Production server console log format. Development console logs are always JSON.                                                    | `json dev / pretty prod` |

--- a/apps/server/src/config/serverPort.test.ts
+++ b/apps/server/src/config/serverPort.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_DEVELOPMENT_PORT,
+  DEFAULT_PRODUCTION_PORT,
+  resolveServerPort,
+} from "@/config/serverPort";
+
+void test("defaults the production server port to 7171", () => {
+  assert.equal(resolveServerPort({ NODE_ENV: "production" }), 7171);
+  assert.equal(DEFAULT_PRODUCTION_PORT, 7171);
+});
+
+void test("keeps the development server port on 3000", () => {
+  assert.equal(resolveServerPort({ NODE_ENV: "development" }), 3000);
+  assert.equal(resolveServerPort({}), 3000);
+  assert.equal(DEFAULT_DEVELOPMENT_PORT, 3000);
+});
+
+void test("lets PORT override the environment default", () => {
+  assert.equal(
+    resolveServerPort({ NODE_ENV: "production", PORT: "8123" }),
+    8123,
+  );
+});

--- a/apps/server/src/config/serverPort.ts
+++ b/apps/server/src/config/serverPort.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_DEVELOPMENT_PORT = 3000;
+export const DEFAULT_PRODUCTION_PORT = 7171;
+
+interface ServerPortEnv {
+  NODE_ENV?: string;
+  PORT?: string;
+}
+
+function defaultServerPort(env: ServerPortEnv = process.env) {
+  return env.NODE_ENV === "production"
+    ? DEFAULT_PRODUCTION_PORT
+    : DEFAULT_DEVELOPMENT_PORT;
+}
+
+export function resolveServerPort(env: ServerPortEnv = process.env) {
+  return Number(env.PORT ?? defaultServerPort(env));
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,6 +2,7 @@ import "@/config/loadEnv";
 import type { Server } from "node:http";
 import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import { createApp } from "@/app";
+import { resolveServerPort } from "@/config/serverPort";
 import { closeDatabase } from "@/db/database";
 import { configureLogging, fatalWithError, getServerLogger } from "@/logging";
 
@@ -19,7 +20,7 @@ function hasCloseAllConnections(
 async function startServer() {
   await configureLogging();
   const { app } = await createApp();
-  const PORT = Number(process.env.PORT ?? 3000);
+  const PORT = resolveServerPort();
 
   const server = app.listen(PORT, "0.0.0.0", () => {
     logger.info("Server listening on {url}.", {

--- a/apps/www/src/content/docs/access-control.mdx
+++ b/apps/www/src/content/docs/access-control.mdx
@@ -86,7 +86,7 @@ cliparr.example.com {
         copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
     }
 
-    reverse_proxy cliparr:3000 {
+    reverse_proxy cliparr:7171 {
         header_up Host {host}
         header_up X-Forwarded-Proto {scheme}
     }
@@ -102,7 +102,7 @@ services:
     environment:
       - APP_KEY=replace-this-with-a-32-character-secure-random-string
     expose:
-      - "3000"
+      - "7171"
     volumes:
       - cliparr-data:/data
     restart: unless-stopped
@@ -146,7 +146,7 @@ With Tailscale, bind Cliparr to localhost and share it only inside your tailnet:
 ```bash
 docker run -d \
   --name cliparr \
-  -p 127.0.0.1:3000:3000 \
+  -p 127.0.0.1:7171:7171 \
   -e APP_KEY="your-32-char-stable-random-secret" \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
@@ -155,7 +155,7 @@ docker run -d \
 Then run Tailscale Serve on the same host:
 
 ```bash
-tailscale serve --bg localhost:3000
+tailscale serve --bg localhost:7171
 ```
 
 Tailscale will give the service a tailnet-only HTTPS URL on the machine's MagicDNS name. Do not use Tailscale Funnel for Cliparr unless you intentionally want to expose it to the public internet.
@@ -167,7 +167,7 @@ For example, if the Cliparr host has WireGuard address `10.8.0.1`, bind Docker t
 ```bash
 docker run -d \
   --name cliparr \
-  -p 10.8.0.1:3000:3000 \
+  -p 10.8.0.1:7171:7171 \
   -e APP_KEY="your-32-char-stable-random-secret" \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
@@ -177,7 +177,7 @@ If you use Caddy inside the VPN, serve Cliparr on an internal name and restrict 
 
 ```caddyfile
 cliparr.home.arpa {
-    reverse_proxy 127.0.0.1:3000 {
+    reverse_proxy 127.0.0.1:7171 {
         header_up Host {host}
         header_up X-Forwarded-Proto {scheme}
     }

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -13,7 +13,7 @@ Run Cliparr in Docker, then open the app and connect Plex, Jellyfin, or a local 
 
 <CommandBlock code={dockerRunCommand} label="Docker quick start" lang="bash" />
 
-Open `http://localhost:3000`, connect Plex or Jellyfin, or choose **Open Video** for a local file.
+Open `http://localhost:7171`, connect Plex or Jellyfin, or choose **Open Video** for a local file.
 
 <Callout title="Stable APP_KEY required" tone="warning">
   Use a stable random `APP_KEY` at least 32 characters long. If it changes

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -65,7 +65,7 @@ export const providers = [
 
 export const dockerRunCommand = `docker run -d \\
   --name cliparr \\
-  -p 3000:3000 \\
+  -p 7171:7171 \\
   -e APP_KEY="your-32-char-stable-random-secret" \\
   -v cliparr-data:/data \\
   ghcr.io/techsquidtv/cliparr:latest`;
@@ -75,7 +75,7 @@ export const dockerComposeExample = `services:
     image: ghcr.io/techsquidtv/cliparr:latest
     container_name: cliparr
     ports:
-      - "3000:3000"
+      - "7171:7171"
     environment:
       - APP_KEY=replace-this-with-a-32-character-secure-random-string
     volumes:
@@ -87,7 +87,7 @@ volumes:
 
 export const structuredConsoleLoggingCommand = `docker run -d \\
   --name cliparr \\
-  -p 3000:3000 \\
+  -p 7171:7171 \\
   -e APP_KEY="your-32-char-stable-random-secret" \\
   -e CLIPARR_LOG_FORMAT=json \\
   -v cliparr-data:/data \\
@@ -136,7 +136,7 @@ export const envVars = [
   {
     name: "PORT",
     description: "Internal port for the Express server.",
-    defaultValue: "3000",
+    defaultValue: "7171 prod / 3000 dev",
     required: false,
   },
   {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ services:
   cliparr:
     build: .
     ports:
-      - "3000:3000"
+      - "7171:7171"
     environment:
       APP_KEY: "${APP_KEY:?APP_KEY is required}"
-      PORT: "3000"
+      PORT: "7171"
       CLIPARR_DATA_DIR: "/data"
     volumes:
       - cliparr-data:/data


### PR DESCRIPTION
## Summary
- Change Docker and production server defaults from port 3000 to 7171.
- Keep development defaults on 3000 and continue allowing PORT to override either environment.
- Update install docs, reverse proxy examples, README, and image smoke tests for 7171.

## Breaking Change
Production deployments that relied on the implicit 3000 default need to publish 7171, set PORT=3000, or map host port 3000 to container port 7171.

## Validation
- pnpm docs:check
- pnpm --filter @cliparr/server test
- pnpm preflight

Closes #40.