### PR TITLE
fix(cliparr): stabilize currently playing media

### DIFF
--- a/apps/frontend/src/api/cliparrClient.test.ts
+++ b/apps/frontend/src/api/cliparrClient.test.ts
@@ -110,6 +110,37 @@ void test("surfaces JSON API errors and coalesces auth failure notifications", a
   );
 });
 
+void test("coalesces in-flight currently playing requests only", async () => {
+  let fetchCount = 0;
+  let releaseFetch: (() => void) | undefined;
+
+  await withMockedFetch(
+    async (input) => {
+      assert.equal(input, "/api/media/currently-playing");
+      fetchCount += 1;
+      await new Promise<void>((resolve) => {
+        releaseFetch = resolve;
+      });
+      return jsonResponse({ sourceErrors: [], viewers: [] });
+    },
+    async () => {
+      const firstRequest = cliparrClient.getCurrentlyPlaying();
+      const secondRequest = cliparrClient.getCurrentlyPlaying();
+
+      assert.equal(fetchCount, 1);
+      releaseFetch?.();
+      assert.deepEqual(await firstRequest, { sourceErrors: [], viewers: [] });
+      assert.deepEqual(await secondRequest, { sourceErrors: [], viewers: [] });
+      assert.equal(fetchCount, 1);
+
+      const thirdRequest = cliparrClient.getCurrentlyPlaying();
+      assert.equal(fetchCount, 2);
+      releaseFetch?.();
+      assert.deepEqual(await thirdRequest, { sourceErrors: [], viewers: [] });
+    },
+  );
+});
+
 void test("follows app auth redirects with the current browser location", async () => {
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   let assignedUrl = "";

--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -43,6 +43,7 @@ function createCliparrRequestError(
 
 const authFailureListeners = new Set<() => void>();
 let authFailureQueued = false;
+let currentlyPlayingRequest: Promise<CurrentlyPlayingResponse> | null = null;
 
 function responseErrorDetails(payload: unknown): ResponseErrorDetails {
   if (!payload || typeof payload !== "object") {
@@ -244,8 +245,13 @@ export const cliparrClient = {
     });
   },
 
-  async getCurrentlyPlaying() {
-    return request<CurrentlyPlayingResponse>("/api/media/currently-playing");
+  getCurrentlyPlaying() {
+    currentlyPlayingRequest ??= request<CurrentlyPlayingResponse>(
+      "/api/media/currently-playing",
+    ).finally(() => {
+      currentlyPlayingRequest = null;
+    });
+    return currentlyPlayingRequest;
   },
 
   async createLocalMediaUrl(url: string) {

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -56,6 +56,14 @@ import {
 const logger = getServerLogger(["provider", "jellyfin", "playback"]);
 const HD_ARTWORK_SIZE = 1920;
 const HD_ARTWORK_QUALITY = 96;
+const PLAYBACK_INFO_CACHE_TTL_MS = 1000 * 60 * 15;
+
+interface CachedPlaybackInfo {
+  expiresAt: number;
+  playbackInfo: JellyfinPlaybackInfo;
+}
+
+const playbackInfoCache = new Map<string, CachedPlaybackInfo>();
 
 function createMediaHandle(
   session: ProviderSessionRecord,
@@ -641,11 +649,30 @@ async function enrichMetadataItem(
 }
 
 async function loadPlaybackInfo(
+  session: ProviderSessionRecord,
   context: JellyfinSourceContext,
+  sessionInfo: JellyfinSessionInfo,
   itemId: string,
 ) {
+  const cacheKey = playbackInfoCacheKey(session, context, sessionInfo, itemId);
+  const cached = playbackInfoCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) {
+    cached.expiresAt = now + PLAYBACK_INFO_CACHE_TTL_MS;
+    return cached.playbackInfo;
+  }
+
+  prunePlaybackInfoCache(now);
+
   try {
-    return await fetchPlaybackInfo(context, itemId);
+    const playbackInfo = await fetchPlaybackInfo(context, itemId);
+    if (stringValue(playbackInfo?.PlaySessionId)) {
+      playbackInfoCache.set(cacheKey, {
+        expiresAt: Date.now() + PLAYBACK_INFO_CACHE_TTL_MS,
+        playbackInfo,
+      });
+    }
+    return playbackInfo;
   } catch (err) {
     logger.warn("Could not fetch Jellyfin playback info.", {
       ...logErrorFields(err),
@@ -654,6 +681,30 @@ async function loadPlaybackInfo(
       "source.base_url": sanitizeUrlForLog(context.baseUrl),
     });
     return undefined;
+  }
+}
+
+function playbackInfoCacheKey(
+  session: ProviderSessionRecord,
+  context: JellyfinSourceContext,
+  sessionInfo: JellyfinSessionInfo,
+  itemId: string,
+) {
+  return [
+    session.id,
+    context.sourceId,
+    stringValue(sessionInfo?.Id) ?? "unknown-session",
+    itemId,
+    stringValue(sessionInfo?.PlayState?.MediaSourceId) ??
+      "unknown-media-source",
+  ].join(":");
+}
+
+function prunePlaybackInfoCache(now = Date.now()) {
+  for (const [cacheKey, cached] of playbackInfoCache.entries()) {
+    if (cached.expiresAt <= now) {
+      playbackInfoCache.delete(cacheKey);
+    }
   }
 }
 
@@ -705,7 +756,7 @@ async function normalizeCurrentPlayback(
 
   const [enrichedItem, playbackInfo] = await Promise.all([
     enrichMetadataItem(context, nowPlayingItem),
-    loadPlaybackInfo(context, itemId),
+    loadPlaybackInfo(session, context, sessionInfo, itemId),
   ]);
   const playSessionId = stringValue(playbackInfo?.PlaySessionId);
   const clientSessionId = stringValue(sessionInfo?.Id);

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -13,9 +13,12 @@ import {
 } from "@/providers/jellyfin/playback";
 import type { JellyfinSourceContext } from "@/providers/jellyfin/shared";
 
+let sessionIndex = 0;
+
 function createSession(): ProviderSessionRecord {
+  sessionIndex += 1;
   return {
-    id: "session-1",
+    id: `session-${sessionIndex}`,
     providerId: "jellyfin",
     providerAccountId: "account-1",
     userToken: "user-token",
@@ -115,7 +118,7 @@ function fetchInputUrl(input: Parameters<typeof fetch>[0]) {
 
 function createJellyfinPlaybackFetch(options: {
   itemId: string;
-  playSessionId?: string | null;
+  playSessionId?: string | null | (() => string | null);
   clientSessionId?: string;
   mediaSourceId?: string;
   title?: string;
@@ -188,8 +191,12 @@ function createJellyfinPlaybackFetch(options: {
     }
 
     if (url.pathname === `/Items/${itemId}/PlaybackInfo`) {
+      const resolvedPlaySessionId =
+        typeof playSessionId === "function" ? playSessionId() : playSessionId;
       return jsonResponse({
-        ...(playSessionId ? { PlaySessionId: playSessionId } : {}),
+        ...(resolvedPlaySessionId
+          ? { PlaySessionId: resolvedPlaySessionId }
+          : {}),
         MediaSources: [mediaSource],
       });
     }
@@ -275,6 +282,56 @@ void test("uses Jellyfin PlaybackInfo play session ids for currently playing str
     assert.notEqual(
       hlsUrl.searchParams.get("playSessionId"),
       "client-session-1",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("reuses Jellyfin playback info for stable currently playing handles", async () => {
+  const session = createSession();
+  const originalFetch = globalThis.fetch;
+  let playbackInfoRequestCount = 0;
+  globalThis.fetch = createJellyfinPlaybackFetch({
+    itemId: "item-1",
+    playSessionId: () => {
+      playbackInfoRequestCount += 1;
+      return `playback-info-session-${playbackInfoRequestCount}`;
+    },
+    clientSessionId: "client-session-1",
+  });
+
+  try {
+    const firstEntries = await listCurrentlyPlaying(session, createSource());
+    const handleCount = session.mediaHandles.size;
+    const secondEntries = await listCurrentlyPlaying(session, createSource());
+
+    assert.equal(playbackInfoRequestCount, 1);
+    assert.equal(session.mediaHandles.size, handleCount);
+    assert.equal(
+      firstEntries[0]?.item.mediaUrl,
+      secondEntries[0]?.item.mediaUrl,
+    );
+    assert.equal(firstEntries[0]?.item.hlsUrl, secondEntries[0]?.item.hlsUrl);
+
+    const streamHandle = [...session.mediaHandles.values()].find((handle) =>
+      handle.path.includes("/stream?"),
+    );
+    const hlsHandle = [...session.mediaHandles.values()].find((handle) =>
+      handle.path.includes("/master.m3u8?"),
+    );
+    assert(streamHandle);
+    assert(hlsHandle);
+
+    const streamUrl = new URL(streamHandle.path, "http://cliparr.local");
+    const hlsUrl = new URL(hlsHandle.path, "http://cliparr.local");
+    assert.equal(
+      streamUrl.searchParams.get("playSessionId"),
+      "playback-info-session-1",
+    );
+    assert.equal(
+      hlsUrl.searchParams.get("playSessionId"),
+      "playback-info-session-1",
     );
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Cache Jellyfin PlaybackInfo per active session/item so changing Jellyfin PlaySessionIds do not mint new media handles on every currently-playing poll.
- Coalesce in-flight frontend currently-playing reads so dev StrictMode and simultaneous consumers share one server request without caching resolved playback snapshots.

## Root Cause
- Jellyfin can return a fresh PlaySessionId from PlaybackInfo on repeated polls, and Cliparr bakes that ID into media paths, defeating media handle reuse.
- The paired /api/media/currently-playing requests in the logs line up with React development StrictMode replaying mount effects.

## Validation
- pnpm preflight