### PR TITLE
feat(server): use official Jellyfin SDK

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cliparr/shared": "workspace:*",
-    "@jellyfin/sdk": "0.13.0",
+    "@jellyfin/sdk": "^0.13.0",
     "@logtape/logtape": "^2.1.1",
     "axios": "^1.16.1",
     "dotenv": "^17.4.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "@cliparr/shared": "workspace:*",
+    "@jellyfin/sdk": "0.13.0",
     "@logtape/logtape": "^2.1.1",
+    "axios": "^1.16.1",
     "dotenv": "^17.4.2",
     "drizzle-orm": "1.0.0-rc.4-273829f",
     "express": "^5.2.1"

--- a/apps/server/src/providers/jellyfin/auth.ts
+++ b/apps/server/src/providers/jellyfin/auth.ts
@@ -3,18 +3,17 @@ import { createApiError, isApiError } from "@/http/errors";
 import type { ProviderResource } from "@/providers/types";
 import { stringValue } from "@/providers/shared/utils";
 import {
+  authenticateJellyfinUser,
   connectionInfo,
   fetchCurrentUser,
+  fetchPublicSystemInfo,
   fetchSessions,
   JELLYFIN_DEVICE_ID,
   JELLYFIN_REQUEST_TIMEOUT_MS,
-  jellyfinJson,
   jellyfinSourceName,
   normalizeBaseUrl,
   resolveCredentialServerUrl,
   sourceContext,
-  type JellyfinAuthenticationResult,
-  type JellyfinPublicSystemInfo,
 } from "@/providers/jellyfin/shared";
 
 async function parseCredentialsInput(body: unknown) {
@@ -63,36 +62,27 @@ async function parseCredentialsInput(body: unknown) {
 
 export async function authenticateWithCredentials(body: unknown) {
   const { serverUrl, username, password } = await parseCredentialsInput(body);
-  const publicInfo = await jellyfinJson<JellyfinPublicSystemInfo>(
-    serverUrl,
-    "/System/Info/Public",
-    {
+  const publicInfo = await fetchPublicSystemInfo({
+    baseUrl: serverUrl,
+    deviceId: JELLYFIN_DEVICE_ID,
+    timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
+    errorCode: "jellyfin_server_unreachable",
+    failureMessage: "Could not reach that Jellyfin server",
+    exposeFailureDetail: false,
+  });
+
+  let authResult;
+  try {
+    authResult = await authenticateJellyfinUser({
+      baseUrl: serverUrl,
+      username,
+      password,
       deviceId: JELLYFIN_DEVICE_ID,
       timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
-      errorCode: "jellyfin_server_unreachable",
-      failureMessage: "Could not reach that Jellyfin server",
+      errorCode: "jellyfin_auth_failed",
+      failureMessage: "Jellyfin sign-in failed",
       exposeFailureDetail: false,
-    },
-  );
-
-  let authResult: JellyfinAuthenticationResult;
-  try {
-    authResult = await jellyfinJson<JellyfinAuthenticationResult>(
-      serverUrl,
-      "/Users/AuthenticateByName",
-      {
-        deviceId: JELLYFIN_DEVICE_ID,
-        timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
-        method: "POST",
-        body: JSON.stringify({
-          Username: username,
-          Pw: password,
-        }),
-        errorCode: "jellyfin_auth_failed",
-        failureMessage: "Jellyfin sign-in failed",
-        exposeFailureDetail: false,
-      },
-    );
+    });
   } catch (err) {
     if (isApiError(err) && err.status === 401) {
       throw createApiError(
@@ -163,16 +153,13 @@ export async function checkSource(source: MediaSource) {
   try {
     const context = sourceContext(source);
     const [publicInfo, currentUser] = await Promise.all([
-      jellyfinJson<JellyfinPublicSystemInfo>(
-        context.baseUrl,
-        "/System/Info/Public",
-        {
-          deviceId: context.deviceId,
-          timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
-          errorCode: "jellyfin_server_unreachable",
-          failureMessage: "Could not reach that Jellyfin server",
-        },
-      ),
+      fetchPublicSystemInfo({
+        baseUrl: context.baseUrl,
+        deviceId: context.deviceId,
+        timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
+        errorCode: "jellyfin_server_unreachable",
+        failureMessage: "Could not reach that Jellyfin server",
+      }),
       fetchCurrentUser(context),
     ]);
 

--- a/apps/server/src/providers/jellyfin/auth.ts
+++ b/apps/server/src/providers/jellyfin/auth.ts
@@ -71,7 +71,7 @@ export async function authenticateWithCredentials(body: unknown) {
     exposeFailureDetail: false,
   });
 
-  let authResult;
+  let authResult: Awaited<ReturnType<typeof authenticateJellyfinUser>>;
   try {
     authResult = await authenticateJellyfinUser({
       baseUrl: serverUrl,

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -1,6 +1,26 @@
 import { createHash, randomUUID } from "crypto";
 import { lookup } from "dns/promises";
 import { isIP } from "net";
+import axios, { type AxiosResponse, type RawAxiosRequestConfig } from "axios";
+import { Jellyfin } from "@jellyfin/sdk";
+import type {
+  AuthenticationResult,
+  BaseItemDto,
+  MediaSourceInfo,
+  MediaStream,
+  PlaybackInfoResponse,
+  PublicSystemInfo,
+  SessionInfoDto,
+  UserDto,
+} from "@jellyfin/sdk/lib/generated-client/models/index.js";
+import {
+  getMediaInfoApi,
+  getSessionApi,
+  getSystemApi,
+  getUserApi,
+  getUserLibraryApi,
+} from "@jellyfin/sdk/lib/utils/api/index.js";
+import { getAuthorizationHeader } from "@jellyfin/sdk/lib/utils/authentication.js";
 import { CLIPARR_CLIENT_VERSION } from "@/config/version";
 import type { MediaSource } from "@/db/mediaSourcesRepository";
 import { createApiError, isApiError } from "@/http/errors";
@@ -36,123 +56,48 @@ export interface JellyfinSourceContext {
   deviceId: string;
 }
 
-interface JellyfinImageTags {
-  [key: string]: string | undefined;
-  Primary?: string;
-  Thumb?: string;
-}
-
-interface JellyfinPerson {
-  Name?: string | null;
+export type JellyfinMediaStream = Omit<MediaStream, "Type"> & {
   Type?: string;
-}
+};
 
-interface JellyfinStudio {
-  Name?: string | null;
-  name?: string | null;
-}
-
-export interface JellyfinMediaStream {
-  Type?: string;
-  Index?: number;
-  Codec?: string | null;
-  Language?: string | null;
-  Title?: string | null;
-  DisplayTitle?: string | null;
-  Width?: number | null;
-  Height?: number | null;
-  IsDefault?: boolean;
-  IsForced?: boolean;
-  IsHearingImpaired?: boolean;
-  IsExternal?: boolean;
-  IsTextSubtitleStream?: boolean;
-}
-
-interface JellyfinMediaSource {
-  Id?: string | null;
-  DefaultAudioStreamIndex?: number | null;
-  DefaultSubtitleStreamIndex?: number | null;
+type JellyfinMediaSource = Omit<MediaSourceInfo, "MediaStreams"> & {
   MediaStreams?: JellyfinMediaStream[] | null;
-}
+};
 
-export interface JellyfinItem {
-  Id?: string;
-  Type?: string;
-  MediaType?: string;
-  Name?: string | null;
-  EpisodeTitle?: string | null;
-  SeriesName?: string | null;
-  SeasonName?: string | null;
-  ParentIndexNumber?: number | null;
-  IndexNumber?: number | null;
-  RunTimeTicks?: number | null;
-  ProductionYear?: number | null;
-  PremiereDate?: string | null;
-  Overview?: string | null;
-  SeriesStudio?: string | null;
-  ChannelName?: string | null;
-  OfficialRating?: string | null;
-  ParentThumbItemId?: string | null;
-  ParentThumbImageTag?: string | null;
-  SeriesId?: string | null;
-  SeriesPrimaryImageTag?: string | null;
-  AlbumId?: string | null;
-  AlbumPrimaryImageTag?: string | null;
-  ImageTags?: JellyfinImageTags | null;
+type JellyfinStudio = NonNullable<
+  NonNullable<BaseItemDto["Studios"]>[number]
+> & {
+  name?: string | null;
+};
+
+export type JellyfinItem = Omit<
+  BaseItemDto,
+  "MediaSources" | "MediaType" | "Studios" | "Type"
+> & {
   MediaSources?: JellyfinMediaSource[] | null;
-  Taglines?: string[] | null;
-  Genres?: string[] | null;
-  People?: JellyfinPerson[] | null;
+  MediaType?: string;
   Studios?: JellyfinStudio[] | null;
-  ProviderIds?: Record<string, string | null> | null;
-}
+  Type?: string;
+};
 
-interface JellyfinPlayState {
-  MediaSourceId?: string | null;
-  AudioStreamIndex?: number | null;
-  SubtitleStreamIndex?: number | null;
-  PositionTicks?: number | null;
-  IsPaused?: boolean;
-}
-
-export interface JellyfinSessionInfo {
-  Id?: string | null;
-  UserId?: string;
-  UserName?: string | null;
-  DeviceName?: string | null;
-  Client?: string | null;
-  DeviceType?: string | null;
-  PlayState?: JellyfinPlayState | null;
+export type JellyfinSessionInfo = Omit<
+  SessionInfoDto,
+  "NowPlayingItem" | "PlayState"
+> & {
   NowPlayingItem?: JellyfinItem | null;
-}
+  PlayState?: SessionInfoDto["PlayState"] | null;
+};
 
-export interface JellyfinPlaybackInfo {
-  PlaySessionId?: string | null;
+export type JellyfinPlaybackInfo = Omit<
+  PlaybackInfoResponse,
+  "MediaSources"
+> & {
   MediaSources?: JellyfinMediaSource[];
-}
+};
 
-export interface JellyfinPublicSystemInfo {
-  Id?: string | null;
-  ServerName?: string | null;
-  ProductName?: string | null;
-  Version?: string | null;
-}
-
-interface JellyfinUserPolicy {
-  IsAdministrator?: boolean;
-}
-
-export interface JellyfinUser {
-  Id?: string;
-  Name?: string | null;
-  Policy?: JellyfinUserPolicy | null;
-}
-
-export interface JellyfinAuthenticationResult {
-  AccessToken?: string | null;
-  ServerId?: string | null;
-  User?: JellyfinUser | null;
-}
+export type JellyfinPublicSystemInfo = PublicSystemInfo;
+export type JellyfinUser = UserDto;
+export type JellyfinAuthenticationResult = AuthenticationResult;
 
 export function booleanValue(value: unknown) {
   return typeof value === "boolean" ? value : undefined;
@@ -400,22 +345,6 @@ export function jellyfinSourceName(
   return `Jellyfin (${hostInfo.label})`;
 }
 
-function buildJellyfinUrl(baseUrl: string, path: string) {
-  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
-    return assertHttpUrl(path);
-  }
-
-  const base = assertHttpUrl(baseUrl);
-  const relative = new URL(path, "http://cliparr.local");
-  const basePath =
-    base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
-  const next = new URL(base.origin);
-  next.pathname = `${basePath}${relative.pathname.startsWith("/") ? relative.pathname : `/${relative.pathname}`}`;
-  next.search = relative.search;
-  next.hash = "";
-  return next;
-}
-
 function isLocalConnection(url: URL) {
   const host = url.hostname.toLowerCase();
   return (
@@ -442,18 +371,37 @@ export function connectionInfo(baseUrl: string) {
   };
 }
 
-function jellyfinAuthorization(token?: string, deviceId = JELLYFIN_DEVICE_ID) {
-  const fields = [
-    ["Client", JELLYFIN_PRODUCT],
-    ["Device", JELLYFIN_DEVICE_NAME],
-    ["DeviceId", deviceId],
-    ["Version", JELLYFIN_VERSION],
-    ...(token ? ([["Token", token]] as const) : []),
-  ];
+const JELLYFIN_CLIENT_INFO = {
+  name: JELLYFIN_PRODUCT,
+  version: JELLYFIN_VERSION,
+};
 
-  return `MediaBrowser ${fields
-    .map(([key, value]) => `${key}="${encodeURIComponent(value)}"`)
-    .join(", ")}`;
+const jellyfinAxios = axios.create({
+  adapter: "fetch",
+});
+
+function jellyfinDeviceInfo(deviceId = JELLYFIN_DEVICE_ID) {
+  return {
+    name: JELLYFIN_DEVICE_NAME,
+    id: deviceId,
+  };
+}
+
+function createJellyfinApi(options: {
+  baseUrl: string;
+  token?: string;
+  deviceId?: string;
+}) {
+  const jellyfin = new Jellyfin({
+    clientInfo: JELLYFIN_CLIENT_INFO,
+    deviceInfo: jellyfinDeviceInfo(options.deviceId),
+  });
+
+  return jellyfin.createApi(
+    normalizeBaseUrl(options.baseUrl),
+    options.token,
+    jellyfinAxios,
+  );
 }
 
 export function jellyfinHeaders(options: {
@@ -465,7 +413,11 @@ export function jellyfinHeaders(options: {
   const headers = new Headers(options.headers);
   headers.set(
     "Authorization",
-    jellyfinAuthorization(options.token, options.deviceId),
+    getAuthorizationHeader(
+      JELLYFIN_CLIENT_INFO,
+      jellyfinDeviceInfo(options.deviceId),
+      options.token,
+    ),
   );
 
   if (options.accept) {
@@ -475,139 +427,188 @@ export function jellyfinHeaders(options: {
   return headers;
 }
 
-async function jellyfinFetch(
-  url: string,
-  init: RequestInit = {},
-  options: {
-    token?: string;
-    deviceId?: string;
-    accept?: string;
-    timeoutMs?: number;
-    errorCode?: string;
-    failureMessage?: string;
-    exposeFailureDetail?: boolean;
-  } = {},
-) {
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    options.timeoutMs ?? JELLYFIN_REQUEST_TIMEOUT_MS,
-  );
-  const headers = jellyfinHeaders({
-    headers: init.headers,
-    token: options.token,
-    deviceId: options.deviceId,
-    accept: options.accept,
-  });
+interface JellyfinSdkRequestOptions {
+  token?: string;
+  deviceId?: string;
+  timeoutMs?: number;
+  errorCode?: string;
+  failureMessage?: string;
+  exposeFailureDetail?: boolean;
+}
 
+function jellyfinSdkRequestConfig(
+  timeoutMs = JELLYFIN_REQUEST_TIMEOUT_MS,
+): RawAxiosRequestConfig {
+  return {
+    timeout: timeoutMs,
+    headers: {
+      Accept: "application/json",
+    },
+  };
+}
+
+function responseHeader<T>(
+  response: AxiosResponse<T>,
+  name: string,
+): string | undefined {
+  function stringifyHeaderValue(value: unknown) {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      return value
+        .filter(
+          (item): item is boolean | number | string =>
+            typeof item === "boolean" ||
+            typeof item === "number" ||
+            typeof item === "string",
+        )
+        .join(", ");
+    }
+
+    if (
+      typeof value === "boolean" ||
+      typeof value === "number" ||
+      typeof value === "string"
+    ) {
+      return String(value);
+    }
+
+    return undefined;
+  }
+
+  const headers = response.headers;
+  if (typeof headers.get === "function") {
+    return stringifyHeaderValue(headers.get(name));
+  }
+
+  const value =
+    headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()];
+  return stringifyHeaderValue(value);
+}
+
+function responseDetail(data: unknown) {
+  const detail =
+    typeof data === "string"
+      ? data
+      : data === undefined
+        ? ""
+        : JSON.stringify(data);
+
+  return detail.slice(0, 400).replace(/\s+/g, " ").trim();
+}
+
+function axiosRequestUrl(err: unknown, fallbackBaseUrl: string) {
+  if (!axios.isAxiosError(err)) {
+    return new URL(fallbackBaseUrl);
+  }
+
+  const requestUrl = err.config?.url;
   try {
-    const response = await fetch(url, {
-      ...init,
-      headers,
-      signal: controller.signal,
-    });
-
-    if (!response.ok && response.status !== 206) {
-      const failureMessage =
-        options.failureMessage ?? "Jellyfin request failed";
-      const exposeFailureDetail = options.exposeFailureDetail ?? true;
-      const detail = (await response.text().catch(() => ""))
-        .slice(0, 400)
-        .replace(/\s+/g, " ")
-        .trim();
-
-      throw createApiError(
-        !exposeFailureDetail && response.status !== 401 ? 502 : response.status,
-        options.errorCode ?? "jellyfin_request_failed",
-        !exposeFailureDetail
-          ? failureMessage
-          : detail
-            ? `${failureMessage}: ${detail}`
-            : `${failureMessage}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return response;
-  } catch (err) {
-    if (isApiError(err)) {
-      throw err;
-    }
-
-    if (err instanceof Error && err.name === "AbortError") {
-      throw createApiError(
-        504,
-        options.errorCode ?? "jellyfin_request_failed",
-        options.failureMessage ?? "Jellyfin request timed out",
-      );
-    }
-
-    const parsed = new URL(url);
-    if (JELLYFIN_DEV_BASE_URL && isLoopbackHost(parsed.hostname)) {
-      throw createApiError(
-        502,
-        options.errorCode ?? "jellyfin_request_failed",
-        `${options.failureMessage ?? "Could not reach that Jellyfin server"}. Cliparr is running in Docker, so localhost points at the Cliparr container. Use ${JELLYFIN_DEV_BASE_URL} for this dev setup.`,
-      );
-    }
-
-    throw createApiError(
-      502,
-      options.errorCode ?? "jellyfin_request_failed",
-      options.exposeFailureDetail === false
-        ? (options.failureMessage ?? "Jellyfin request failed")
-        : `${options.failureMessage ?? "Jellyfin request failed"}: ${errorMessage(err)}`,
-    );
-  } finally {
-    clearTimeout(timeout);
+    return new URL(requestUrl ?? "", err.config?.baseURL ?? fallbackBaseUrl);
+  } catch {
+    return new URL(fallbackBaseUrl);
   }
 }
 
-export async function jellyfinJson<T>(
-  baseUrl: string,
-  path: string,
-  options: {
-    token?: string;
-    deviceId?: string;
-    timeoutMs?: number;
-    method?: string;
-    body?: string;
-    errorCode?: string;
-    failureMessage?: string;
-    exposeFailureDetail?: boolean;
-  } = {},
-) {
-  const url = buildJellyfinUrl(baseUrl, path);
-  const response = await jellyfinFetch(
-    url.toString(),
-    {
-      method: options.method,
-      body: options.body,
-      headers: options.body
-        ? { "Content-Type": "application/json" }
-        : undefined,
-    },
-    {
-      ...options,
-      accept: "application/json",
-    },
+function isAxiosTimeout(err: unknown) {
+  return (
+    axios.isAxiosError(err) &&
+    (err.code === "ETIMEDOUT" ||
+      err.code === "ECONNABORTED" ||
+      /timeout/i.test(err.message))
   );
-  const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.toLowerCase().includes("json")) {
-    throw createApiError(
-      502,
-      options.errorCode ?? "jellyfin_invalid_response",
-      "That URL did not return the Jellyfin API. Make sure it points at your Jellyfin server base URL.",
+}
+
+function toJellyfinSdkError(
+  err: unknown,
+  baseUrl: string,
+  options: JellyfinSdkRequestOptions,
+) {
+  if (isApiError(err)) {
+    return err;
+  }
+
+  const errorCode = options.errorCode ?? "jellyfin_request_failed";
+  const failureMessage = options.failureMessage ?? "Jellyfin request failed";
+
+  if (axios.isAxiosError(err) && err.response) {
+    const exposeFailureDetail = options.exposeFailureDetail ?? true;
+    const detail = responseDetail(err.response.data);
+    return createApiError(
+      !exposeFailureDetail && err.response.status !== 401
+        ? 502
+        : err.response.status,
+      errorCode,
+      !exposeFailureDetail
+        ? failureMessage
+        : detail
+          ? `${failureMessage}: ${detail}`
+          : `${failureMessage}: ${err.response.status} ${err.response.statusText}`,
     );
   }
 
-  try {
-    return (await response.json()) as T;
-  } catch {
-    throw createApiError(
+  if (isAxiosTimeout(err)) {
+    return createApiError(504, errorCode, `${failureMessage} timed out`);
+  }
+
+  const parsed = axiosRequestUrl(err, baseUrl);
+  if (JELLYFIN_DEV_BASE_URL && isLoopbackHost(parsed.hostname)) {
+    return createApiError(
       502,
-      options.errorCode ?? "jellyfin_invalid_response",
-      "Jellyfin returned an unreadable response. Make sure the server URL is correct and not a login page.",
+      errorCode,
+      `${options.failureMessage ?? "Could not reach that Jellyfin server"}. Cliparr is running in Docker, so localhost points at the Cliparr container. Use ${JELLYFIN_DEV_BASE_URL} for this dev setup.`,
     );
+  }
+
+  return createApiError(
+    502,
+    errorCode,
+    options.exposeFailureDetail === false
+      ? failureMessage
+      : `${failureMessage}: ${errorMessage(err)}`,
+  );
+}
+
+async function jellyfinSdkJson<T>(
+  baseUrl: string,
+  request: (
+    api: ReturnType<typeof createJellyfinApi>,
+    config: RawAxiosRequestConfig,
+  ) => Promise<AxiosResponse<T>>,
+  options: JellyfinSdkRequestOptions = {},
+) {
+  try {
+    const response = await request(
+      createJellyfinApi({
+        baseUrl,
+        token: options.token,
+        deviceId: options.deviceId,
+      }),
+      jellyfinSdkRequestConfig(options.timeoutMs),
+    );
+
+    const contentType = responseHeader(response, "content-type") ?? "";
+    if (!contentType.toLowerCase().includes("json")) {
+      throw createApiError(
+        502,
+        options.errorCode ?? "jellyfin_invalid_response",
+        "That URL did not return the Jellyfin API. Make sure it points at your Jellyfin server base URL.",
+      );
+    }
+
+    if (response.data === null || typeof response.data !== "object") {
+      throw createApiError(
+        502,
+        options.errorCode ?? "jellyfin_invalid_response",
+        "Jellyfin returned an unreadable response. Make sure the server URL is correct and not a login page.",
+      );
+    }
+
+    return response.data;
+  } catch (err) {
+    throw toJellyfinSdkError(err, baseUrl, options);
   }
 }
 
@@ -645,19 +646,82 @@ export function sourceContext(source: MediaSource): JellyfinSourceContext {
 }
 
 export async function fetchCurrentUser(context: JellyfinSourceContext) {
-  return jellyfinJson<JellyfinUser>(context.baseUrl, "/Users/Me", {
-    token: context.token,
-    deviceId: context.deviceId,
-    timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
-    errorCode: "jellyfin_auth_failed",
-    failureMessage: "Jellyfin authentication failed",
-  });
+  return jellyfinSdkJson<JellyfinUser>(
+    context.baseUrl,
+    (api, config) => getUserApi(api).getCurrentUser(config),
+    {
+      token: context.token,
+      deviceId: context.deviceId,
+      timeoutMs: JELLYFIN_REQUEST_TIMEOUT_MS,
+      errorCode: "jellyfin_auth_failed",
+      failureMessage: "Jellyfin authentication failed",
+    },
+  );
+}
+
+export async function fetchPublicSystemInfo(options: {
+  baseUrl: string;
+  deviceId?: string;
+  timeoutMs?: number;
+  errorCode?: string;
+  failureMessage?: string;
+  exposeFailureDetail?: boolean;
+}) {
+  return jellyfinSdkJson<JellyfinPublicSystemInfo>(
+    options.baseUrl,
+    (api, config) => getSystemApi(api).getPublicSystemInfo(config),
+    {
+      deviceId: options.deviceId,
+      timeoutMs: options.timeoutMs,
+      errorCode: options.errorCode,
+      failureMessage: options.failureMessage,
+      exposeFailureDetail: options.exposeFailureDetail,
+    },
+  );
+}
+
+export async function authenticateJellyfinUser(options: {
+  baseUrl: string;
+  username: string;
+  password: string;
+  deviceId?: string;
+  timeoutMs?: number;
+  errorCode?: string;
+  failureMessage?: string;
+  exposeFailureDetail?: boolean;
+}) {
+  return jellyfinSdkJson<JellyfinAuthenticationResult>(
+    options.baseUrl,
+    (api, config) =>
+      getUserApi(api).authenticateUserByName(
+        {
+          authenticateUserByName: {
+            Username: options.username,
+            Pw: options.password,
+          },
+        },
+        config,
+      ),
+    {
+      deviceId: options.deviceId,
+      timeoutMs: options.timeoutMs,
+      errorCode: options.errorCode,
+      failureMessage: options.failureMessage,
+      exposeFailureDetail: options.exposeFailureDetail,
+    },
+  );
 }
 
 export async function fetchSessions(context: JellyfinSourceContext) {
-  return jellyfinJson<JellyfinSessionInfo[]>(
+  return jellyfinSdkJson<JellyfinSessionInfo[]>(
     context.baseUrl,
-    "/Sessions?activeWithinSeconds=300",
+    (api, config) =>
+      getSessionApi(api).getSessions(
+        {
+          activeWithinSeconds: 300,
+        },
+        config,
+      ),
     {
       token: context.token,
       deviceId: context.deviceId,
@@ -672,9 +736,16 @@ export async function fetchItem(
   context: JellyfinSourceContext,
   itemId: string,
 ) {
-  return jellyfinJson<JellyfinItem>(
+  return jellyfinSdkJson<JellyfinItem>(
     context.baseUrl,
-    `/Items/${encodeURIComponent(itemId)}?userId=${encodeURIComponent(context.userId)}`,
+    (api, config) =>
+      getUserLibraryApi(api).getItem(
+        {
+          itemId,
+          userId: context.userId,
+        },
+        config,
+      ),
     {
       token: context.token,
       deviceId: context.deviceId,
@@ -689,9 +760,16 @@ export async function fetchPlaybackInfo(
   context: JellyfinSourceContext,
   itemId: string,
 ) {
-  return jellyfinJson<JellyfinPlaybackInfo>(
+  return jellyfinSdkJson<JellyfinPlaybackInfo>(
     context.baseUrl,
-    `/Items/${encodeURIComponent(itemId)}/PlaybackInfo?userId=${encodeURIComponent(context.userId)}`,
+    (api, config) =>
+      getMediaInfoApi(api).getPlaybackInfo(
+        {
+          itemId,
+          userId: context.userId,
+        },
+        config,
+      ),
     {
       token: context.token,
       deviceId: context.deviceId,

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -232,9 +232,15 @@ void test("logs into Jellyfin with credentials and stores a remembered provider 
             : input instanceof URL
               ? input.toString()
               : input.url;
+        const requestBody =
+          typeof init?.body === "string"
+            ? init.body
+            : input instanceof Request
+              ? await input.clone().text()
+              : undefined;
         upstreamRequests.push({
           url: requestUrl,
-          body: typeof init?.body === "string" ? init.body : undefined,
+          body: requestBody || undefined,
         });
 
         if (requestUrl === "http://1.1.1.1:8096/jellyfin/System/Info/Public") {

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
     onlyBundle: false,
     alwaysBundle: [
       /^@cliparr\/shared(?:\/.*)?$/,
+      /^@jellyfin\/sdk(?:\/.*)?$/,
       /^@logtape\/logtape(?:\/.*)?$/,
+      /^axios(?:\/.*)?$/,
       /^dotenv(?:\/.*)?$/,
       /^drizzle-orm(?:\/.*)?$/,
       /^express(?:\/.*)?$/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@jellyfin/sdk':
-        specifier: 0.13.0
+        specifier: ^0.13.0
         version: 0.13.0(axios@1.16.1)
       '@logtape/logtape':
         specifier: ^2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,9 +143,15 @@ importers:
       '@cliparr/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@jellyfin/sdk':
+        specifier: 0.13.0
+        version: 0.13.0(axios@1.16.1)
       '@logtape/logtape':
         specifier: ^2.1.1
         version: 2.1.1
+      axios:
+        specifier: ^1.16.1
+        version: 1.16.1
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1387,6 +1393,11 @@ packages:
 
   '@interactjs/types@1.10.27':
     resolution: {integrity: sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==}
+
+  '@jellyfin/sdk@0.13.0':
+    resolution: {integrity: sha512-oiBAOXH6s+dKdReSsYgNktBDzbxtg4JVWhEzIxZSxKcWMdSKmBtK41MhXRO7IWAC40DguKUm3nU/Z493qPAlWA==}
+    peerDependencies:
+      axios: ^1.12.0
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -3236,6 +3247,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -3303,6 +3318,12 @@ packages:
     resolution: {integrity: sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3420,6 +3441,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -3693,6 +3718,10 @@ packages:
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -3934,6 +3963,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   es-toolkit@1.47.0:
     resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
@@ -4120,12 +4153,25 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
 
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -4233,6 +4279,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -4300,6 +4350,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4785,8 +4839,16 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -5035,6 +5097,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6940,6 +7006,10 @@ snapshots:
 
   '@interactjs/types@1.10.27': {}
 
+  '@jellyfin/sdk@0.13.0(axios@1.16.1)':
+    dependencies:
+      axios: 1.16.1
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8706,6 +8776,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -8854,6 +8930,18 @@ snapshots:
       - uploadthing
       - yaml
 
+  asynckit@0.4.0: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   babel-dead-code-elimination@1.0.12:
@@ -8964,6 +9052,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -9248,6 +9340,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -9356,6 +9450,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   es-toolkit@1.47.0: {}
 
@@ -9703,6 +9804,8 @@ snapshots:
 
   flattie@1.1.1: {}
 
+  follow-redirects@1.16.0: {}
+
   fontace@0.4.1:
     dependencies:
       fontkitten: 1.0.3
@@ -9710,6 +9813,14 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   formatly@0.3.0:
     dependencies:
@@ -9803,6 +9914,10 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -9970,6 +10085,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.6.3:
     dependencies:
@@ -10675,7 +10797,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -10944,6 +11072,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary
- Replace the manual Jellyfin JSON helpers with official @jellyfin/sdk API clients in the server provider.
- Pin @jellyfin/sdk to 0.13.0 and add the axios peer dependency for the supported Jellyfin 10.11.x SDK line.
- Preserve Cliparr-specific Jellyfin media proxy, playback, subtitle, and URL-safety behavior.

## Validation
- pnpm preflight