### PR TITLE
fix(server): proxy Plex viewer avatars

### DIFF
--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -1100,7 +1100,20 @@ function playbackSessionIdentity(item: PlexMetadataItem) {
   );
 }
 
+export function createPlexViewerAvatarUrl(
+  session: ProviderSessionRecord,
+  context: PlexSourceContext,
+  item: PlexMetadataItem,
+) {
+  const avatarPath = stringValue(item?.User?.thumb);
+  return avatarPath
+    ? createMediaHandle(session, context, avatarPath)
+    : undefined;
+}
+
 function playbackViewer(
+  session: ProviderSessionRecord,
+  context: PlexSourceContext,
   item: PlexMetadataItem,
   sourceId: string,
   sessionId: string,
@@ -1113,7 +1126,7 @@ function playbackViewer(
     providerId: "plex" as const,
     externalId,
     name: stringValue(item?.User?.title) ?? "Unknown User",
-    avatarUrl: stringValue(item?.User?.thumb),
+    avatarUrl: createPlexViewerAvatarUrl(session, context, item),
   };
 }
 
@@ -1270,7 +1283,7 @@ async function normalizeCurrentPlayback(
       }
 
       return {
-        viewer: playbackViewer(item, source.id, sessionId),
+        viewer: playbackViewer(session, context, item, source.id, sessionId),
         item: {
           id: `${source.id}:${sessionId}`,
           source: {

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { ProviderSessionRecord } from "@/session/store";
 import {
   createCliparrPlexTranscodeSessionId,
+  createPlexViewerAvatarUrl,
   createPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
@@ -144,6 +145,24 @@ void test("creates a direct content URL for Plex sidecar text subtitle streams",
   );
   assert.equal(tracks[0]?.contentFormat, "srt");
   assert.equal(onlyMediaHandle(session).path, "/library/streams/101.srt");
+});
+
+void test("proxies Plex viewer avatar URLs through provider media handles", () => {
+  const session = createSession();
+  const context = createContext();
+  const item = {
+    User: {
+      id: "user-1",
+      title: "Alice",
+      thumb: "https://plex.tv/users/user-1/avatar?c=123",
+    },
+  };
+
+  const avatarUrl = createPlexViewerAvatarUrl(session, context, item);
+  const handle = onlyMediaHandle(session);
+
+  assert.equal(avatarUrl, `/api/media/${handle.id}`);
+  assert.equal(handle.path, "https://plex.tv/users/user-1/avatar?c=123");
 });
 
 void test("creates a subtitle transcode content URL for the selected embedded Plex text subtitle", () => {


### PR DESCRIPTION
## Summary
- Proxy Plex viewer avatar URLs through provider media handles before returning currently playing viewers.
- Keep the original plex.tv avatar URL in the handle so the server follows Plex redirects and returns same-origin /api/media URLs under cross-origin isolation.

## Validation
- pnpm preflight