### PR TITLE
feat(ci): add Sync Changelog workflow and style rich release notes

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,22 @@
+name: Sync Changelog
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages deploy
+        env:
+          CLOUDFLARE_PAGES_DEPLOY_HOOK_URL: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK_URL }}
+        run: |
+          if [[ -z "${CLOUDFLARE_PAGES_DEPLOY_HOOK_URL}" ]]; then
+            echo "Error: CLOUDFLARE_PAGES_DEPLOY_HOOK_URL is not set." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --request POST "${CLOUDFLARE_PAGES_DEPLOY_HOOK_URL}"

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -250,6 +250,13 @@
     @apply font-medium text-foreground underline decoration-border transition-colors hover:decoration-primary;
   }
 
+  .release-notes img,
+  .release-notes video {
+    @apply mt-4 rounded-lg border border-border bg-card shadow-sm;
+    max-width: 100%;
+    height: auto;
+  }
+
   .release-notes :not(pre) > code {
     @apply rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[0.88em] text-foreground;
   }


### PR DESCRIPTION
Allows manual retriggering of the site build to mirror manual updates to GitHub release notes.
- Adds a 'Sync Changelog' workflow that triggers the Cloudflare Pages deploy hook.
- Adds CSS styles for images and videos in release notes to ensure they are rendered correctly on the website.
- This supports adding notes, pictures, and videos to v1.0.0 after autogeneration.