### PR TITLE
security(server): harden provider redirects

### DIFF
--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -37,6 +37,7 @@ const JELLYFIN_VERSION = CLIPARR_CLIENT_VERSION;
 
 export const JELLYFIN_REQUEST_TIMEOUT_MS = 5000;
 const CURRENT_PLAYBACK_REQUEST_TIMEOUT_MS = 5000;
+const JELLYFIN_MAX_REDIRECTS = 5;
 
 const JELLYFIN_DEV_BASE_URL = stringValue(process.env.CLIPARR_DEV_JELLYFIN_URL);
 const ALLOW_LOOPBACK_JELLYFIN_URLS = booleanEnv(
@@ -181,6 +182,38 @@ function isLinkLocalHost(hostname: string) {
   return host.startsWith("169.254.") || /^fe[89ab][0-9a-f]:/i.test(host);
 }
 
+function ipv4Octets(hostname: string) {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const octets = parts.map((part) => Number(part));
+  if (
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return undefined;
+  }
+
+  return octets as [number, number, number, number];
+}
+
+function isPrivateHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  const octets = ipv4Octets(host);
+  if (octets) {
+    const [first, second] = octets;
+    return (
+      first === 10 ||
+      (first === 100 && second >= 64 && second <= 127) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    );
+  }
+
+  return /^f[cd][0-9a-f]{2}:/i.test(host);
+}
+
 function isMulticastHost(hostname: string) {
   const host = normalizeHostname(hostname);
   if (/^ff[0-9a-f]{2}:/i.test(host)) {
@@ -215,7 +248,10 @@ async function resolveHostnameAddresses(hostname: string) {
   }
 }
 
-function assertAllowedResolvedAddress(address: string) {
+function assertAllowedResolvedAddress(
+  address: string,
+  options: { allowPrivate?: boolean } = {},
+) {
   if (
     isUnspecifiedHost(address) ||
     isLinkLocalHost(address) ||
@@ -225,6 +261,14 @@ function assertAllowedResolvedAddress(address: string) {
       400,
       "invalid_jellyfin_server_url",
       "Jellyfin serverUrl resolved to an unsafe address",
+    );
+  }
+
+  if (isPrivateHost(address) && options.allowPrivate !== true) {
+    throw createApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl resolved to an unsafe internal address",
     );
   }
 
@@ -241,9 +285,20 @@ function assertAllowedResolvedAddress(address: string) {
   }
 }
 
-async function assertAllowedJellyfinServerUrl(url: string) {
+async function assertAllowedJellyfinServerUrl(
+  url: string,
+  options: { allowPrivate?: boolean } = { allowPrivate: true },
+) {
   const parsed = assertHttpUrl(url.trim());
   const hostname = normalizeHostname(parsed.hostname);
+
+  if (parsed.username || parsed.password) {
+    throw createApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl must not include embedded credentials",
+    );
+  }
 
   if (DISALLOWED_JELLYFIN_HOSTNAMES.has(hostname)) {
     throw createApiError(
@@ -265,10 +320,10 @@ async function assertAllowedJellyfinServerUrl(url: string) {
     );
   }
 
-  assertAllowedResolvedAddress(hostname);
+  assertAllowedResolvedAddress(hostname, options);
 
   for (const address of await resolveHostnameAddresses(hostname)) {
-    assertAllowedResolvedAddress(address);
+    assertAllowedResolvedAddress(address, options);
   }
 
   return parsed;
@@ -376,8 +431,162 @@ const JELLYFIN_CLIENT_INFO = {
   version: JELLYFIN_VERSION,
 };
 
+function isRedirectStatus(status: number) {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+async function reusableRequestBody(request: Request) {
+  if (request.method === "GET" || request.method === "HEAD" || !request.body) {
+    return undefined;
+  }
+
+  const contentType = (request.headers.get("content-type") ?? "").toLowerCase();
+  if (contentType.includes("json") || contentType.startsWith("text/")) {
+    return request.clone().text();
+  }
+
+  return request.clone().arrayBuffer();
+}
+
+async function closeRedirectResponse(response: globalThis.Response) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Redirect response bodies are discarded before the next request.
+  }
+}
+
+function redirectUrl(location: string, requestUrl: URL) {
+  try {
+    return new URL(location, requestUrl);
+  } catch {
+    throw createApiError(
+      502,
+      "jellyfin_invalid_redirect",
+      "Jellyfin server returned an invalid redirect URL",
+    );
+  }
+}
+
+function updateRedirectRequest(
+  init: RequestInit,
+  response: globalThis.Response,
+  nextUrl: URL,
+  currentUrl: URL,
+) {
+  const headers = new Headers(init.headers);
+  const method = String(init.method ?? "GET").toUpperCase();
+  const shouldSwitchToGet =
+    response.status === 303 ||
+    ((response.status === 301 || response.status === 302) && method === "POST");
+
+  if (nextUrl.origin !== currentUrl.origin) {
+    headers.delete("authorization");
+    headers.delete("cookie");
+    headers.delete("x-emby-authorization");
+    headers.delete("x-emby-token");
+    headers.delete("x-mediabrowser-token");
+  }
+
+  if (!shouldSwitchToGet) {
+    return {
+      ...init,
+      headers,
+    };
+  }
+
+  headers.delete("content-length");
+  headers.delete("content-type");
+
+  return {
+    ...init,
+    method: "GET",
+    headers,
+    body: undefined,
+  };
+}
+
+async function assertAllowedJellyfinRequestUrl(
+  requestUrl: URL,
+  trustedOrigin: string,
+) {
+  const parsed = assertHttpUrl(requestUrl.toString());
+  if (parsed.username || parsed.password) {
+    throw createApiError(
+      400,
+      "invalid_jellyfin_server_url",
+      "Jellyfin serverUrl must not include embedded credentials",
+    );
+  }
+
+  if (requestUrl.origin === trustedOrigin) {
+    return;
+  }
+
+  await assertAllowedJellyfinServerUrl(requestUrl.toString(), {
+    allowPrivate: false,
+  });
+}
+
+async function fetchJellyfinWithManualRedirects(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) {
+  const request = new Request(input, init);
+  const trustedOrigin = new URL(request.url).origin;
+  let requestUrl = new URL(request.url);
+  let requestInit: RequestInit = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body: await reusableRequestBody(request),
+    signal: request.signal,
+  };
+
+  for (
+    let redirectCount = 0;
+    redirectCount <= JELLYFIN_MAX_REDIRECTS;
+    redirectCount += 1
+  ) {
+    await assertAllowedJellyfinRequestUrl(requestUrl, trustedOrigin);
+
+    const response = await globalThis.fetch(requestUrl.toString(), {
+      ...requestInit,
+      redirect: "manual",
+    });
+    const location = response.headers.get("location");
+    if (!isRedirectStatus(response.status) || !location) {
+      return response;
+    }
+
+    const nextUrl = redirectUrl(location, requestUrl);
+    requestInit = updateRedirectRequest(
+      requestInit,
+      response,
+      nextUrl,
+      requestUrl,
+    );
+    await closeRedirectResponse(response);
+    requestUrl = nextUrl;
+  }
+
+  throw createApiError(
+    502,
+    "jellyfin_redirect_limit",
+    "Jellyfin request redirected too many times",
+  );
+}
+
 const jellyfinAxios = axios.create({
   adapter: "fetch",
+  env: {
+    fetch: fetchJellyfinWithManualRedirects,
+  },
 });
 
 function jellyfinDeviceInfo(deviceId = JELLYFIN_DEVICE_ID) {

--- a/apps/server/src/providers/jellyfin/shared.ts
+++ b/apps/server/src/providers/jellyfin/shared.ts
@@ -161,11 +161,19 @@ function isLoopbackHost(hostname: string) {
 
 function normalizeIpCandidate(value: string) {
   const normalized = value.toLowerCase();
-  if (normalized.startsWith("[") && normalized.endsWith("]")) {
-    return normalized.slice(1, -1);
+  const unwrapped =
+    normalized.startsWith("[") && normalized.endsWith("]")
+      ? normalized.slice(1, -1)
+      : normalized;
+
+  const mappedIpv4Prefix = "::ffff:";
+  if (!unwrapped.startsWith(mappedIpv4Prefix)) {
+    return unwrapped;
   }
 
-  return normalized.startsWith("::ffff:") ? normalized.slice(7) : normalized;
+  return (
+    mappedIpv4Address(unwrapped.slice(mappedIpv4Prefix.length)) ?? unwrapped
+  );
 }
 
 function normalizeHostname(value: string) {
@@ -196,6 +204,34 @@ function ipv4Octets(hostname: string) {
   }
 
   return octets as [number, number, number, number];
+}
+
+function mappedIpv4Address(hostname: string) {
+  const octets = ipv4Octets(hostname);
+  if (octets) {
+    return octets.join(".");
+  }
+
+  const words = hostname.split(":");
+  if (words.length !== 2) {
+    return undefined;
+  }
+
+  const parsedWords = words.map((word) => Number.parseInt(word, 16));
+  if (
+    words.some(
+      (word, index) =>
+        !/^[0-9a-f]{1,4}$/i.test(word) ||
+        !Number.isInteger(parsedWords[index]) ||
+        parsedWords[index] < 0 ||
+        parsedWords[index] > 0xffff,
+    )
+  ) {
+    return undefined;
+  }
+
+  const [high, low] = parsedWords as [number, number];
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
 }
 
 function isPrivateHost(hostname: string) {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -343,7 +343,7 @@ void test("validates cross-origin media redirects before following them", async 
     return new Response(null, {
       status: 302,
       headers: {
-        location: "http://127.0.0.1/admin",
+        location: "http://[::ffff:127.0.0.1]/admin",
       },
     });
   }) as typeof fetch;

--- a/apps/server/src/providers/plex/pmsClient.test.ts
+++ b/apps/server/src/providers/plex/pmsClient.test.ts
@@ -4,6 +4,7 @@ import { isApiError } from "@/http/errors";
 import {
   plexPmsResponseStatusMessage,
   requestPlexPmsCurrentSessions,
+  requestPlexPmsIdentity,
   requestPlexPmsMetadata,
   type PlexPmsRequestContext,
   type PlexPmsRequestOptions,
@@ -25,9 +26,8 @@ function withMockFetch(
   callback: () => Promise<void>,
 ) {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input) => {
-    assert(input instanceof Request);
-    return handler(input);
+  globalThis.fetch = (async (input, init) => {
+    return handler(new Request(input, init));
   }) as typeof fetch;
 
   return callback().finally(() => {
@@ -91,6 +91,101 @@ void test("serializes Plex metadata ids through the generated SDK", async () => 
           Metadata: [{ ratingKey: "123" }],
         },
       });
+    },
+  );
+});
+
+void test("validates Plex PMS redirects before following them", async () => {
+  const requests: Request[] = [];
+
+  await withMockFetch(
+    (request) => {
+      requests.push(request);
+      if (request.url === "http://1.1.1.1:32400/identity") {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "http://[::ffff:127.0.0.1]:32400/identity",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${request.url}`);
+    },
+    async () => {
+      await assert.rejects(
+        () =>
+          requestPlexPmsIdentity(
+            {
+              baseUrl: "http://1.1.1.1:32400",
+              token: "server-token",
+            },
+            options,
+          ),
+        (error: unknown) =>
+          isApiError(error) &&
+          error.status === 400 &&
+          error.code === "plex_unsafe_redirect",
+      );
+
+      assert.deepEqual(
+        requests.map((request) => request.url),
+        ["http://1.1.1.1:32400/identity"],
+      );
+      assert.equal(requests[0]?.redirect, "manual");
+    },
+  );
+});
+
+void test("follows Plex PMS redirects to public targets without forwarding tokens", async () => {
+  const requests: Request[] = [];
+
+  await withMockFetch(
+    (request) => {
+      requests.push(request);
+      if (request.url === "http://1.1.1.1:32400/identity") {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "http://1.1.1.2:32400/identity",
+          },
+        });
+      }
+
+      if (request.url === "http://1.1.1.2:32400/identity") {
+        return jsonResponse({
+          MediaContainer: {
+            claimed: true,
+            machineIdentifier: "plex-server-1",
+            version: "1.41.0",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${request.url}`);
+    },
+    async () => {
+      const data = await requestPlexPmsIdentity(
+        {
+          baseUrl: "http://1.1.1.1:32400",
+          token: "server-token",
+        },
+        options,
+      );
+
+      assert.deepEqual(data, {
+        MediaContainer: {
+          claimed: true,
+          machineIdentifier: "plex-server-1",
+          version: "1.41.0",
+        },
+      });
+      assert.deepEqual(
+        requests.map((request) => request.url),
+        ["http://1.1.1.1:32400/identity", "http://1.1.1.2:32400/identity"],
+      );
+      assert.equal(requests[0]?.headers.get("X-Plex-Token"), "server-token");
+      assert.equal(requests[1]?.headers.get("X-Plex-Token"), null);
     },
   );
 });

--- a/apps/server/src/providers/plex/pmsClient.ts
+++ b/apps/server/src/providers/plex/pmsClient.ts
@@ -1,3 +1,5 @@
+import { lookup } from "dns/promises";
+import { isIP } from "net";
 import { createApiError, isApiError, type ApiError } from "@/http/errors";
 import { createClient } from "@/providers/plex/generated/client/client.gen";
 import type { Client } from "@/providers/plex/generated/client/types.gen";
@@ -6,7 +8,7 @@ import {
   libraryMetadataGetSlash,
   statusGetSlash,
 } from "@/providers/plex/generated/sdk.gen";
-import { errorMessage } from "@/providers/shared/utils";
+import { errorMessage, uniqueStrings } from "@/providers/shared/utils";
 
 export interface PlexPmsRequestContext {
   baseUrl: string;
@@ -37,6 +39,324 @@ interface PlexPmsResponseApiError extends ApiError {
   plexPmsStatusText: string;
 }
 
+const PLEX_PMS_MAX_REDIRECTS = 5;
+const DISALLOWED_PLEX_PMS_REDIRECT_HOSTNAMES = new Set([
+  "metadata",
+  "metadata.azure.internal",
+  "metadata.google.internal",
+]);
+
+function normalizeIpCandidate(value: string) {
+  const normalized = value.toLowerCase();
+  const unwrapped =
+    normalized.startsWith("[") && normalized.endsWith("]")
+      ? normalized.slice(1, -1)
+      : normalized;
+
+  const mappedIpv4Prefix = "::ffff:";
+  if (!unwrapped.startsWith(mappedIpv4Prefix)) {
+    return unwrapped;
+  }
+
+  return (
+    mappedIpv4Address(unwrapped.slice(mappedIpv4Prefix.length)) ?? unwrapped
+  );
+}
+
+function normalizeHostname(value: string) {
+  return normalizeIpCandidate(value.trim()).replace(/\.+$/, "");
+}
+
+function ipv4Octets(hostname: string) {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const octets = parts.map((part) => Number(part));
+  if (
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return undefined;
+  }
+
+  return octets as [number, number, number, number];
+}
+
+function mappedIpv4Address(hostname: string) {
+  const octets = ipv4Octets(hostname);
+  if (octets) {
+    return octets.join(".");
+  }
+
+  const words = hostname.split(":");
+  if (words.length !== 2) {
+    return undefined;
+  }
+
+  const parsedWords = words.map((word) => Number.parseInt(word, 16));
+  if (
+    words.some(
+      (word, index) =>
+        !/^[0-9a-f]{1,4}$/i.test(word) ||
+        !Number.isInteger(parsedWords[index]) ||
+        parsedWords[index] < 0 ||
+        parsedWords[index] > 0xffff,
+    )
+  ) {
+    return undefined;
+  }
+
+  const [high, low] = parsedWords as [number, number];
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  return host === "localhost" || host === "::1" || host.startsWith("127.");
+}
+
+function isUnspecifiedHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  return host === "0.0.0.0" || host === "::";
+}
+
+function isLinkLocalHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  return host.startsWith("169.254.") || /^fe[89ab][0-9a-f]:/i.test(host);
+}
+
+function isPrivateHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  const octets = ipv4Octets(host);
+  if (octets) {
+    const [first, second] = octets;
+    return (
+      first === 10 ||
+      (first === 100 && second >= 64 && second <= 127) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    );
+  }
+
+  return /^f[cd][0-9a-f]{2}:/i.test(host);
+}
+
+function isMulticastHost(hostname: string) {
+  const host = normalizeHostname(hostname);
+  if (/^ff[0-9a-f]{2}:/i.test(host)) {
+    return true;
+  }
+
+  const firstOctet = Number(host.split(".")[0]);
+  return Number.isInteger(firstOctet) && firstOctet >= 224 && firstOctet <= 239;
+}
+
+function assertHttpUrl(url: URL) {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw createApiError(
+      400,
+      "plex_unsafe_redirect",
+      "Plex PMS request URL must use HTTP or HTTPS",
+    );
+  }
+
+  if (url.username || url.password) {
+    throw createApiError(
+      400,
+      "plex_unsafe_redirect",
+      "Plex PMS request URL must not include embedded credentials",
+    );
+  }
+}
+
+function assertAllowedRedirectHostname(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    DISALLOWED_PLEX_PMS_REDIRECT_HOSTNAMES.has(normalized) ||
+    isLoopbackHost(normalized) ||
+    isUnspecifiedHost(normalized) ||
+    isLinkLocalHost(normalized) ||
+    isPrivateHost(normalized) ||
+    isMulticastHost(normalized)
+  ) {
+    throw createApiError(
+      400,
+      "plex_unsafe_redirect",
+      "Plex PMS redirect points at an unsafe internal address",
+    );
+  }
+}
+
+async function resolveHostnameAddresses(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  if (isIP(normalized)) {
+    return [];
+  }
+
+  try {
+    const records = await lookup(normalized, {
+      all: true,
+      verbatim: true,
+    });
+
+    return uniqueStrings(
+      records.map((record) => normalizeIpCandidate(record.address)),
+    );
+  } catch {
+    throw createApiError(
+      400,
+      "plex_unsafe_redirect",
+      "Plex PMS redirect hostname could not be resolved for security validation",
+    );
+  }
+}
+
+async function assertAllowedPlexPmsRequestUrl(
+  requestUrl: URL,
+  trustedOrigin: string,
+) {
+  assertHttpUrl(requestUrl);
+  if (requestUrl.origin === trustedOrigin) {
+    return;
+  }
+
+  assertAllowedRedirectHostname(requestUrl.hostname);
+
+  for (const address of await resolveHostnameAddresses(requestUrl.hostname)) {
+    assertAllowedRedirectHostname(address);
+  }
+}
+
+function isRedirectStatus(status: number) {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+async function reusableRequestBody(request: Request) {
+  if (request.method === "GET" || request.method === "HEAD" || !request.body) {
+    return undefined;
+  }
+
+  const contentType = (request.headers.get("content-type") ?? "").toLowerCase();
+  if (contentType.includes("json") || contentType.startsWith("text/")) {
+    return request.clone().text();
+  }
+
+  return request.clone().arrayBuffer();
+}
+
+async function closeRedirectResponse(response: Response) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Redirect response bodies are discarded before the next request.
+  }
+}
+
+function redirectUrl(location: string, requestUrl: URL) {
+  try {
+    return new URL(location, requestUrl);
+  } catch {
+    throw createApiError(
+      502,
+      "plex_invalid_redirect",
+      "Plex PMS returned an invalid redirect URL",
+    );
+  }
+}
+
+function updateRedirectRequest(
+  init: RequestInit,
+  response: Response,
+  nextUrl: URL,
+  currentUrl: URL,
+) {
+  const headers = new Headers(init.headers);
+  const method = String(init.method ?? "GET").toUpperCase();
+  const shouldSwitchToGet =
+    response.status === 303 ||
+    ((response.status === 301 || response.status === 302) && method === "POST");
+
+  if (nextUrl.origin !== currentUrl.origin) {
+    headers.delete("authorization");
+    headers.delete("cookie");
+    headers.delete("x-plex-token");
+  }
+
+  if (!shouldSwitchToGet) {
+    return {
+      ...init,
+      headers,
+    };
+  }
+
+  headers.delete("content-length");
+  headers.delete("content-type");
+
+  return {
+    ...init,
+    method: "GET",
+    headers,
+    body: undefined,
+  };
+}
+
+async function fetchPlexPmsWithManualRedirects(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) {
+  const request = new Request(input, init);
+  const trustedOrigin = new URL(request.url).origin;
+  let requestUrl = new URL(request.url);
+  let requestInit: RequestInit = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body: await reusableRequestBody(request),
+    signal: request.signal,
+  };
+
+  for (
+    let redirectCount = 0;
+    redirectCount <= PLEX_PMS_MAX_REDIRECTS;
+    redirectCount += 1
+  ) {
+    await assertAllowedPlexPmsRequestUrl(requestUrl, trustedOrigin);
+
+    const response = await globalThis.fetch(requestUrl.toString(), {
+      ...requestInit,
+      redirect: "manual",
+    });
+    const location = response.headers.get("location");
+    if (!isRedirectStatus(response.status) || !location) {
+      return response;
+    }
+
+    const nextUrl = redirectUrl(location, requestUrl);
+    requestInit = updateRedirectRequest(
+      requestInit,
+      response,
+      nextUrl,
+      requestUrl,
+    );
+    await closeRedirectResponse(response);
+    requestUrl = nextUrl;
+  }
+
+  throw createApiError(
+    502,
+    "plex_redirect_limit",
+    "Plex PMS request redirected too many times",
+  );
+}
+
 function createPlexPmsSdkClient(
   context: PlexPmsRequestContext,
   options: PlexPmsRequestOptions,
@@ -50,6 +370,7 @@ function createPlexPmsSdkClient(
       "X-Plex-Product": options.product,
       "X-Plex-Token": context.token,
     },
+    fetch: fetchPlexPmsWithManualRedirects,
     parseAs: "json",
     signal,
   });

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -136,11 +136,19 @@ export function shouldAttachProviderAuth(
 
 function normalizeIpCandidate(value: string) {
   const normalized = value.toLowerCase();
-  if (normalized.startsWith("[") && normalized.endsWith("]")) {
-    return normalized.slice(1, -1);
+  const unwrapped =
+    normalized.startsWith("[") && normalized.endsWith("]")
+      ? normalized.slice(1, -1)
+      : normalized;
+
+  const mappedIpv4Prefix = "::ffff:";
+  if (!unwrapped.startsWith(mappedIpv4Prefix)) {
+    return unwrapped;
   }
 
-  return normalized.startsWith("::ffff:") ? normalized.slice(7) : normalized;
+  return (
+    mappedIpv4Address(unwrapped.slice(mappedIpv4Prefix.length)) ?? unwrapped
+  );
 }
 
 function normalizeHostname(value: string) {
@@ -161,6 +169,34 @@ function ipv4Octets(hostname: string) {
   }
 
   return octets as [number, number, number, number];
+}
+
+function mappedIpv4Address(hostname: string) {
+  const octets = ipv4Octets(hostname);
+  if (octets) {
+    return octets.join(".");
+  }
+
+  const words = hostname.split(":");
+  if (words.length !== 2) {
+    return undefined;
+  }
+
+  const parsedWords = words.map((word) => Number.parseInt(word, 16));
+  if (
+    words.some(
+      (word, index) =>
+        !/^[0-9a-f]{1,4}$/i.test(word) ||
+        !Number.isInteger(parsedWords[index]) ||
+        parsedWords[index] < 0 ||
+        parsedWords[index] > 0xffff,
+    )
+  ) {
+    return undefined;
+  }
+
+  const [high, low] = parsedWords as [number, number];
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
 }
 
 function isUnsafeIpv4Host(hostname: string) {

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -323,6 +323,146 @@ void test("logs into Jellyfin with credentials and stores a remembered provider 
   });
 });
 
+void test("rejects Jellyfin credential-login redirects to loopback before connecting", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const upstreamRequests: Array<{ url: string; redirectMode: unknown }> = [];
+
+    await withMockedFetch(
+      async (input, init) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        upstreamRequests.push({
+          url: requestUrl,
+          redirectMode: init?.redirect,
+        });
+
+        if (requestUrl === "http://1.1.1.1:8096/jellyfin/System/Info/Public") {
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location: "http://127.0.0.1:8096/System/Info/Public",
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch: ${requestUrl}`);
+      },
+      async () => {
+        const response = await fetchLocal(
+          `${baseUrl}/api/providers/jellyfin/auth/login`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              serverUrl: "http://1.1.1.1:8096/jellyfin",
+              username: "admin",
+              password: "secret",
+            }),
+          },
+        );
+
+        assert.equal(response.status, 400);
+        const body = (await response.json()) as {
+          error?: { code?: string };
+        };
+        assert.equal(body.error?.code, "invalid_jellyfin_server_url");
+        assert.deepEqual(
+          upstreamRequests.map((request) => request.url),
+          ["http://1.1.1.1:8096/jellyfin/System/Info/Public"],
+        );
+        assert.equal(upstreamRequests[0]?.redirectMode, "manual");
+      },
+    );
+  });
+});
+
+void test("follows Jellyfin credential-login redirects to public targets", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const upstreamRequests: string[] = [];
+
+    await withMockedFetch(
+      async (input) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        upstreamRequests.push(requestUrl);
+
+        if (requestUrl === "http://1.1.1.1:8096/jellyfin/System/Info/Public") {
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location: "http://1.1.1.2:8096/jellyfin/System/Info/Public",
+            },
+          });
+        }
+
+        if (requestUrl === "http://1.1.1.2:8096/jellyfin/System/Info/Public") {
+          return jsonResponse({
+            Id: "jellyfin-server-1",
+            ServerName: "Jelly Lab",
+            ProductName: "Jellyfin",
+            Version: "10.9.0",
+          });
+        }
+
+        if (
+          requestUrl === "http://1.1.1.1:8096/jellyfin/Users/AuthenticateByName"
+        ) {
+          return jsonResponse({
+            AccessToken: "jellyfin-user-token",
+            ServerId: "jellyfin-server-1",
+            User: {
+              Id: "admin-user",
+              Name: "Admin",
+              Policy: {
+                IsAdministrator: true,
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch: ${requestUrl}`);
+      },
+      async () => {
+        const response = await fetchLocal(
+          `${baseUrl}/api/providers/jellyfin/auth/login`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              serverUrl: "http://1.1.1.1:8096/jellyfin",
+              username: "admin",
+              password: "secret",
+            }),
+          },
+        );
+
+        assert.equal(response.status, 200);
+        const body = (await response.json()) as {
+          session?: { providerId?: string };
+        };
+        assert.equal(body.session?.providerId, "jellyfin");
+        assert.deepEqual(upstreamRequests, [
+          "http://1.1.1.1:8096/jellyfin/System/Info/Public",
+          "http://1.1.1.2:8096/jellyfin/System/Info/Public",
+          "http://1.1.1.1:8096/jellyfin/Users/AuthenticateByName",
+        ]);
+      },
+    );
+  });
+});
+
 void test("updates sources across connected accounts and preserves Plex manual URL mode", async () => {
   await withTestApp(async (baseUrl, fetchLocal) => {
     const account = upsertProviderAccountByAccessToken({

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -344,7 +344,7 @@ void test("rejects Jellyfin credential-login redirects to loopback before connec
           return new Response(null, {
             status: 302,
             headers: {
-              location: "http://127.0.0.1:8096/System/Info/Public",
+              location: "http://[::ffff:127.0.0.1]:8096/System/Info/Public",
             },
           });
         }


### PR DESCRIPTION
## Summary

- disable automatic redirects for Jellyfin SDK and Plex PMS generated-client requests
- follow bounded redirect chains manually and validate every off-origin redirect target before connecting
- strip sensitive provider headers on cross-origin redirects and cover loopback, IPv4-mapped loopback, and public-to-public redirects in regressions

## Root Cause

Provider API clients validated or trusted the initial server URL/connection but let underlying fetch transports follow redirects automatically. Redirect targets were not revalidated before the next server-side request.

## Validation

- `pnpm preflight`
