### PR TITLE
feat(ci): replace Release channel dropdown with rc checkbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,11 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      channel:
-        description: Release channel
+      rc:
+        description: Create as Release Candidate (pre-release)
         required: true
-        default: stable
-        type: choice
-        options:
-          - stable
-          - rc
-          - beta
+        default: false
+        type: boolean
       dry_run:
         description: Plan, check, and generate notes without publishing
         required: true
@@ -64,8 +60,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          CHANNEL="stable"
+          if [[ "${{ inputs.rc }}" == "true" ]]; then
+            CHANNEL="rc"
+          fi
+
           node scripts/release/plan-release.mjs \
-            --channel "${{ inputs.channel }}" \
+            --channel "${CHANNEL}" \
             --target "${GITHUB_SHA}" \
             --image-name "${IMAGE_NAME}" \
             --github-output


### PR DESCRIPTION
Improves the Release workflow UI by replacing the 'channel' dropdown with a simpler 'rc' checkbox.
- Selecting the 'rc' checkbox creates a Release Candidate (e.g., v0.6.2-rc.1).
- Leaving it unchecked creates a standard stable release.
- This addresses feedback that the previous UI was less intuitive and clearer signals were needed for pre-releases.