### PR TITLE
docs(www): add Windows command tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 The fastest way to get Cliparr running is via the GitHub Container Registry.
 
+**macOS / Linux**
+
 ```bash
 docker run -d \
   --name cliparr \
@@ -44,6 +46,19 @@ docker run -d \
   -v cliparr-data:/data \
   ghcr.io/techsquidtv/cliparr:latest
 ```
+
+**PowerShell**
+
+```powershell
+docker run -d `
+  --name cliparr `
+  -p 7171:7171 `
+  -e APP_KEY="your-32-char-stable-random-secret" `
+  -v cliparr-data:/data `
+  ghcr.io/techsquidtv/cliparr:latest
+```
+
+On Windows, run this from Docker Desktop or another Docker engine using Linux containers. Cliparr publishes Linux container images for linux/amd64 and linux/arm64.
 
 > [!IMPORTANT]
 > **Stable APP_KEY required**: Cliparr uses APP_KEY to encrypt provider credentials at rest. Use a stable random secret at least 32 characters long. If you change it later, you will need to re-authenticate your media servers.

--- a/apps/www/scripts/sync-readme.ts
+++ b/apps/www/scripts/sync-readme.ts
@@ -1,7 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import prettier from "prettier";
-import { dockerRunCommand, envVars, features, warnings } from "@/data/product";
+import {
+  dockerLinuxContainerNote,
+  dockerRunCommand,
+  dockerRunPowerShellCommand,
+  envVars,
+  features,
+  warnings,
+} from "@/data/product";
 
 const rootDir = path.resolve(import.meta.dirname, "../../..");
 const readmePath = path.join(rootDir, "README.md");
@@ -29,7 +36,7 @@ function renderDockerQuickStart() {
     .map((warning) => `> [!IMPORTANT]\n> **${warning.title}**: ${warning.body}`)
     .join("\n\n");
 
-  return `The fastest way to get Cliparr running is via the GitHub Container Registry.\n\n\`\`\`bash\n${dockerRunCommand}\n\`\`\`\n\n${warningBlocks}`;
+  return `The fastest way to get Cliparr running is via the GitHub Container Registry.\n\n**macOS / Linux**\n\n\`\`\`bash\n${dockerRunCommand}\n\`\`\`\n\n**PowerShell**\n\n\`\`\`powershell\n${dockerRunPowerShellCommand}\n\`\`\`\n\n${dockerLinuxContainerNote}\n\n${warningBlocks}`;
 }
 
 function renderConfiguration() {

--- a/apps/www/src/components/CommandBlock.astro
+++ b/apps/www/src/components/CommandBlock.astro
@@ -88,6 +88,74 @@ const groupId = `command-${hashCommandBlockId(
                 {variant.label}
               </label>
               <div class="command-panel">
+                <button
+                  aria-label="Copy command"
+                  class="command-copy-button"
+                  data-command-copy
+                  title="Copy command"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="command-copy-icon command-copy-icon-copy"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <rect
+                      height="14"
+                      rx="2"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      width="14"
+                      x="8"
+                      y="8"
+                    />
+                    <path
+                      d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="command-copy-icon command-copy-icon-copied"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 6 9 17l-5-5"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="command-copy-icon command-copy-icon-failed"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m18 6-12 12"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
                 <div class="command-code">
                   <Code
                     code={variant.code}
@@ -101,12 +169,82 @@ const groupId = `command-${hashCommandBlockId(
         })}
       </div>
     ) : (
-      <div class="command-code">
-        <Code
-          code={commandVariants[0].code}
-          lang={commandVariants[0].lang}
-          theme="github-dark"
-        />
+      <div class="command-panel-single">
+        <button
+          aria-label="Copy command"
+          class="command-copy-button"
+          data-command-copy
+          title="Copy command"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="command-copy-icon command-copy-icon-copy"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <rect
+              height="14"
+              rx="2"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              width="14"
+              x="8"
+              y="8"
+            />
+            <path
+              d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            class="command-copy-icon command-copy-icon-copied"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M20 6 9 17l-5-5"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            class="command-copy-icon command-copy-icon-failed"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 6-12 12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="m6 6 12 12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+        <div class="command-code">
+          <Code
+            code={commandVariants[0].code}
+            lang={commandVariants[0].lang}
+            theme="github-dark"
+          />
+        </div>
       </div>
     )
   }
@@ -139,6 +277,81 @@ const groupId = `command-${hashCommandBlockId(
     }
   }
 
+  async function writeClipboardText(value: string) {
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(value);
+        return;
+      } catch {
+        // Fall back for browsers that expose Clipboard API but deny it here.
+      }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "0";
+    textarea.style.left = "-9999px";
+    document.body.append(textarea);
+    textarea.select();
+
+    try {
+      if (!document.execCommand("copy")) {
+        throw new Error("Copy command was rejected.");
+      }
+    } finally {
+      textarea.remove();
+    }
+  }
+
+  async function copyCommand(button: HTMLButtonElement) {
+    const panel = button.closest(".command-panel, .command-panel-single");
+    const code = panel?.querySelector("code")?.textContent;
+
+    if (!code) {
+      return;
+    }
+
+    await writeClipboardText(code.trimEnd());
+    button.dataset.copyState = "copied";
+    button.setAttribute("aria-label", "Copied");
+    button.title = "Copied";
+
+    window.setTimeout(() => {
+      button.setAttribute("aria-label", "Copy command");
+      button.title = "Copy command";
+      delete button.dataset.copyState;
+    }, 1600);
+  }
+
+  function bindCommandCopyButtons() {
+    for (const button of document.querySelectorAll<HTMLButtonElement>(
+      "[data-command-copy]",
+    )) {
+      if (button.dataset.copyBound) {
+        continue;
+      }
+
+      button.dataset.copyBound = "true";
+      button.addEventListener("click", () => {
+        void copyCommand(button).catch(() => {
+          button.dataset.copyState = "failed";
+          button.setAttribute("aria-label", "Copy failed");
+          button.title = "Copy failed";
+
+          window.setTimeout(() => {
+            button.setAttribute("aria-label", "Copy command");
+            button.title = "Copy command";
+            delete button.dataset.copyState;
+          }, 1600);
+        });
+      });
+    }
+  }
+
   selectPreferredCommandTabs();
+  bindCommandCopyButtons();
   document.addEventListener("astro:page-load", selectPreferredCommandTabs);
+  document.addEventListener("astro:page-load", bindCommandCopyButtons);
 </script>

--- a/apps/www/src/components/CommandBlock.astro
+++ b/apps/www/src/components/CommandBlock.astro
@@ -358,11 +358,10 @@ const groupId = `command-${hashCommandBlockId(
     }
   }
 
-  selectPreferredCommandTabs();
-  bindCommandCopyButtons();
-
   if (!document.documentElement.dataset.cliparrCommandBlockInit) {
     document.documentElement.dataset.cliparrCommandBlockInit = "true";
+    selectPreferredCommandTabs();
+    bindCommandCopyButtons();
     document.addEventListener("astro:page-load", selectPreferredCommandTabs);
     document.addEventListener("astro:page-load", bindCommandCopyButtons);
   }

--- a/apps/www/src/components/CommandBlock.astro
+++ b/apps/www/src/components/CommandBlock.astro
@@ -1,13 +1,53 @@
 ---
 import { Code } from "astro:components";
+import type {
+  CommandExampleLanguage,
+  CommandExampleVariant,
+} from "@/data/product";
 
 interface Props {
-  code: string;
-  lang?: "bash" | "yaml";
+  code?: string;
+  lang?: CommandExampleLanguage;
   label?: string;
+  variants?: readonly CommandExampleVariant[];
 }
 
-const { code, label, lang = "bash" } = Astro.props;
+const { code, label, lang = "bash", variants } = Astro.props;
+
+const commandVariants =
+  variants ??
+  (code
+    ? ([
+        {
+          code,
+          label: "Command",
+          lang,
+        },
+      ] satisfies readonly CommandExampleVariant[])
+    : []);
+
+if (commandVariants.length === 0) {
+  throw new Error("CommandBlock requires either code or variants.");
+}
+
+const hasTabs = commandVariants.length > 1;
+
+function hashCommandBlockId(value: string) {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+
+  return Math.abs(hash).toString(36);
+}
+
+const groupId = `command-${hashCommandBlockId(
+  `${label ?? ""}:${commandVariants
+    .map((variant) => `${variant.label}:${variant.lang}:${variant.code}`)
+    .join("|")}`,
+)}`;
 ---
 
 <figure
@@ -20,7 +60,85 @@ const { code, label, lang = "bash" } = Astro.props;
       </figcaption>
     )
   }
-  <div class="command-code">
-    <Code code={code} lang={lang} theme="github-dark" />
-  </div>
+  {
+    hasTabs ? (
+      <div
+        class="command-tabs"
+        data-command-tabs
+        style={`--tab-count: ${commandVariants.length}`}
+      >
+        {commandVariants.map((variant, index) => {
+          const optionId = `${groupId}-${index}`;
+
+          return (
+            <>
+              <input
+                checked={index === 0}
+                class="command-tab-input"
+                data-command-shell={variant.lang}
+                id={optionId}
+                name={groupId}
+                type="radio"
+              />
+              <label
+                class="command-tab-label"
+                for={optionId}
+                style={`grid-column: ${index + 1}`}
+              >
+                {variant.label}
+              </label>
+              <div class="command-panel">
+                <div class="command-code">
+                  <Code
+                    code={variant.code}
+                    lang={variant.lang}
+                    theme="github-dark"
+                  />
+                </div>
+              </div>
+            </>
+          );
+        })}
+      </div>
+    ) : (
+      <div class="command-code">
+        <Code
+          code={commandVariants[0].code}
+          lang={commandVariants[0].lang}
+          theme="github-dark"
+        />
+      </div>
+    )
+  }
 </figure>
+
+<script>
+  function preferredCommandShell() {
+    const nav = window.navigator;
+    const userAgentData =
+      "userAgentData" in nav
+        ? (nav.userAgentData as { platform?: string })
+        : undefined;
+    const platform = userAgentData?.platform ?? nav.platform ?? "";
+    const userAgent = nav.userAgent ?? "";
+
+    return /win/i.test(`${platform} ${userAgent}`) ? "powershell" : "bash";
+  }
+
+  function selectPreferredCommandTabs() {
+    const preferredShell = preferredCommandShell();
+
+    for (const tabs of document.querySelectorAll("[data-command-tabs]")) {
+      const input = tabs.querySelector<HTMLInputElement>(
+        `[data-command-shell="${preferredShell}"]`,
+      );
+
+      if (input) {
+        input.checked = true;
+      }
+    }
+  }
+
+  selectPreferredCommandTabs();
+  document.addEventListener("astro:page-load", selectPreferredCommandTabs);
+</script>

--- a/apps/www/src/components/CommandBlock.astro
+++ b/apps/www/src/components/CommandBlock.astro
@@ -253,11 +253,15 @@ const groupId = `command-${hashCommandBlockId(
 <script>
   function preferredCommandShell() {
     const nav = window.navigator;
-    const userAgentData =
-      "userAgentData" in nav
-        ? (nav.userAgentData as { platform?: string })
+    const userAgentData = Reflect.get(nav, "userAgentData");
+    const userAgentPlatform =
+      userAgentData && typeof userAgentData === "object"
+        ? Reflect.get(userAgentData, "platform")
         : undefined;
-    const platform = userAgentData?.platform ?? nav.platform ?? "";
+    const platform =
+      typeof userAgentPlatform === "string"
+        ? userAgentPlatform
+        : (nav.platform ?? "");
     const userAgent = nav.userAgent ?? "";
 
     return /win/i.test(`${platform} ${userAgent}`) ? "powershell" : "bash";
@@ -267,26 +271,17 @@ const groupId = `command-${hashCommandBlockId(
     const preferredShell = preferredCommandShell();
 
     for (const tabs of document.querySelectorAll("[data-command-tabs]")) {
-      const input = tabs.querySelector<HTMLInputElement>(
+      const input = tabs.querySelector(
         `[data-command-shell="${preferredShell}"]`,
       );
 
-      if (input) {
+      if (input instanceof HTMLInputElement) {
         input.checked = true;
       }
     }
   }
 
-  async function writeClipboardText(value: string) {
-    if (navigator.clipboard) {
-      try {
-        await navigator.clipboard.writeText(value);
-        return;
-      } catch {
-        // Fall back for browsers that expose Clipboard API but deny it here.
-      }
-    }
-
+  function writeClipboardTextFallback(value = "") {
     const textarea = document.createElement("textarea");
     textarea.value = value;
     textarea.setAttribute("readonly", "");
@@ -297,15 +292,26 @@ const groupId = `command-${hashCommandBlockId(
     textarea.select();
 
     try {
-      if (!document.execCommand("copy")) {
-        throw new Error("Copy command was rejected.");
-      }
+      return document.execCommand("copy");
     } finally {
       textarea.remove();
     }
   }
 
-  async function copyCommand(button: HTMLButtonElement) {
+  async function writeClipboardText(value = "") {
+    if (writeClipboardTextFallback(value)) {
+      return;
+    }
+
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+
+    throw new Error("Copy command was rejected.");
+  }
+
+  async function copyCommand(button = document.createElement("button")) {
     const panel = button.closest(".command-panel, .command-panel-single");
     const code = panel?.querySelector("code")?.textContent;
 
@@ -326,24 +332,26 @@ const groupId = `command-${hashCommandBlockId(
   }
 
   function bindCommandCopyButtons() {
-    for (const button of document.querySelectorAll<HTMLButtonElement>(
-      "[data-command-copy]",
-    )) {
-      if (button.dataset.copyBound) {
+    for (const item of document.querySelectorAll("button[data-command-copy]")) {
+      if (!(item instanceof HTMLButtonElement)) {
         continue;
       }
 
-      button.dataset.copyBound = "true";
-      button.addEventListener("click", () => {
-        void copyCommand(button).catch(() => {
-          button.dataset.copyState = "failed";
-          button.setAttribute("aria-label", "Copy failed");
-          button.title = "Copy failed";
+      if (item.dataset.copyBound) {
+        continue;
+      }
+
+      item.dataset.copyBound = "true";
+      item.addEventListener("click", () => {
+        void copyCommand(item).catch(() => {
+          item.dataset.copyState = "failed";
+          item.setAttribute("aria-label", "Copy failed");
+          item.title = "Copy failed";
 
           window.setTimeout(() => {
-            button.setAttribute("aria-label", "Copy command");
-            button.title = "Copy command";
-            delete button.dataset.copyState;
+            item.setAttribute("aria-label", "Copy command");
+            item.title = "Copy command";
+            delete item.dataset.copyState;
           }, 1600);
         });
       });
@@ -352,6 +360,10 @@ const groupId = `command-${hashCommandBlockId(
 
   selectPreferredCommandTabs();
   bindCommandCopyButtons();
-  document.addEventListener("astro:page-load", selectPreferredCommandTabs);
-  document.addEventListener("astro:page-load", bindCommandCopyButtons);
+
+  if (!document.documentElement.dataset.cliparrCommandBlockInit) {
+    document.documentElement.dataset.cliparrCommandBlockInit = "true";
+    document.addEventListener("astro:page-load", selectPreferredCommandTabs);
+    document.addEventListener("astro:page-load", bindCommandCopyButtons);
+  }
 </script>

--- a/apps/www/src/content/docs/access-control.mdx
+++ b/apps/www/src/content/docs/access-control.mdx
@@ -5,7 +5,12 @@ section: install-operate
 order: 30
 ---
 
-import Callout from "../../components/Callout.astro";
+import Callout from "@/components/Callout.astro";
+import CommandBlock from "@/components/CommandBlock.astro";
+import {
+  tailscaleDockerRunCommandVariants,
+  wireguardDockerRunCommandVariants,
+} from "@/data/product";
 
 Cliparr can remember provider connections, but it does not have a full user system with app-level accounts, roles, or permissions. Treat access to the Cliparr web app as access to the connected sources and active media sessions.
 
@@ -143,14 +148,10 @@ For many home setups, the safest access control is no public Cliparr endpoint at
 
 With Tailscale, bind Cliparr to localhost and share it only inside your tailnet:
 
-```bash
-docker run -d \
-  --name cliparr \
-  -p 127.0.0.1:7171:7171 \
-  -e APP_KEY="your-32-char-stable-random-secret" \
-  -v cliparr-data:/data \
-  ghcr.io/techsquidtv/cliparr:latest
-```
+<CommandBlock
+  variants={tailscaleDockerRunCommandVariants}
+  label="Bind Cliparr to localhost"
+/>
 
 Then run Tailscale Serve on the same host:
 
@@ -164,14 +165,10 @@ With WireGuard, keep the same idea: do not publish Cliparr to the public interfa
 
 For example, if the Cliparr host has WireGuard address `10.8.0.1`, bind Docker to that address instead of every interface:
 
-```bash
-docker run -d \
-  --name cliparr \
-  -p 10.8.0.1:7171:7171 \
-  -e APP_KEY="your-32-char-stable-random-secret" \
-  -v cliparr-data:/data \
-  ghcr.io/techsquidtv/cliparr:latest
-```
+<CommandBlock
+  variants={wireguardDockerRunCommandVariants}
+  label="Bind Cliparr to WireGuard"
+/>
 
 If you use Caddy inside the VPN, serve Cliparr on an internal name and restrict firewall access to VPN clients:
 

--- a/apps/www/src/content/docs/development.mdx
+++ b/apps/www/src/content/docs/development.mdx
@@ -6,11 +6,14 @@ order: 10
 ---
 
 import CommandBlock from "@/components/CommandBlock.astro";
-import { developmentSetupCommands, preflightCommands } from "@/data/product";
+import {
+  developmentSetupCommandVariants,
+  preflightCommands,
+} from "@/data/product";
 
 Development uses the root pnpm workspace. You need Node.js 24 or newer and pnpm 11.2.2 via Corepack.
 
-<CommandBlock code={developmentSetupCommands} label="Local setup" lang="bash" />
+<CommandBlock variants={developmentSetupCommandVariants} label="Local setup" />
 
 The frontend runs on `http://localhost:5173`. The API server runs on `http://localhost:3000` and redirects auth callback pages back to the Vite frontend during development.
 

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -7,11 +7,17 @@ order: 10
 
 import Callout from "@/components/Callout.astro";
 import CommandBlock from "@/components/CommandBlock.astro";
-import { dockerComposeExample, dockerRunCommand } from "@/data/product";
+import {
+  dockerComposeExample,
+  dockerLinuxContainerNote,
+  dockerRunCommandVariants,
+} from "@/data/product";
 
 Run Cliparr in Docker, then open the app and connect Plex, Jellyfin, or a local video. Mount `/data` before connecting media servers so settings and encrypted credentials survive updates.
 
-<CommandBlock code={dockerRunCommand} label="Docker quick start" lang="bash" />
+<CommandBlock variants={dockerRunCommandVariants} label="Docker quick start" />
+
+{dockerLinuxContainerNote}
 
 Open `http://localhost:7171`, connect Plex or Jellyfin, or choose **Open Video** for a local file.
 

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -17,7 +17,7 @@ Run Cliparr in Docker, then open the app and connect Plex, Jellyfin, or a local 
 
 <CommandBlock variants={dockerRunCommandVariants} label="Docker quick start" />
 
-{dockerLinuxContainerNote}
+<p>{dockerLinuxContainerNote}</p>
 
 Open `http://localhost:7171`, connect Plex or Jellyfin, or choose **Open Video** for a local file.
 

--- a/apps/www/src/content/docs/logging.mdx
+++ b/apps/www/src/content/docs/logging.mdx
@@ -9,7 +9,7 @@ import Callout from "@/components/Callout.astro";
 import CommandBlock from "@/components/CommandBlock.astro";
 import {
   rotatingFileLoggingCompose,
-  structuredConsoleLoggingCommand,
+  structuredConsoleLoggingCommandVariants,
 } from "@/data/product";
 
 Development server logs are emitted as JSON Lines so every local console line includes Cliparr's structured LogTape fields. Frontend development logs use the same JSON format in the browser console.
@@ -17,9 +17,8 @@ Development server logs are emitted as JSON Lines so every local console line in
 Production server logs default to `pretty`, the readable terminal format that shows the timestamp, level, category, and message. Set `CLIPARR_LOG_FORMAT=json` or `CLIPARR_LOG_FORMAT=logfmt` in production when you want each console line to include structured fields such as `event.name`, `event.outcome`, request data, provider IDs, media handle IDs, counts, durations, and error details. JSON is best for log collectors. logfmt is compact and readable in plain terminals.
 
 <CommandBlock
-  code={structuredConsoleLoggingCommand}
+  variants={structuredConsoleLoggingCommandVariants}
   label="Structured console logs"
-  lang="bash"
 />
 
 `CLIPARR_LOG_LEVEL` controls how much the server emits. Development defaults to `debug`; production defaults to `info`. Use `trace` only while chasing detailed media proxy or playback behavior because it can be noisy.

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -63,12 +63,35 @@ export const providers = [
   },
 ] as const;
 
+export type CommandExampleLanguage = "bash" | "powershell" | "yaml";
+
+export interface CommandExampleVariant {
+  label: string;
+  code: string;
+  lang: CommandExampleLanguage;
+}
+
 export const dockerRunCommand = `docker run -d \\
   --name cliparr \\
   -p 7171:7171 \\
   -e APP_KEY="your-32-char-stable-random-secret" \\
   -v cliparr-data:/data \\
   ghcr.io/techsquidtv/cliparr:latest`;
+
+export const dockerRunPowerShellCommand = `docker run -d \`
+  --name cliparr \`
+  -p 7171:7171 \`
+  -e APP_KEY="your-32-char-stable-random-secret" \`
+  -v cliparr-data:/data \`
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+export const dockerRunCommandVariants = [
+  { label: "macOS / Linux", code: dockerRunCommand, lang: "bash" },
+  { label: "PowerShell", code: dockerRunPowerShellCommand, lang: "powershell" },
+] satisfies readonly CommandExampleVariant[];
+
+export const dockerLinuxContainerNote =
+  "On Windows, run this from Docker Desktop or another Docker engine using Linux containers. Cliparr publishes Linux container images for linux/amd64 and linux/arm64.";
 
 export const dockerComposeExample = `services:
   cliparr:
@@ -85,13 +108,80 @@ export const dockerComposeExample = `services:
 volumes:
   cliparr-data:`;
 
-export const structuredConsoleLoggingCommand = `docker run -d \\
+const structuredConsoleLoggingCommand = `docker run -d \\
   --name cliparr \\
   -p 7171:7171 \\
   -e APP_KEY="your-32-char-stable-random-secret" \\
   -e CLIPARR_LOG_FORMAT=json \\
   -v cliparr-data:/data \\
   ghcr.io/techsquidtv/cliparr:latest`;
+
+const structuredConsoleLoggingPowerShellCommand = `docker run -d \`
+  --name cliparr \`
+  -p 7171:7171 \`
+  -e APP_KEY="your-32-char-stable-random-secret" \`
+  -e CLIPARR_LOG_FORMAT=json \`
+  -v cliparr-data:/data \`
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+export const structuredConsoleLoggingCommandVariants = [
+  {
+    label: "macOS / Linux",
+    code: structuredConsoleLoggingCommand,
+    lang: "bash",
+  },
+  {
+    label: "PowerShell",
+    code: structuredConsoleLoggingPowerShellCommand,
+    lang: "powershell",
+  },
+] satisfies readonly CommandExampleVariant[];
+
+const tailscaleDockerRunCommand = `docker run -d \\
+  --name cliparr \\
+  -p 127.0.0.1:7171:7171 \\
+  -e APP_KEY="your-32-char-stable-random-secret" \\
+  -v cliparr-data:/data \\
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+const tailscaleDockerRunPowerShellCommand = `docker run -d \`
+  --name cliparr \`
+  -p 127.0.0.1:7171:7171 \`
+  -e APP_KEY="your-32-char-stable-random-secret" \`
+  -v cliparr-data:/data \`
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+export const tailscaleDockerRunCommandVariants = [
+  { label: "macOS / Linux", code: tailscaleDockerRunCommand, lang: "bash" },
+  {
+    label: "PowerShell",
+    code: tailscaleDockerRunPowerShellCommand,
+    lang: "powershell",
+  },
+] satisfies readonly CommandExampleVariant[];
+
+const wireguardDockerRunCommand = `docker run -d \\
+  --name cliparr \\
+  -p 10.8.0.1:7171:7171 \\
+  -e APP_KEY="your-32-char-stable-random-secret" \\
+  -v cliparr-data:/data \\
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+const wireguardDockerRunPowerShellCommand = `docker run -d \`
+  --name cliparr \`
+  -p 10.8.0.1:7171:7171 \`
+  -e APP_KEY="your-32-char-stable-random-secret" \`
+  -v cliparr-data:/data \`
+  ghcr.io/techsquidtv/cliparr:latest`;
+
+export const wireguardDockerRunCommandVariants = [
+  { label: "macOS / Linux", code: wireguardDockerRunCommand, lang: "bash" },
+  {
+    label: "PowerShell",
+    code: wireguardDockerRunPowerShellCommand,
+    lang: "powershell",
+  },
+] satisfies readonly CommandExampleVariant[];
 
 export const rotatingFileLoggingCompose = `services:
   cliparr:
@@ -106,11 +196,26 @@ export const rotatingFileLoggingCompose = `services:
     volumes:
       - cliparr-data:/data`;
 
-export const developmentSetupCommands = `git clone https://github.com/techsquidtv/cliparr.git
+const developmentSetupCommands = `git clone https://github.com/techsquidtv/cliparr.git
 cd cliparr
 cp .env.example .env
 pnpm install
 pnpm dev`;
+
+const developmentSetupPowerShellCommands = `git clone https://github.com/techsquidtv/cliparr.git
+Set-Location cliparr
+Copy-Item .env.example .env
+pnpm install
+pnpm dev`;
+
+export const developmentSetupCommandVariants = [
+  { label: "macOS / Linux", code: developmentSetupCommands, lang: "bash" },
+  {
+    label: "PowerShell",
+    code: developmentSetupPowerShellCommands,
+    lang: "powershell",
+  },
+] satisfies readonly CommandExampleVariant[];
 
 export const preflightCommands = `pnpm preflight`;
 

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -5,7 +5,7 @@ import FeatureGrid from "@/components/FeatureGrid.astro";
 import { Picture } from "astro:assets";
 import screenshotImage from "@/assets/screenshot.webp";
 import {
-  dockerRunCommand,
+  dockerRunCommandVariants,
   productIntro,
   providers,
   site,
@@ -124,7 +124,7 @@ import {
           clips whenever something worth saving is playing.
         </p>
       </div>
-      <CommandBlock code={dockerRunCommand} label="Docker" lang="bash" />
+      <CommandBlock variants={dockerRunCommandVariants} label="Docker" />
     </div>
   </section>
 

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -262,7 +262,7 @@
     margin: 0;
     overflow-x: auto;
     background: black !important;
-    padding: 1rem;
+    padding: 2.75rem 1rem 1rem;
     font-size: 0.875rem;
     line-height: 1.65;
   }
@@ -312,10 +312,68 @@
     grid-column: 1 / -1;
     grid-row: 2;
     min-width: 0;
+    position: relative;
     border-top: 1px solid rgb(255 255 255 / 0.1);
   }
 
   .command-tab-input:checked + .command-tab-label + .command-panel {
+    display: block;
+  }
+
+  .command-panel-single {
+    position: relative;
+  }
+
+  .command-copy-button {
+    position: absolute;
+    top: 0.625rem;
+    right: 0.625rem;
+    z-index: 1;
+    display: inline-grid;
+    width: 2.25rem;
+    height: 2.25rem;
+    place-items: center;
+    border: 1px solid rgb(255 255 255 / 0.14);
+    border-radius: 0.375rem;
+    background: rgb(255 255 255 / 0.08);
+    color: rgb(255 255 255 / 0.72);
+    cursor: pointer;
+    padding: 0;
+    transition:
+      background-color 160ms ease,
+      border-color 160ms ease,
+      color 160ms ease;
+  }
+
+  .command-copy-button:hover,
+  .command-copy-button:focus-visible,
+  .command-copy-button[data-copy-state="copied"] {
+    background: rgb(255 255 255 / 0.14);
+    border-color: rgb(255 255 255 / 0.22);
+    color: white;
+  }
+
+  .command-copy-button[data-copy-state="failed"] {
+    background: color-mix(in oklch, var(--destructive) 28%, black);
+    border-color: color-mix(in oklch, var(--destructive) 68%, white);
+    color: white;
+  }
+
+  .command-copy-icon {
+    grid-area: 1 / 1;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .command-copy-icon-copied,
+  .command-copy-icon-failed,
+  .command-copy-button[data-copy-state="copied"] .command-copy-icon-copy,
+  .command-copy-button[data-copy-state="failed"] .command-copy-icon-copy {
+    display: none;
+  }
+
+  .command-copy-button[data-copy-state="copied"] .command-copy-icon-copied,
+  .command-copy-button[data-copy-state="failed"] .command-copy-icon-failed {
     display: block;
   }
 

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -267,6 +267,69 @@
     line-height: 1.65;
   }
 
+  .command-tabs {
+    display: grid;
+    grid-template-columns: repeat(var(--tab-count), max-content) minmax(0, 1fr);
+    background: black;
+  }
+
+  .command-tab-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .command-tab-label {
+    grid-row: 1;
+    border-right: 1px solid rgb(255 255 255 / 0.1);
+    color: rgb(255 255 255 / 0.58);
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1rem;
+    padding: 0.625rem 1rem;
+    transition:
+      background-color 160ms ease,
+      color 160ms ease;
+    user-select: none;
+  }
+
+  .command-tab-label:hover,
+  .command-tab-input:focus-visible + .command-tab-label {
+    background: rgb(255 255 255 / 0.08);
+    color: white;
+  }
+
+  .command-tab-input:checked + .command-tab-label {
+    background: rgb(255 255 255 / 0.1);
+    color: white;
+  }
+
+  .command-panel {
+    display: none;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    min-width: 0;
+    border-top: 1px solid rgb(255 255 255 / 0.1);
+  }
+
+  .command-tab-input:checked + .command-tab-label + .command-panel {
+    display: block;
+  }
+
+  @media (max-width: 36rem) {
+    .command-tabs {
+      grid-template-columns: repeat(var(--tab-count), minmax(0, 1fr));
+    }
+
+    .command-tab-label {
+      padding-inline: 0.75rem;
+      text-align: center;
+    }
+  }
+
   .prose-docs > svg[id^="mermaid-"] {
     @apply mt-5 h-auto w-full rounded-lg border border-border bg-card p-4 shadow-2xl shadow-black/20 sm:p-6;
     display: block;


### PR DESCRIPTION
## Summary
- Add shell tabs to reusable website command blocks and default them from browser platform/user-agent hints.
- Add PowerShell variants for Docker run and local setup examples while keeping YAML examples unchanged.
- Add icon-only copy buttons with copied/error icon states for command blocks.
- Clarify that Windows PowerShell usage still requires a Docker engine running Linux containers for linux/amd64 or linux/arm64 images.

## Validation
- pnpm docs:check
- pnpm --filter @cliparr/www build
- pnpm preflight
- In-app browser smoke checks for tab defaults and icon-only copy behavior