### PR TITLE
fix(server): include all connected media sources

### DIFF
--- a/apps/server/src/db/mediaSourcesRepository.ts
+++ b/apps/server/src/db/mediaSourcesRepository.ts
@@ -131,7 +131,7 @@ export function updateMediaSource(id: string, input: UpdateMediaSourceInput) {
   return getMediaSource(id);
 }
 
-function getMediaSource(id: string) {
+export function getMediaSource(id: string) {
   return getMediaSourceWhere(eq(mediaSources.id, id));
 }
 
@@ -147,18 +147,10 @@ export function getMediaSourceForAccount(
   return where ? getMediaSourceWhere(where) : undefined;
 }
 
-export function deleteMediaSourceForAccount(
-  id: string,
-  providerAccountId: string,
-) {
+export function deleteMediaSource(id: string) {
   const result = getDatabase()
     .delete(mediaSources)
-    .where(
-      and(
-        eq(mediaSources.id, id),
-        eq(mediaSources.providerAccountId, providerAccountId),
-      ),
-    )
+    .where(eq(mediaSources.id, id))
     .run();
 
   return result.changes > 0;
@@ -256,65 +248,4 @@ export function listMediaSources(
         : and(...filters);
 
   return listMediaSourcesWhere(where);
-}
-
-export function updateMediaSourceForAccount(
-  id: string,
-  providerAccountId: string,
-  input: UpdateMediaSourceInput,
-) {
-  getDatabase()
-    .update(mediaSources)
-    .set({
-      ...(input.externalId !== undefined
-        ? { externalId: input.externalId }
-        : {}),
-      ...(input.name !== undefined ? { name: input.name } : {}),
-      ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
-      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
-      ...(input.connection !== undefined
-        ? { connection: encryptJsonSecrets(input.connection) }
-        : {}),
-      ...(input.credentials !== undefined
-        ? { credentials: encryptJsonSecrets(input.credentials) }
-        : {}),
-      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-      ...(input.lastCheckedAt !== undefined
-        ? { lastCheckedAt: input.lastCheckedAt }
-        : {}),
-      ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
-      updatedAt: currentTimestampSql(),
-    })
-    .where(
-      and(
-        eq(mediaSources.id, id),
-        eq(mediaSources.providerAccountId, providerAccountId),
-      ),
-    )
-    .run();
-
-  return getMediaSourceForAccount(id, providerAccountId);
-}
-
-export function updateMediaSourceHealthForAccount(
-  id: string,
-  providerAccountId: string,
-  input: { lastCheckedAt: string; lastError?: string },
-) {
-  getDatabase()
-    .update(mediaSources)
-    .set({
-      lastCheckedAt: input.lastCheckedAt,
-      lastError: input.lastError ?? null,
-      updatedAt: currentTimestampSql(),
-    })
-    .where(
-      and(
-        eq(mediaSources.id, id),
-        eq(mediaSources.providerAccountId, providerAccountId),
-      ),
-    )
-    .run();
-
-  return getMediaSourceForAccount(id, providerAccountId);
 }

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -840,7 +840,7 @@ async function normalizeCurrentPlayback(
   const playbackDiagnostics = {
     sessionId: session.id,
     sourceId: source.id,
-    providerAccountId: session.providerAccountId,
+    providerAccountId: source.providerAccountId,
     playSessionId,
     currentlyPlayingItem: {
       id: playbackItemId,

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -1094,7 +1094,7 @@ async function normalizeCurrentPlayback(
       const playbackDiagnostics = {
         sessionId: session.id,
         sourceId: source.id,
-        providerAccountId: session.providerAccountId,
+        providerAccountId: source.providerAccountId,
         playbackSessionId: sessionId,
         transcodeSessionId,
         currentlyPlayingItem: {

--- a/apps/server/src/routes/media.ts
+++ b/apps/server/src/routes/media.ts
@@ -330,7 +330,6 @@ mediaRouter.get(
     const sourceErrors: SourcePlaybackError[] = [];
     const sources = listMediaSources({
       enabledOnly: true,
-      providerAccountId: session.providerAccountId,
     }).flatMap((source) => {
       const provider = getProvider(source.providerId);
       if (!provider) {
@@ -390,8 +389,14 @@ mediaRouter.get(
       ),
       ...logDurationFields(startedAt),
       "session.id": session.id,
-      "provider.id": session.providerId,
-      "provider.account.id": session.providerAccountId,
+      "session.provider.id": session.providerId,
+      "session.provider.account.id": session.providerAccountId,
+      "source.provider.ids": [
+        ...new Set(sources.map(({ source }) => source.providerId)),
+      ],
+      "provider.account.count": new Set(
+        sources.map(({ source }) => source.providerAccountId),
+      ).size,
       "source.count": sources.length,
       "viewer.count": new Set(entries.map((entry) => entry.viewer.id)).size,
       "playback.item.count": entries.length,

--- a/apps/server/src/routes/mediaCurrentPlaying.test.ts
+++ b/apps/server/src/routes/mediaCurrentPlaying.test.ts
@@ -116,10 +116,17 @@ void test("aggregates currently playing results across enabled sources with part
       label: "Plex Account",
       accessToken: "user-token",
     });
+    const otherAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Other Plex Account",
+      accessToken: "other-token",
+    });
     assert(account);
+    assert(otherAccount);
 
     const alpha = createSource(account.id, "Alpha");
     const zeta = createSource(account.id, "Zeta");
+    const omega = createSource(otherAccount.id, "Omega");
     createSource(account.id, "Failure");
     createSource(account.id, "Ghost", "missing-provider");
     createSource(account.id, "Unsupported");
@@ -170,6 +177,16 @@ void test("aggregates currently playing results across enabled sources with part
         ];
       }
 
+      if (source.id === omega.id) {
+        return [
+          playbackEntry(
+            source,
+            { id: "viewer-carol", name: "Carol" },
+            "omega-item",
+          ),
+        ];
+      }
+
       return [];
     };
 
@@ -193,10 +210,10 @@ void test("aggregates currently playing results across enabled sources with part
         }>;
       };
 
-      assert.deepEqual(calls, ["Alpha", "Failure", "Zeta"]);
+      assert.deepEqual(calls, ["Alpha", "Failure", "Omega", "Zeta"]);
       assert.deepEqual(
         body.viewers?.map((group) => group.viewer.name),
-        ["Alice", "Bob"],
+        ["Alice", "Bob", "Carol"],
       );
       assert.deepEqual(
         body.viewers?.[0]?.items.map((item) => item.source.name),

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -323,7 +323,7 @@ void test("logs into Jellyfin with credentials and stores a remembered provider 
   });
 });
 
-void test("updates sources with account isolation and preserves Plex manual URL mode", async () => {
+void test("updates sources across connected accounts and preserves Plex manual URL mode", async () => {
   await withTestApp(async (baseUrl, fetchLocal) => {
     const account = upsertProviderAccountByAccessToken({
       providerId: "plex",
@@ -335,8 +335,14 @@ void test("updates sources with account isolation and preserves Plex manual URL 
       label: "Other Plex Account",
       accessToken: "other-token",
     });
+    const jellyfinAccount = upsertProviderAccountByAccessToken({
+      providerId: "jellyfin",
+      label: "Jellyfin Account",
+      accessToken: "jellyfin-user-token",
+    });
     assert(account);
     assert(otherAccount);
+    assert(jellyfinAccount);
 
     const source = upsertMediaSource({
       providerId: "plex",
@@ -359,8 +365,16 @@ void test("updates sources with account isolation and preserves Plex manual URL 
       name: "Other Plex",
       baseUrl: "http://other.example:32400",
     });
+    const jellyfinSource = upsertMediaSource({
+      providerId: "jellyfin",
+      providerAccountId: jellyfinAccount.id,
+      externalId: "jellyfin-server-1",
+      name: "Jelly Lab",
+      baseUrl: "http://jelly.example:8096",
+    });
     assert(source);
     assert(otherSource);
+    assert(jellyfinSource);
 
     const session = createProviderSession({
       providerId: "plex",
@@ -369,15 +383,20 @@ void test("updates sources with account isolation and preserves Plex manual URL 
     });
     const sessionCookie = `${getSessionCookieName()}=${session.id}`;
 
-    const isolatedResponse = await fetchLocal(
-      `${baseUrl}/api/sources/${otherSource.id}`,
+    const crossAccountResponse = await fetchLocal(
+      `${baseUrl}/api/sources/${jellyfinSource.id}`,
       {
         headers: {
           cookie: sessionCookie,
         },
       },
     );
-    assert.equal(isolatedResponse.status, 404);
+    assert.equal(crossAccountResponse.status, 200);
+    const crossAccountBody = (await crossAccountResponse.json()) as {
+      source?: { id?: string; providerId?: string };
+    };
+    assert.equal(crossAccountBody.source?.id, jellyfinSource.id);
+    assert.equal(crossAccountBody.source?.providerId, "jellyfin");
 
     const rejectedPatchResponse = await fetchLocal(
       `${baseUrl}/api/sources/${source.id}`,
@@ -435,8 +454,8 @@ void test("updates sources with account isolation and preserves Plex manual URL 
       sources?: Array<{ id: string }>;
     };
     assert.deepEqual(
-      listed.sources?.map((item) => item.id),
-      [source.id],
+      listed.sources?.map((item) => item.id).sort(),
+      [jellyfinSource.id, otherSource.id, source.id].sort(),
     );
   });
 });

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -8,12 +8,11 @@ import {
 } from "@cliparr/shared/logging";
 import {
   listMediaSources,
-  deleteMediaSourceForAccount,
-  getMediaSourceForAccount,
-  updateMediaSourceHealthForAccount,
+  deleteMediaSource,
+  getMediaSource,
   type MediaSource,
   type UpdateMediaSourceInput,
-  updateMediaSourceForAccount,
+  updateMediaSource,
 } from "@/db/mediaSourcesRepository";
 import { asyncHandler, createApiError, isApiError } from "@/http/errors";
 import {
@@ -42,8 +41,8 @@ function serializeSource(source: MediaSource) {
   };
 }
 
-function requireMediaSource(sourceId: string, providerAccountId: string) {
-  const source = getMediaSourceForAccount(sourceId, providerAccountId);
+function requireMediaSource(sourceId: string) {
+  const source = getMediaSource(sourceId);
   if (!source) {
     throw createApiError(404, "source_not_found", "Source was not found");
   }
@@ -153,12 +152,10 @@ function changedSourceFields(input: UpdateMediaSourceInput) {
 sourcesRouter.get(
   "/",
   asyncHandler(async (req, res) => {
-    const session = requireAccountSession(req);
+    requireAccountSession(req);
     setNoStore(res);
     res.json({
-      sources: listMediaSources({
-        providerAccountId: session.providerAccountId,
-      }).map(serializeSource),
+      sources: listMediaSources().map(serializeSource),
     });
   }),
 );
@@ -166,12 +163,9 @@ sourcesRouter.get(
 sourcesRouter.get(
   "/:id",
   asyncHandler(async (req, res) => {
-    const session = requireAccountSession(req);
+    requireAccountSession(req);
     setNoStore(res);
-    const source = requireMediaSource(
-      req.params.id as string,
-      session.providerAccountId,
-    );
+    const source = requireMediaSource(req.params.id as string);
     res.json({ source: serializeSource(source) });
   }),
 );
@@ -183,39 +177,33 @@ sourcesRouter.patch(
     setNoStore(res);
     const startedAt = Date.now();
     const sourceId = req.params.id as string;
+    let source: MediaSource | undefined;
 
     try {
-      const existingSource = requireMediaSource(
-        sourceId,
-        session.providerAccountId,
-      );
+      source = requireMediaSource(sourceId);
       const input = parseSourceUpdate(req.body);
       const nextInput =
-        existingSource.providerId === "plex" && input.baseUrl !== undefined
+        source.providerId === "plex" && input.baseUrl !== undefined
           ? {
               ...input,
               connection: withPlexBaseUrlMode(
-                existingSource.connection,
+                source.connection,
                 PLEX_BASE_URL_MODE_MANUAL,
               ),
             }
           : input;
-      const source = updateMediaSourceForAccount(
-        sourceId,
-        session.providerAccountId,
-        nextInput,
-      );
-      if (!source) {
+      const updatedSource = updateMediaSource(sourceId, nextInput);
+      if (!updatedSource) {
         throw createApiError(404, "source_not_found", "Source was not found");
       }
-      res.json({ source: serializeSource(source) });
+      res.json({ source: serializeSource(updatedSource) });
 
       logger.info("Media source updated.", {
         ...logEventFields("source.update", "success"),
         ...logDurationFields(startedAt),
-        "source.id": source.id,
-        "provider.id": source.providerId,
-        "provider.account.id": session.providerAccountId,
+        "source.id": updatedSource.id,
+        "provider.id": updatedSource.providerId,
+        "provider.account.id": updatedSource.providerAccountId,
         "source.changed_fields": changedSourceFields(input),
         "source.base_url": sanitizeUrlForLog(input.baseUrl),
       });
@@ -229,7 +217,9 @@ sourcesRouter.patch(
           ...logDurationFields(startedAt),
           ...logErrorFields(err),
           "source.id": sourceId,
-          "provider.account.id": session.providerAccountId,
+          "provider.id": source?.providerId,
+          "provider.account.id": source?.providerAccountId,
+          "session.provider.account.id": session.providerAccountId,
           "http.status_code": isApiError(err) ? err.status : undefined,
         }),
       );
@@ -245,13 +235,11 @@ sourcesRouter.delete(
     setNoStore(res);
     const startedAt = Date.now();
     const sourceId = req.params.id as string;
+    let source: MediaSource | undefined;
 
     try {
-      const source = requireMediaSource(sourceId, session.providerAccountId);
-      const deleted = deleteMediaSourceForAccount(
-        sourceId,
-        session.providerAccountId,
-      );
+      source = requireMediaSource(sourceId);
+      const deleted = deleteMediaSource(sourceId);
       if (!deleted) {
         throw createApiError(404, "source_not_found", "Source was not found");
       }
@@ -263,7 +251,7 @@ sourcesRouter.delete(
         ...logDurationFields(startedAt),
         "source.id": source.id,
         "provider.id": source.providerId,
-        "provider.account.id": session.providerAccountId,
+        "provider.account.id": source.providerAccountId,
       });
     } catch (err) {
       warnWithError(
@@ -275,7 +263,9 @@ sourcesRouter.delete(
           ...logDurationFields(startedAt),
           ...logErrorFields(err),
           "source.id": sourceId,
-          "provider.account.id": session.providerAccountId,
+          "provider.id": source?.providerId,
+          "provider.account.id": source?.providerAccountId,
+          "session.provider.account.id": session.providerAccountId,
           "http.status_code": isApiError(err) ? err.status : undefined,
         }),
       );
@@ -291,9 +281,10 @@ sourcesRouter.post(
     setNoStore(res);
     const startedAt = Date.now();
     const sourceId = req.params.id as string;
+    let source: MediaSource | undefined;
 
     try {
-      const source = requireMediaSource(sourceId, session.providerAccountId);
+      source = requireMediaSource(sourceId);
       const provider = getProvider(source.providerId);
       if (!provider) {
         throw createApiError(
@@ -307,14 +298,10 @@ sourcesRouter.post(
       const result = await provider.checkSource(source);
 
       if (!result.ok) {
-        const updatedSource = updateMediaSourceHealthForAccount(
-          source.id,
-          session.providerAccountId,
-          {
-            lastCheckedAt: checkedAt,
-            lastError: result.message,
-          },
-        );
+        const updatedSource = updateMediaSource(source.id, {
+          lastCheckedAt: checkedAt,
+          lastError: result.message,
+        });
 
         if (!updatedSource) {
           throw createApiError(404, "source_not_found", "Source was not found");
@@ -333,29 +320,23 @@ sourcesRouter.post(
           ...logDurationFields(startedAt),
           "source.id": source.id,
           "provider.id": source.providerId,
-          "provider.account.id": session.providerAccountId,
+          "provider.account.id": source.providerAccountId,
           "source.health.ok": false,
           "error.message": result.message,
         });
         return;
       }
 
-      const updatedSource = updateMediaSourceForAccount(
-        source.id,
-        session.providerAccountId,
-        {
-          ...(result.name !== undefined ? { name: result.name } : {}),
-          ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
-          ...(result.connection !== undefined
-            ? { connection: result.connection }
-            : {}),
-          ...(result.metadata !== undefined
-            ? { metadata: result.metadata }
-            : {}),
-          lastCheckedAt: checkedAt,
-          lastError: null,
-        },
-      );
+      const updatedSource = updateMediaSource(source.id, {
+        ...(result.name !== undefined ? { name: result.name } : {}),
+        ...(result.baseUrl !== undefined ? { baseUrl: result.baseUrl } : {}),
+        ...(result.connection !== undefined
+          ? { connection: result.connection }
+          : {}),
+        ...(result.metadata !== undefined ? { metadata: result.metadata } : {}),
+        lastCheckedAt: checkedAt,
+        lastError: null,
+      });
 
       if (!updatedSource) {
         throw createApiError(404, "source_not_found", "Source was not found");
@@ -371,7 +352,7 @@ sourcesRouter.post(
         ...logDurationFields(startedAt),
         "source.id": source.id,
         "provider.id": source.providerId,
-        "provider.account.id": session.providerAccountId,
+        "provider.account.id": source.providerAccountId,
         "source.health.ok": true,
         "source.base_url": sanitizeUrlForLog(result.baseUrl),
       });
@@ -385,7 +366,9 @@ sourcesRouter.post(
           ...logDurationFields(startedAt),
           ...logErrorFields(err),
           "source.id": sourceId,
-          "provider.account.id": session.providerAccountId,
+          "provider.id": source?.providerId,
+          "provider.account.id": source?.providerAccountId,
+          "session.provider.account.id": session.providerAccountId,
           "http.status_code": isApiError(err) ? err.status : undefined,
         }),
       );


### PR DESCRIPTION
## Summary

- List, update, delete, and check all stored media sources once Cliparr is authenticated instead of filtering to the current provider account.
- Include enabled sources across provider accounts in currently-playing discovery.
- Log the actual source provider account in source/playback paths and cover the cross-account behavior with route tests.

## Validation

- `pnpm preflight`
