### PR TITLE
fix(frontend): align dashboard card heights

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -70,6 +70,15 @@ function sessionActionLabel(
   return canEditSession(session) ? "Edit Clip" : "No stream";
 }
 
+const DASHBOARD_VIDEO_STYLE_CARD_CLASS =
+  "relative flex h-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left text-card-foreground";
+const DASHBOARD_VIDEO_STYLE_THUMBNAIL_CLASS =
+  "relative aspect-[2/3] w-full shrink-0 overflow-hidden bg-background";
+const DASHBOARD_VIDEO_STYLE_BODY_CLASS =
+  "flex flex-1 flex-col gap-3 p-3 md:p-4";
+const DASHBOARD_PLAYBACK_GRID_CLASS =
+  "grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3";
+
 function ViewerAvatar({
   name,
   avatarUrl,
@@ -158,16 +167,19 @@ export const DashboardPlaybackCard = memo(function DashboardPlaybackCard({
         }
       }}
       disabled={!canEdit}
-      className="group relative flex flex-col overflow-hidden rounded-lg border border-border bg-card text-left text-card-foreground transition-all hover:border-primary/50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border"
+      className={cn(
+        DASHBOARD_VIDEO_STYLE_CARD_CLASS,
+        "group transition-all hover:border-primary/50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border",
+      )}
     >
-      <div className="relative aspect-video w-full bg-background">
+      <div className={DASHBOARD_VIDEO_STYLE_THUMBNAIL_CLASS}>
         {mediaSession.thumbUrl ? (
           <img
             src={mediaSession.thumbUrl}
             alt={mediaSession.title}
-            className="h-full w-full object-cover opacity-80 transition-opacity group-hover:opacity-100"
-            width="640"
-            height="360"
+            className="absolute inset-0 h-full w-full object-cover opacity-80 transition-opacity group-hover:opacity-100"
+            width="2000"
+            height="3000"
             decoding="async"
             style={
               thumbnailViewTransitionName
@@ -178,7 +190,7 @@ export const DashboardPlaybackCard = memo(function DashboardPlaybackCard({
             }
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center">
+          <div className="absolute inset-0 flex h-full w-full items-center justify-center">
             <Video className="h-8 w-8 text-muted-foreground/50" />
           </div>
         )}
@@ -202,7 +214,7 @@ export const DashboardPlaybackCard = memo(function DashboardPlaybackCard({
           </h3>
         </div>
       </div>
-      <div className="flex flex-1 flex-col gap-3 p-3 md:p-4">
+      <div className={DASHBOARD_VIDEO_STYLE_BODY_CLASS}>
         <ViewerChip
           viewer={viewer}
           sessionCount={viewerSessionCount}
@@ -211,7 +223,7 @@ export const DashboardPlaybackCard = memo(function DashboardPlaybackCard({
         <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
           <span className="truncate">{mediaSession.playerTitle}</span>
         </div>
-        <div className="flex w-full items-center justify-center rounded-lg bg-primary/10 py-2 text-sm font-medium text-primary transition-colors group-hover:bg-primary group-hover:text-primary-foreground">
+        <div className="mt-auto flex w-full items-center justify-center rounded-lg bg-primary/10 py-2 text-sm font-medium text-primary transition-colors group-hover:bg-primary group-hover:text-primary-foreground">
           {sessionActionLabel(mediaSession)}
         </div>
       </div>
@@ -223,23 +235,32 @@ function DashboardPlaybackCardSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "flex flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground",
+        DASHBOARD_VIDEO_STYLE_CARD_CLASS,
+        "animate-pulse",
         className,
       )}
       aria-hidden="true"
       data-dashboard-playback-skeleton
     >
-      <div className="aspect-video w-full bg-background" />
-      <div className="flex flex-1 flex-col gap-3 p-3 md:p-4">
+      <div className={DASHBOARD_VIDEO_STYLE_THUMBNAIL_CLASS}>
+        <div className="absolute inset-0 h-full w-full bg-muted/60" />
+        <div className="absolute inset-0 bg-linear-to-t from-card via-card/35 to-transparent" />
+        <div className="absolute top-3 left-3 h-6 w-36 rounded-full bg-card/90 shadow-sm" />
+        <div className="absolute right-3 bottom-3 left-3">
+          <div className="mb-2 h-3 w-16 rounded bg-primary/20" />
+          <div className="h-6 w-4/5 rounded bg-muted" />
+        </div>
+      </div>
+      <div className={DASHBOARD_VIDEO_STYLE_BODY_CLASS}>
         <div className="flex min-w-0 items-center gap-2.5">
-          <div className="h-8 w-8 shrink-0 rounded-full bg-background" />
+          <div className="h-8 w-8 shrink-0 rounded-full bg-primary/10" />
           <div className="min-w-0 flex-1 space-y-2">
-            <div className="h-3 w-28 rounded bg-background" />
-            <div className="h-2.5 w-36 rounded bg-background" />
+            <div className="h-4 w-28 rounded bg-muted" />
+            <div className="h-3 w-36 rounded bg-muted/70" />
           </div>
         </div>
-        <div className="h-4 w-24 rounded bg-background" />
-        <div className="h-9 w-full rounded-lg bg-primary/10" />
+        <div className="h-5 w-24 rounded bg-muted/70" />
+        <div className="mt-auto h-9 w-full rounded-lg bg-primary/10" />
       </div>
     </div>
   );
@@ -518,7 +539,10 @@ export default function DashboardScreen({
 
           {loading && !error && (
             <div
-              className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3"
+              role="status"
+              aria-live="polite"
+              aria-label="Loading currently playing sessions"
+              className={DASHBOARD_PLAYBACK_GRID_CLASS}
               data-dashboard-loading-grid
             >
               <DashboardPlaybackCardSkeleton />
@@ -528,7 +552,7 @@ export default function DashboardScreen({
           )}
 
           {!loading && hasPlaybackCards && (
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3">
+            <div className={DASHBOARD_PLAYBACK_GRID_CLASS}>
               {playbackCards.map((card) => (
                 <DashboardPlaybackCard
                   key={card.session.id}

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -77,6 +77,33 @@ const dashboardPlaybackGroups: ViewerPlaybackGroup[] = [
   },
 ];
 
+const dashboardMusicPlaybackGroups: ViewerPlaybackGroup[] = [
+  {
+    viewer: {
+      id: "viewer-music",
+      providerId: "plex",
+      name: "Music Listener",
+    },
+    items: [
+      {
+        id: "session-music",
+        source: {
+          id: "source-music",
+          name: "Plex",
+          providerId: "plex",
+        },
+        title: "A Square Album Cover",
+        type: "track",
+        duration: 240,
+        playerTitle: "Office Speaker",
+        playerState: "playing",
+        thumbUrl: "/api/media/music-thumb.jpg",
+        hlsUrl: "/api/media/music.m3u8",
+      },
+    ],
+  },
+];
+
 function restoreGlobalProperty(
   name: string,
   descriptor: PropertyDescriptor | undefined,
@@ -282,7 +309,11 @@ void test("reserves dashboard playback card space before sessions load", () => {
   );
 
   assert.match(markup, /data-dashboard-loading-grid/);
+  assert.match(markup, /role="status"/);
+  assert.match(markup, /aria-live="polite"/);
+  assert.match(markup, /aria-label="Loading currently playing sessions"/);
   assert.match(markup, /data-dashboard-playback-skeleton/);
+  assert.match(markup, /aspect-\[2\/3\]/);
 });
 
 void test("reserves dashboard version badge space before health loads", () => {
@@ -343,6 +374,30 @@ void test("renders dashboard playback cards with viewer context", () => {
   assert.match(markup, /playing/);
   assert.match(markup, /1 active session/);
   assert.match(markup, /Living Room/);
+  assert.match(markup, /aspect-\[2\/3\]/);
+  assert.match(markup, /mt-auto/);
+});
+
+void test("renders music playback cards inside the video-style card frame", () => {
+  const card = flattenDashboardPlaybackItems(dashboardMusicPlaybackGroups)[0];
+  assert.ok(card);
+
+  const markup = renderToStaticMarkup(
+    createElement(DashboardPlaybackCard, {
+      card,
+      activeViewTransitionSessionId: null,
+      onSelectSession: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /A Square Album Cover/);
+  assert.match(markup, /TRACK/);
+  assert.match(
+    markup,
+    /relative aspect-\[2\/3\] w-full shrink-0 overflow-hidden/,
+  );
+  assert.match(markup, /absolute inset-0 h-full w-full object-cover/);
+  assert.match(markup, /mt-auto/);
 });
 
 void test("renders the editor thumbnail behind loading preview state", () => {


### PR DESCRIPTION
## Summary
- Use the normal Plex video/poster card thumbnail frame as the shared dashboard card reference: a 2:3 frame matching the observed 328.664x492.992 desktop thumbnail size.
- Keep skeleton cards and rendered playback cards on the same shared card structure so loading state matches the final card location and sizing.
- Crop square music artwork into the same 2:3 frame and keep Edit Clip bottom-aligned so music cards no longer render shorter or place the action higher.

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm preflight
- Browser check with mocked 2000x3000 Plex-style video art + square music art: both wide-desktop thumbnail frames measured 328.664x492.992 and both Edit Clip actions shared the same position.