### PR TITLE
feat(cliparr): add editable subtitle timeline

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -41,9 +41,11 @@ flowchart TD
     K --> C2
 
     D --> D1["timelineZoom helpers"]
+    D --> D2["editable subtitle cue timeline actions"]
     E --> E1["editorShortcutCommands"]
     J --> J1["useSubtitleCues"]
     J --> J2["selectPreferredSubtitleTrack"]
+    J --> J3["editable subtitle cue state"]
 
     F["SourcesDialog"] --> F1["useSourcesState"]
     F1 --> F2["sourcesStateUtils"]
@@ -286,7 +288,7 @@ flowchart TD
     C -- "Yes" --> D["Attach provider auth/session headers"]
     C -- "No" --> E["Do not attach provider auth headers"]
 
-    D --> F{"Range request or not HLS-derived?"}
+    D --> F{"Range request for non-HLS handle?"}
     E --> F
 
     F -- "Yes" --> G["Fetch upstream with retry policy"]
@@ -297,7 +299,7 @@ flowchart TD
     G5 --> G1
     G1 -- "Yes" --> G2["Rewrite playlist and send response"]
     G1 -- "No" --> G3["Stream response body directly"]
-    F -- "No" --> H["Build short-lived cache key"]
+    F -- "No" --> H["Strip Range for HLS playlists/segments and build short-lived cache key"]
     H --> I{"Cached response exists?"}
     I -- "Yes" --> J["Serve cached response"]
     I -- "No" --> K{"Matching in-flight response exists?"}
@@ -369,9 +371,12 @@ flowchart LR
     D --> P["Preview canvas with optional subtitles"]
     P --> Q["Framegrab dialog"]
     Q --> R["PNG clipboard or image download"]
-    S --> T["useEditorSubtitles loads and clips subtitle cues"]
-    T --> P
-    T --> U["Export subtitle burn-in readiness"]
+    S --> T["useEditorSubtitles loads whole-file subtitle cues"]
+    T --> T1["editable in-memory subtitle cue list"]
+    T1 --> T2["EditorTimeline subtitle row"]
+    T2 --> T1
+    T1 --> P
+    T1 --> U["Export subtitle burn-in readiness"]
     B --> G["useEditorExport source selection"]
     C --> G
     F --> G

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -65,10 +65,27 @@ interface Props {
 }
 
 export default function EditorScreen({ session, onBack }: Props) {
-  const initialClipRange = buildInitialClipRange(
-    session.duration,
-    session.initialPlayheadSeconds,
-  );
+  const initialSessionRef = useRef<{
+    sessionId: string;
+    duration: number;
+    clipRange: ReturnType<typeof buildInitialClipRange>;
+  } | null>(null);
+  if (
+    !initialSessionRef.current ||
+    initialSessionRef.current.sessionId !== session.id ||
+    (initialSessionRef.current.duration <= 0 && session.duration > 0)
+  ) {
+    initialSessionRef.current = {
+      sessionId: session.id,
+      duration: Math.max(session.duration, 0),
+      clipRange: buildInitialClipRange(
+        session.duration,
+        session.initialPlayheadSeconds,
+      ),
+    };
+  }
+  const initialDuration = initialSessionRef.current.duration;
+  const initialClipRange = initialSessionRef.current.clipRange;
   const [startTime, setStartTime] = useState(() => initialClipRange.startTime);
   const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
@@ -91,9 +108,14 @@ export default function EditorScreen({ session, onBack }: Props) {
     subtitleLoading,
     subtitleError,
     subtitlePreviewEnabled,
+    selectedSubtitleCue,
+    selectedSubtitleCueId,
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    handleSubtitleCueSelect,
+    handleSubtitleCueTextChange,
+    handleSubtitleCueRangeChange,
   } = useEditorSubtitles({
     session,
     startTime,
@@ -132,7 +154,7 @@ export default function EditorScreen({ session, onBack }: Props) {
   } = useEditorPlayback({
     hlsSource: session.hlsSource,
     directSource: session.directSource,
-    initialDuration: session.duration,
+    initialDuration,
     initialCurrentTime: initialClipRange.startTime,
     startTime,
     endTime,
@@ -359,6 +381,15 @@ export default function EditorScreen({ session, onBack }: Props) {
     },
     [duration, frameStepSeconds, getPlaybackTime, pausePlayback, seekToTime],
   );
+  const handleTimelineSubtitleCueSelect = useCallback(
+    (cueId: string | null) => {
+      handleSubtitleCueSelect(cueId);
+      if (cueId) {
+        setPlaybackSidebarOpen(true);
+      }
+    },
+    [handleSubtitleCueSelect],
+  );
   const {
     timelineRef,
     timelineWheelRegionRef,
@@ -386,6 +417,11 @@ export default function EditorScreen({ session, onBack }: Props) {
     onClipRangeCommit: (nextStart, nextEnd) => {
       void warmClipSelection(nextStart, nextEnd);
     },
+    subtitleCues,
+    selectedSubtitleCueId,
+    showSubtitleRow: subtitleEnabled && selectedSubtitleTrack !== null,
+    subtitleLoading,
+    onSubtitleCueRangeChange: handleSubtitleCueRangeChange,
   });
 
   useEffect(() => {
@@ -465,7 +501,9 @@ export default function EditorScreen({ session, onBack }: Props) {
   const headerExportDisabledReason = durationExportDisabledReason;
   const layoutVariant = isDesktopLayout ? "desktop" : "mobile";
   const propertiesActive =
-    previewSourceLabel === "Direct source" || Boolean(playbackFallbackReason);
+    previewSourceLabel === "Direct source" ||
+    Boolean(playbackFallbackReason) ||
+    Boolean(selectedSubtitleCue);
   const previewPane = (
     <EditorPreviewPane
       error={isDesktopLayout ? error : null}
@@ -521,6 +559,7 @@ export default function EditorScreen({ session, onBack }: Props) {
       activeTimelineScale={activeTimelineScale}
       timelineScaleCount={timelineScaleCount}
       playbackReadyRange={isHlsPreviewSource ? playbackReadyRange : null}
+      subtitleCues={subtitleCues}
       loadingPreview={loadingPreview}
       playing={playing}
       handleTimelineScroll={handleTimelineScroll}
@@ -529,6 +568,7 @@ export default function EditorScreen({ session, onBack }: Props) {
       handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
       isValidTimelineRange={isValidTimelineRange}
       seekToTime={seekToTime}
+      onSubtitleCueSelect={handleTimelineSubtitleCueSelect}
       onCursorDragStart={() => {
         if (playing) {
           pausePlayback();
@@ -576,6 +616,10 @@ export default function EditorScreen({ session, onBack }: Props) {
           subtitleLoading={subtitleLoading}
           subtitleError={subtitleError}
           selectedSubtitleTrack={selectedSubtitleTrack}
+          selectedSubtitleCue={selectedSubtitleCue}
+          duration={duration}
+          onSubtitleCueTextChange={handleSubtitleCueTextChange}
+          onSubtitleCueRangeChange={handleSubtitleCueRangeChange}
         />
       </div>
     );
@@ -763,7 +807,7 @@ function buildPlaybackFallbackReason({
   const prefix =
     hlsFallbackInfo.category === "preview-only"
       ? "Preview switched sources"
-      : "Using direct media";
+      : "HLS preview failed; using direct media";
 
   return `${prefix}: ${hlsFallbackInfo.message}`;
 }

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -31,6 +31,15 @@ import {
   editorPropertyLabelClassName,
   editorPropertySelectTriggerClassName,
 } from "@/components/editor/EditorPropertyControls";
+import { EditorEditableTimecode } from "@/components/editor/EditorEditableTimecode";
+import {
+  formatTimecodeInput,
+  roundTimelineTime,
+} from "@/components/editor/editorUtils";
+import type {
+  EditableSubtitleCue,
+  SubtitleCueRangeUpdate,
+} from "@/components/editor/editorSubtitleCues";
 import { useSubtitleFontOptions } from "@/components/editor/useSubtitleFontOptions";
 
 interface EditorSubtitlePanelProps {
@@ -47,6 +56,13 @@ interface EditorSubtitlePanelProps {
   subtitleLoading: boolean;
   subtitleError: string | null;
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  selectedSubtitleCue: EditableSubtitleCue | null;
+  duration: number;
+  onSubtitleCueTextChange: (cueId: string, text: string) => void;
+  onSubtitleCueRangeChange: (
+    updates: readonly SubtitleCueRangeUpdate[],
+    duration: number,
+  ) => void;
 }
 
 function subtitleTrackLabel(track: PlaybackSubtitleTrack) {
@@ -87,6 +103,10 @@ export function EditorSubtitlePanel({
   subtitleLoading,
   subtitleError,
   selectedSubtitleTrack,
+  selectedSubtitleCue,
+  duration,
+  onSubtitleCueTextChange,
+  onSubtitleCueRangeChange,
 }: EditorSubtitlePanelProps) {
   const canEnableBurnIn = subtitleTrackSupportsBurnIn(selectedSubtitleTrack);
   const styleControlsDisabled = !subtitlesEnabled || !canEnableBurnIn;
@@ -122,6 +142,23 @@ export function EditorSubtitlePanel({
       ...current,
       [key]: value,
     }));
+  }
+
+  function updateCueRange(
+    cue: EditableSubtitleCue,
+    startTime: number,
+    endTime: number,
+  ) {
+    onSubtitleCueRangeChange(
+      [
+        {
+          cueId: cue.id,
+          startTime,
+          endTime,
+        },
+      ],
+      duration,
+    );
   }
 
   const subtitleToggle = (
@@ -230,6 +267,72 @@ export function EditorSubtitlePanel({
         )}
       </EditorPropertySection>
 
+      {selectedSubtitleCue && (
+        <EditorPropertySection
+          title="Cue"
+          action={
+            <span className={editorPropertyLabelClassName()}>
+              {formatTimecodeInput(
+                roundTimelineTime(
+                  selectedSubtitleCue.endTime - selectedSubtitleCue.startTime,
+                ),
+              )}
+            </span>
+          }
+        >
+          <EditorPropertyRow label="Text" align="start">
+            <textarea
+              aria-label="Subtitle cue text"
+              className="min-h-24 w-full resize-y rounded-[var(--radius-control)] border border-editor-border bg-editor-control px-2.5 py-2 text-sm leading-5 text-sidebar-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-editor-accent focus:ring-2 focus:ring-editor-accent/35"
+              onChange={(event) =>
+                onSubtitleCueTextChange(
+                  selectedSubtitleCue.id,
+                  event.target.value,
+                )
+              }
+              spellCheck
+              value={selectedSubtitleCue.text}
+            />
+          </EditorPropertyRow>
+
+          <CueTimecodeControl
+            label="Start"
+            value={selectedSubtitleCue.startTime}
+            onCommit={(value) =>
+              updateCueRange(
+                selectedSubtitleCue,
+                value,
+                selectedSubtitleCue.endTime,
+              )
+            }
+          />
+          <CueTimecodeControl
+            label="End"
+            value={selectedSubtitleCue.endTime}
+            onCommit={(value) =>
+              updateCueRange(
+                selectedSubtitleCue,
+                selectedSubtitleCue.startTime,
+                value,
+              )
+            }
+          />
+          <CueTimecodeControl
+            label="Duration"
+            value={roundTimelineTime(
+              selectedSubtitleCue.endTime - selectedSubtitleCue.startTime,
+            )}
+            onCommit={(value) =>
+              updateCueRange(
+                selectedSubtitleCue,
+                selectedSubtitleCue.startTime,
+                selectedSubtitleCue.startTime + value,
+              )
+            }
+          />
+        </EditorPropertySection>
+      )}
+
       <div
         aria-disabled={styleControlsDisabled}
         className={cn(
@@ -238,7 +341,7 @@ export function EditorSubtitlePanel({
         )}
       >
         <EditorPropertySection
-          title="Text"
+          title="Track text"
           action={
             styleTooltip ? (
               <Tooltip>
@@ -324,7 +427,7 @@ export function EditorSubtitlePanel({
           />
         </EditorPropertySection>
 
-        <EditorPropertySection title="Shadow">
+        <EditorPropertySection title="Track shadow">
           <EditorColorControl
             label="Color"
             value={subtitleStyleSettings.shadowColor}
@@ -353,7 +456,7 @@ export function EditorSubtitlePanel({
           />
         </EditorPropertySection>
 
-        <EditorPropertySection title="Stroke">
+        <EditorPropertySection title="Track stroke">
           <EditorColorControl
             label="Color"
             value={subtitleStyleSettings.strokeColor}
@@ -372,7 +475,7 @@ export function EditorSubtitlePanel({
           />
         </EditorPropertySection>
 
-        <EditorPropertySection title="Position">
+        <EditorPropertySection title="Track position">
           <EditorRangeControl
             label="Bottom"
             value={subtitleStyleSettings.bottomMargin}
@@ -386,5 +489,33 @@ export function EditorSubtitlePanel({
         </EditorPropertySection>
       </div>
     </div>
+  );
+}
+
+function CueTimecodeControl({
+  label,
+  value,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  onCommit: (value: number) => void;
+}) {
+  return (
+    <EditorPropertyRow label={label}>
+      <EditorEditableTimecode
+        ariaLabel={`subtitle cue ${label.toLowerCase()}`}
+        buttonClassName="h-8 w-full rounded-[var(--radius-control)] border border-editor-border bg-editor-control px-2.5 text-xs font-medium text-sidebar-foreground shadow-none hover:bg-editor-control-hover"
+        className="w-full"
+        inputClassName="w-full rounded-[var(--radius-control)] text-xs"
+        inputWidth="100%"
+        onCommit={onCommit}
+        value={value}
+      >
+        <span className="font-mono tabular-nums">
+          {formatTimecodeInput(value)}
+        </span>
+      </EditorEditableTimecode>
+    </EditorPropertyRow>
   );
 }

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { CSSProperties, RefObject } from "react";
-import { Scissors } from "lucide-react";
+import { Captions, LoaderCircle, Scissors } from "lucide-react";
 import type { PlaybackReadyRange } from "@/components/editor/useEditorPlayback";
 import { isPlaybackReadyRangeVisible } from "@/components/editor/editorPlaybackWarmupRange";
 import {
@@ -14,6 +14,12 @@ import {
   type ClipTimelineAction,
   type TimelineZoomLevel,
 } from "@/components/editor/editorUtils";
+import {
+  SUBTITLE_LOADING_ACTION_ID,
+  subtitleCueActionId,
+  subtitleCueIdFromActionId,
+  type EditableSubtitleCue,
+} from "@/components/editor/editorSubtitleCues";
 
 interface EditorTimelineProps {
   timelineRef: RefObject<TimelineState | null>;
@@ -23,6 +29,7 @@ interface EditorTimelineProps {
   activeTimelineScale: TimelineZoomLevel;
   timelineScaleCount: number;
   playbackReadyRange: PlaybackReadyRange | null;
+  subtitleCues: readonly EditableSubtitleCue[];
   loadingPreview: boolean;
   playing: boolean;
   handleTimelineScroll: (data: { scrollLeft: number }) => void;
@@ -39,6 +46,7 @@ interface EditorTimelineProps {
   }) => void;
   isValidTimelineRange: (start: number, end: number) => boolean;
   seekToTime: (time: number) => Promise<void> | void;
+  onSubtitleCueSelect: (cueId: string | null) => void;
   onCursorDragStart: () => void;
   onCursorDrag: (time: number) => void;
 }
@@ -51,6 +59,7 @@ export function EditorTimeline({
   activeTimelineScale,
   timelineScaleCount,
   playbackReadyRange,
+  subtitleCues,
   loadingPreview,
   playing,
   handleTimelineScroll,
@@ -59,9 +68,19 @@ export function EditorTimeline({
   handleTimelineActionResizeEnd,
   isValidTimelineRange,
   seekToTime,
+  onSubtitleCueSelect,
   onCursorDragStart,
   onCursorDrag,
 }: EditorTimelineProps) {
+  const subtitlePreviewTextByActionId = useMemo(() => {
+    return new Map(
+      subtitleCues.map((cue) => {
+        const previewText = cue.lines.join(" ").trim() || "Empty subtitle";
+        return [subtitleCueActionId(cue.id), previewText] as const;
+      }),
+    );
+  }, [subtitleCues]);
+
   const getReadyFillStyle = useCallback(
     (action: ClipTimelineAction): CSSProperties | null => {
       if (
@@ -98,6 +117,30 @@ export function EditorTimeline({
 
   const renderClipTimelineAction = useCallback(
     (action: ClipTimelineAction) => {
+      if (action.effectId === "subtitle-placeholder") {
+        return (
+          <div className="cliparr-timeline-action-content cliparr-timeline-subtitle-placeholder">
+            <span className="cliparr-timeline-action-label">
+              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              Loading subtitles
+            </span>
+          </div>
+        );
+      }
+
+      if (action.effectId === "subtitle") {
+        return (
+          <div className="cliparr-timeline-action-content cliparr-timeline-subtitle-content">
+            <span className="cliparr-timeline-action-label cliparr-timeline-subtitle-label">
+              <Captions className="h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0 truncate">
+                {subtitlePreviewTextByActionId.get(action.id) ?? "Subtitle cue"}
+              </span>
+            </span>
+          </div>
+        );
+      }
+
       const isSource = action.effectId === "source";
       const readyFillStyle = getReadyFillStyle(action);
 
@@ -118,7 +161,19 @@ export function EditorTimeline({
         </div>
       );
     },
-    [getReadyFillStyle, playbackReadyRange],
+    [getReadyFillStyle, playbackReadyRange, subtitlePreviewTextByActionId],
+  );
+
+  const selectSubtitleTimelineAction = useCallback(
+    (action: { id: string; effectId?: string }) => {
+      if (action.effectId !== "subtitle") {
+        onSubtitleCueSelect(null);
+        return;
+      }
+
+      onSubtitleCueSelect(subtitleCueIdFromActionId(action.id));
+    },
+    [onSubtitleCueSelect],
   );
 
   return (
@@ -142,9 +197,16 @@ export function EditorTimeline({
         onChange={handleTimelineChange}
         onActionMoving={({ start, end }) => isValidTimelineRange(start, end)}
         onActionResizing={({ start, end }) => isValidTimelineRange(start, end)}
+        onActionMoveStart={({ action }) => {
+          selectSubtitleTimelineAction(action);
+        }}
+        onActionResizeStart={({ action }) => {
+          selectSubtitleTimelineAction(action);
+        }}
         onActionMoveEnd={handleTimelineActionMoveEnd}
         onActionResizeEnd={handleTimelineActionResizeEnd}
         onClickTimeArea={(time) => {
+          onSubtitleCueSelect(null);
           void seekToTime(time);
           return false;
         }}
@@ -156,9 +218,13 @@ export function EditorTimeline({
             return;
           }
 
+          onSubtitleCueSelect(null);
           void seekToTime(time);
         }}
-        onClickActionOnly={(_, { time }) => {
+        onClickActionOnly={(_, { action, time }) => {
+          if (action.id !== SUBTITLE_LOADING_ACTION_ID) {
+            selectSubtitleTimelineAction(action);
+          }
           void seekToTime(time);
         }}
         onCursorDragStart={onCursorDragStart}

--- a/apps/frontend/src/components/editor/editorSubtitleCues.test.ts
+++ b/apps/frontend/src/components/editor/editorSubtitleCues.test.ts
@@ -1,0 +1,148 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SUBTITLE_LOADING_ACTION_ID,
+  buildSubtitleTimelineActions,
+  clampSubtitleCueRange,
+  normalizeEditableSubtitleCues,
+  subtitleCueActionId,
+  subtitleCueIdFromActionId,
+  subtitleCueTextToLines,
+  updateEditableSubtitleCueRanges,
+  updateEditableSubtitleCueText,
+} from "@/components/editor/editorSubtitleCues";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+
+const importedCues = [
+  {
+    id: "1",
+    startTime: 2.004,
+    endTime: 4.006,
+    text: "Hello\r\nworld",
+    lines: ["Hello", "world"],
+  },
+  {
+    startTime: 5,
+    endTime: 6,
+    text: "Second cue",
+    lines: ["Second cue"],
+  },
+] satisfies SubtitleCue[];
+
+void test("normalizes imported subtitles into stable editable cues", () => {
+  const cues = normalizeEditableSubtitleCues(importedCues);
+
+  assert.equal(cues.length, 2);
+  assert.equal(cues[0]?.id, "cue-1-1-2.00-4.01");
+  assert.equal(cues[0]?.startTime, 2);
+  assert.equal(cues[0]?.endTime, 4.01);
+  assert.equal(cues[0]?.text, "Hello\nworld");
+  assert.deepEqual(cues[0]?.lines, ["Hello", "world"]);
+  assert.equal(cues[1]?.id, "cue-2-cue-5.00-6.00");
+});
+
+void test("derives visible subtitle lines from edited text", () => {
+  assert.deepEqual(subtitleCueTextToLines("  Hello  \n\n world "), [
+    "Hello",
+    "world",
+  ]);
+  assert.deepEqual(subtitleCueTextToLines("   \n"), []);
+});
+
+void test("updates cue text while preserving timing and id", () => {
+  const cues = normalizeEditableSubtitleCues(importedCues);
+  const updated = updateEditableSubtitleCueText(
+    cues,
+    cues[0]?.id ?? "",
+    "Edited\r\n\nsubtitle",
+  );
+
+  assert.notEqual(updated, cues);
+  assert.equal(updated[0]?.id, cues[0]?.id);
+  assert.equal(updated[0]?.startTime, cues[0]?.startTime);
+  assert.equal(updated[0]?.text, "Edited\n\nsubtitle");
+  assert.deepEqual(updated[0]?.lines, ["Edited", "subtitle"]);
+});
+
+void test("clamps subtitle cue timing to media duration and minimum length", () => {
+  assert.deepEqual(
+    clampSubtitleCueRange({
+      startTime: -1,
+      endTime: 0.02,
+      duration: 10,
+    }),
+    {
+      startTime: 0,
+      endTime: 0.1,
+    },
+  );
+
+  assert.deepEqual(
+    clampSubtitleCueRange({
+      startTime: 9.98,
+      endTime: 12,
+      duration: 10,
+    }),
+    {
+      startTime: 9.9,
+      endTime: 10,
+    },
+  );
+});
+
+void test("updates cue timing from timeline actions and keeps cues sorted", () => {
+  const cues = normalizeEditableSubtitleCues(importedCues);
+  const updated = updateEditableSubtitleCueRanges(
+    cues,
+    [
+      {
+        cueId: cues[1]?.id ?? "",
+        startTime: 0.5,
+        endTime: 1.5,
+      },
+    ],
+    10,
+  );
+
+  assert.equal(updated[0]?.id, cues[1]?.id);
+  assert.equal(updated[0]?.startTime, 0.5);
+  assert.equal(updated[0]?.endTime, 1.5);
+  assert.equal(updated[1]?.id, cues[0]?.id);
+});
+
+void test("builds subtitle timeline actions with selection and loading states", () => {
+  const cues = normalizeEditableSubtitleCues(importedCues);
+  const actions = buildSubtitleTimelineActions({
+    cues,
+    duration: 10,
+    selectedCueId: cues[0]?.id ?? null,
+    loading: false,
+  });
+
+  assert.equal(actions[0]?.id, subtitleCueActionId(cues[0]?.id ?? ""));
+  assert.equal(subtitleCueIdFromActionId(actions[0]?.id ?? ""), cues[0]?.id);
+  assert.equal(actions[0]?.effectId, "subtitle");
+  assert.equal(actions[0]?.selected, true);
+  assert.equal(actions[1]?.selected, false);
+
+  const loadingActions = buildSubtitleTimelineActions({
+    cues: [],
+    duration: 10,
+    selectedCueId: null,
+    loading: true,
+  });
+  assert.deepEqual(loadingActions, [
+    {
+      id: SUBTITLE_LOADING_ACTION_ID,
+      start: 0,
+      end: 10,
+      effectId: "subtitle-placeholder",
+      flexible: false,
+      movable: false,
+      minStart: 0,
+      maxEnd: 10,
+    },
+  ]);
+});

--- a/apps/frontend/src/components/editor/editorSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/editorSubtitleCues.ts
@@ -1,0 +1,232 @@
+import {
+  MIN_CLIP_SECONDS,
+  roundTimelineTime,
+  type ClipTimelineAction,
+} from "@/components/editor/editorUtils";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+
+export interface EditableSubtitleCue extends SubtitleCue {
+  id: string;
+}
+
+export interface SubtitleCueRangeUpdate {
+  cueId: string;
+  startTime: number;
+  endTime: number;
+}
+
+const SUBTITLE_TIMELINE_ACTION_PREFIX = "subtitle-cue:";
+export const SUBTITLE_LOADING_ACTION_ID = "subtitle-loading";
+
+function sanitizeCueId(value: string) {
+  return value.replace(/[^a-zA-Z0-9_.:-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function stableSubtitleCueId(cue: SubtitleCue, index: number) {
+  const sourceId = sanitizeCueId(cue.id?.trim() || "cue");
+  const start = roundTimelineTime(cue.startTime).toFixed(2);
+  const end = roundTimelineTime(cue.endTime).toFixed(2);
+
+  return sanitizeCueId(`cue-${index + 1}-${sourceId}-${start}-${end}`).slice(
+    0,
+    96,
+  );
+}
+
+function sortedSubtitleCues(cues: readonly EditableSubtitleCue[]) {
+  return [...cues].sort(
+    (left, right) =>
+      left.startTime - right.startTime ||
+      left.endTime - right.endTime ||
+      left.id.localeCompare(right.id),
+  );
+}
+
+export function subtitleCueTextToLines(text: string) {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function normalizeEditableSubtitleCues(
+  cues: readonly SubtitleCue[],
+): EditableSubtitleCue[] {
+  return sortedSubtitleCues(
+    cues.map((cue, index) => {
+      const text = cue.text.replace(/\r\n?/g, "\n").trim();
+      const lines =
+        cue.lines.length > 0
+          ? cue.lines.map((line) => line.trim()).filter(Boolean)
+          : subtitleCueTextToLines(text);
+
+      return {
+        ...cue,
+        id: stableSubtitleCueId(cue, index),
+        startTime: roundTimelineTime(cue.startTime),
+        endTime: roundTimelineTime(cue.endTime),
+        text,
+        lines,
+      };
+    }),
+  );
+}
+
+export function clampSubtitleCueRange({
+  startTime,
+  endTime,
+  duration,
+}: {
+  startTime: number;
+  endTime: number;
+  duration: number;
+}) {
+  const safeDuration = Math.max(
+    0,
+    roundTimelineTime(Number.isFinite(duration) ? duration : 0),
+  );
+  if (safeDuration <= 0) {
+    return {
+      startTime: 0,
+      endTime: 0,
+    };
+  }
+
+  const minCueDuration = Math.min(MIN_CLIP_SECONDS, safeDuration);
+  const safeStart = Number.isFinite(startTime) ? startTime : 0;
+  const safeEnd = Number.isFinite(endTime) ? endTime : safeStart;
+  const clampedStart = Math.min(
+    Math.max(safeStart, 0),
+    Math.max(safeDuration - minCueDuration, 0),
+  );
+  const clampedEnd = Math.min(
+    Math.max(safeEnd, clampedStart + minCueDuration),
+    safeDuration,
+  );
+
+  return {
+    startTime: roundTimelineTime(clampedStart),
+    endTime: roundTimelineTime(clampedEnd),
+  };
+}
+
+export function updateEditableSubtitleCueText(
+  cues: EditableSubtitleCue[],
+  cueId: string,
+  text: string,
+) {
+  const normalizedText = text.replace(/\r\n?/g, "\n");
+  let changed = false;
+  const nextCues = cues.map((cue) => {
+    if (cue.id !== cueId) {
+      return cue;
+    }
+
+    const lines = subtitleCueTextToLines(normalizedText);
+    if (
+      cue.text === normalizedText &&
+      cue.lines.join("\n") === lines.join("\n")
+    ) {
+      return cue;
+    }
+
+    changed = true;
+    return {
+      ...cue,
+      text: normalizedText,
+      lines,
+    };
+  });
+
+  return changed ? nextCues : cues;
+}
+
+export function updateEditableSubtitleCueRanges(
+  cues: EditableSubtitleCue[],
+  updates: readonly SubtitleCueRangeUpdate[],
+  duration: number,
+) {
+  if (updates.length === 0) {
+    return cues;
+  }
+
+  const updatesByCueId = new Map(
+    updates.map((update) => [update.cueId, update] as const),
+  );
+  let changed = false;
+  const nextCues = cues.map((cue) => {
+    const update = updatesByCueId.get(cue.id);
+    if (!update) {
+      return cue;
+    }
+
+    const range = clampSubtitleCueRange({
+      startTime: update.startTime,
+      endTime: update.endTime,
+      duration,
+    });
+    if (cue.startTime === range.startTime && cue.endTime === range.endTime) {
+      return cue;
+    }
+
+    changed = true;
+    return {
+      ...cue,
+      ...range,
+    };
+  });
+
+  return changed ? sortedSubtitleCues(nextCues) : cues;
+}
+
+export function subtitleCueActionId(cueId: string) {
+  return `${SUBTITLE_TIMELINE_ACTION_PREFIX}${cueId}`;
+}
+
+export function subtitleCueIdFromActionId(actionId: string) {
+  return actionId.startsWith(SUBTITLE_TIMELINE_ACTION_PREFIX)
+    ? actionId.slice(SUBTITLE_TIMELINE_ACTION_PREFIX.length)
+    : null;
+}
+
+export function buildSubtitleTimelineActions({
+  cues,
+  duration,
+  selectedCueId,
+  loading,
+}: {
+  cues: readonly EditableSubtitleCue[];
+  duration: number;
+  selectedCueId: string | null;
+  loading: boolean;
+}) {
+  const safeDuration = Math.max(duration, MIN_CLIP_SECONDS);
+
+  if (loading && cues.length === 0) {
+    return [
+      {
+        id: SUBTITLE_LOADING_ACTION_ID,
+        start: 0,
+        end: safeDuration,
+        effectId: "subtitle-placeholder",
+        flexible: false,
+        movable: false,
+        minStart: 0,
+        maxEnd: safeDuration,
+      },
+    ] as ClipTimelineAction[];
+  }
+
+  return cues.map((cue) => ({
+    id: subtitleCueActionId(cue.id),
+    start: cue.startTime,
+    end: cue.endTime,
+    effectId: "subtitle",
+    selected: cue.id === selectedCueId,
+    flexible: true,
+    movable: true,
+    minStart: 0,
+    maxEnd: safeDuration,
+  })) as ClipTimelineAction[];
+}

--- a/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.test.ts
@@ -67,7 +67,7 @@ void test("blocks export when the selected subtitle track is unsupported", () =>
     }),
     {
       label: "Not supported",
-      detail: "Select this embedded subtitle in Plex first.",
+      detail: "Plex embedded subtitles cannot be downloaded for editing.",
       tone: "warning",
       disabledReason: "Choose another subtitle track or turn subtitles off.",
     },

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EditorSession } from "@/lib/editorMedia";
 import {
   selectPreferredSubtitleTrack,
@@ -10,7 +10,17 @@ import {
   saveSubtitleStyleSettings,
 } from "@/lib/subtitles/settings";
 import { trimSubtitleCues } from "@/lib/subtitles/trimSubtitleCues";
-import type { PlaybackSubtitleTrack } from "@/providers/types";
+import type {
+  PlaybackSubtitleSelection,
+  PlaybackSubtitleTrack,
+} from "@/providers/types";
+import {
+  normalizeEditableSubtitleCues,
+  updateEditableSubtitleCueRanges,
+  updateEditableSubtitleCueText,
+  type EditableSubtitleCue,
+  type SubtitleCueRangeUpdate,
+} from "@/components/editor/editorSubtitleCues";
 import { buildSubtitleExportSummary } from "@/components/editor/subtitleExportSummary";
 import { useSubtitleCues } from "@/components/editor/useSubtitleCues";
 
@@ -18,6 +28,50 @@ interface UseEditorSubtitlesProps {
   session: EditorSession;
   startTime: number;
   endTime: number;
+}
+
+function boolSignature(value: boolean | undefined) {
+  return value ? "1" : "0";
+}
+
+function subtitleTrackImportSignature(track: PlaybackSubtitleTrack) {
+  return [
+    subtitleTrackKey(track),
+    track.languageCode ?? "",
+    track.title ?? "",
+    track.codec ?? "",
+    track.contentFormat ?? "",
+    boolSignature(track.isText),
+    boolSignature(track.isDefault),
+    boolSignature(track.isForced),
+    boolSignature(track.isHearingImpaired),
+    boolSignature(track.isExternal),
+    track.contentUrl ? "content-url" : "no-content-url",
+  ].join("\u001f");
+}
+
+function subtitleTracksImportSignature(
+  tracks: readonly PlaybackSubtitleTrack[],
+) {
+  return tracks.map(subtitleTrackImportSignature).join("\u001e");
+}
+
+function subtitleSelectionSignature(
+  selection: PlaybackSubtitleSelection | undefined,
+) {
+  if (!selection) {
+    return "none";
+  }
+
+  return [
+    selection.streamId ?? "",
+    selection.index ?? "",
+    selection.languageCode ?? "",
+    selection.title ?? "",
+    selection.codec ?? "",
+    selection.contentFormat ?? "",
+    boolSignature(selection.isText),
+  ].join("\u001f");
 }
 
 export function useEditorSubtitles({
@@ -31,14 +85,16 @@ export function useEditorSubtitles({
   const [subtitleEnabled, setSubtitleEnabled] = useState(false);
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] =
     useState("none");
+  const [editableSubtitleCues, setEditableSubtitleCues] = useState<
+    EditableSubtitleCue[]
+  >([]);
+  const [selectedSubtitleCueId, setSelectedSubtitleCueId] = useState<
+    string | null
+  >(null);
+  const autoSubtitleSelectionSignatureRef = useRef<string | null>(null);
 
   const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
-    () =>
-      session.local
-        ? []
-        : (session.subtitleTracks ?? []).filter((track) =>
-            subtitleTrackSupportsBurnIn(track),
-          ),
+    () => (session.local ? [] : (session.subtitleTracks ?? [])),
     [session.local, session.subtitleTracks],
   );
   const selectedSubtitleTrack = useMemo(() => {
@@ -52,6 +108,15 @@ export function useEditorSubtitles({
       ) ?? null
     );
   }, [selectedSubtitleTrackKey, subtitleTracks]);
+  const subtitleTracksSignature = useMemo(
+    () => subtitleTracksImportSignature(subtitleTracks),
+    [subtitleTracks],
+  );
+  const selectedSubtitleSelectionSignature = useMemo(
+    () => subtitleSelectionSignature(session.selectedSubtitleTrack),
+    [session.selectedSubtitleTrack],
+  );
+  const autoSubtitleSelectionSignature = `${session.id}\u001e${selectedSubtitleSelectionSignature}\u001e${subtitleTracksSignature}`;
   const {
     subtitleCues,
     subtitleLoading,
@@ -66,11 +131,22 @@ export function useEditorSubtitles({
   const subtitlePreviewEnabled =
     subtitleEnabled &&
     subtitleTrackSupportsBurnIn(selectedSubtitleTrack) &&
-    subtitleCues.length > 0;
+    editableSubtitleCues.length > 0;
+  const selectedSubtitleCue = useMemo(
+    () =>
+      selectedSubtitleCueId
+        ? (editableSubtitleCues.find(
+            (cue) => cue.id === selectedSubtitleCueId,
+          ) ?? null)
+        : null,
+    [editableSubtitleCues, selectedSubtitleCueId],
+  );
   const clippedSubtitleCues = useMemo(
     () =>
-      subtitleEnabled ? trimSubtitleCues(subtitleCues, startTime, endTime) : [],
-    [endTime, startTime, subtitleCues, subtitleEnabled],
+      subtitleEnabled
+        ? trimSubtitleCues(editableSubtitleCues, startTime, endTime)
+        : [],
+    [editableSubtitleCues, endTime, startTime, subtitleEnabled],
   );
   const subtitleExportSummary = useMemo(
     () =>
@@ -99,6 +175,19 @@ export function useEditorSubtitles({
   }, [subtitleStyleSettings]);
 
   useEffect(() => {
+    setEditableSubtitleCues(normalizeEditableSubtitleCues(subtitleCues));
+    setSelectedSubtitleCueId(null);
+  }, [subtitleCues]);
+
+  useEffect(() => {
+    if (
+      autoSubtitleSelectionSignatureRef.current ===
+      autoSubtitleSelectionSignature
+    ) {
+      return;
+    }
+    autoSubtitleSelectionSignatureRef.current = autoSubtitleSelectionSignature;
+
     const preferredSubtitleTrack = selectPreferredSubtitleTrack(
       subtitleTracks,
       session.selectedSubtitleTrack,
@@ -116,8 +205,10 @@ export function useEditorSubtitles({
       ),
     );
     resetSubtitleCues();
+    setEditableSubtitleCues([]);
+    setSelectedSubtitleCueId(null);
   }, [
-    session.id,
+    autoSubtitleSelectionSignature,
     session.selectedSubtitleTrack,
     subtitleTracks,
     resetSubtitleCues,
@@ -131,6 +222,8 @@ export function useEditorSubtitles({
       if (value === "none") {
         setSubtitleEnabled(false);
         resetSubtitleCues();
+        setEditableSubtitleCues([]);
+        setSelectedSubtitleCueId(null);
         return;
       }
 
@@ -140,8 +233,32 @@ export function useEditorSubtitles({
       setSubtitleEnabled(
         Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)),
       );
+      setEditableSubtitleCues([]);
+      setSelectedSubtitleCueId(null);
     },
     [clearSubtitleError, resetSubtitleCues, subtitleTracks],
+  );
+
+  const handleSubtitleCueSelect = useCallback((cueId: string | null) => {
+    setSelectedSubtitleCueId(cueId);
+  }, []);
+
+  const handleSubtitleCueTextChange = useCallback(
+    (cueId: string, text: string) => {
+      setEditableSubtitleCues((currentCues) =>
+        updateEditableSubtitleCueText(currentCues, cueId, text),
+      );
+    },
+    [],
+  );
+
+  const handleSubtitleCueRangeChange = useCallback(
+    (updates: readonly SubtitleCueRangeUpdate[], duration: number) => {
+      setEditableSubtitleCues((currentCues) =>
+        updateEditableSubtitleCueRanges(currentCues, updates, duration),
+      );
+    },
+    [],
   );
 
   return {
@@ -152,12 +269,17 @@ export function useEditorSubtitles({
     setSubtitleEnabled,
     subtitleStyleSettings,
     setSubtitleStyleSettings,
-    subtitleCues,
+    subtitleCues: editableSubtitleCues,
     subtitleLoading,
     subtitleError,
     subtitlePreviewEnabled,
+    selectedSubtitleCue,
+    selectedSubtitleCueId,
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    handleSubtitleCueSelect,
+    handleSubtitleCueTextChange,
+    handleSubtitleCueRangeChange,
   };
 }

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -22,6 +22,12 @@ import {
   type ClipTimelineEffects,
 } from "@/components/editor/editorUtils";
 import {
+  buildSubtitleTimelineActions,
+  subtitleCueIdFromActionId,
+  type EditableSubtitleCue,
+  type SubtitleCueRangeUpdate,
+} from "@/components/editor/editorSubtitleCues";
+import {
   accumulateTimelineWheelZoomDelta,
   resolveTimelineScrollWheelUpdate,
   resolveTimelineZoomUpdate,
@@ -35,6 +41,14 @@ interface UseEditorTimelineProps {
   sessionId: string;
   updateClipRange: (start: number, end: number) => void;
   onClipRangeCommit?: (start: number, end: number) => void;
+  subtitleCues?: readonly EditableSubtitleCue[];
+  selectedSubtitleCueId?: string | null;
+  showSubtitleRow?: boolean;
+  subtitleLoading?: boolean;
+  onSubtitleCueRangeChange?: (
+    updates: readonly SubtitleCueRangeUpdate[],
+    duration: number,
+  ) => void;
 }
 
 interface TimelineZoomAnchorOptions {
@@ -96,6 +110,11 @@ export function useEditorTimeline({
   sessionId,
   updateClipRange,
   onClipRangeCommit,
+  subtitleCues = [],
+  selectedSubtitleCueId = null,
+  showSubtitleRow = false,
+  subtitleLoading = false,
+  onSubtitleCueRangeChange,
 }: UseEditorTimelineProps) {
   const timelineRef = useRef<TimelineState>(null);
   const timelineWheelRegionRef = useRef<HTMLDivElement>(null);
@@ -113,6 +132,11 @@ export function useEditorTimeline({
     () => ({
       source: { id: "source", name: "Source" },
       clip: { id: "clip", name: "Clip" },
+      subtitle: { id: "subtitle", name: "Subtitle" },
+      "subtitle-placeholder": {
+        id: "subtitle-placeholder",
+        name: "Subtitle placeholder",
+      },
     }),
     [],
   );
@@ -195,7 +219,7 @@ export function useEditorTimeline({
         )
       : MIN_CLIP_SECONDS;
 
-    return [
+    const rows: ClipTimelineData = [
       {
         id: "source-media",
         rowHeight: 32,
@@ -231,7 +255,32 @@ export function useEditorTimeline({
         ],
       },
     ];
-  }, [duration, endTime, hasDuration, startTime]);
+
+    if (showSubtitleRow) {
+      rows.push({
+        id: "subtitles",
+        rowHeight: 44,
+        selected: Boolean(selectedSubtitleCueId),
+        actions: buildSubtitleTimelineActions({
+          cues: subtitleCues,
+          duration: safeDuration,
+          selectedCueId: selectedSubtitleCueId,
+          loading: subtitleLoading,
+        }),
+      });
+    }
+
+    return rows;
+  }, [
+    duration,
+    endTime,
+    hasDuration,
+    selectedSubtitleCueId,
+    showSubtitleRow,
+    startTime,
+    subtitleCues,
+    subtitleLoading,
+  ]);
 
   useEffect(() => {
     timelineZoomIndexRef.current = timelineZoomIndex;
@@ -502,16 +551,44 @@ export function useEditorTimeline({
 
   const handleTimelineChange = useCallback(
     (nextData: ClipTimelineData) => {
-      const nextAction = nextData
-        .flatMap((row) => row.actions)
-        .find((action) => action.id === "selected-clip");
-      if (!nextAction) {
-        return false;
+      const nextActions = nextData.flatMap((row) => row.actions);
+      const nextAction = nextActions.find(
+        (action) => action.id === "selected-clip",
+      );
+      if (nextAction) {
+        updateClipRange(nextAction.start, nextAction.end);
       }
 
-      updateClipRange(nextAction.start, nextAction.end);
+      const subtitleUpdates = nextActions.flatMap<SubtitleCueRangeUpdate>(
+        (action) => {
+          if (action.effectId !== "subtitle") {
+            return [];
+          }
+
+          const cueId = subtitleCueIdFromActionId(action.id);
+          if (!cueId) {
+            return [];
+          }
+
+          return [
+            {
+              cueId,
+              startTime: action.start,
+              endTime: action.end,
+            },
+          ];
+        },
+      );
+
+      if (subtitleUpdates.length > 0) {
+        onSubtitleCueRangeChange?.(subtitleUpdates, duration);
+      }
+
+      if (!nextAction && subtitleUpdates.length === 0) {
+        return false;
+      }
     },
-    [updateClipRange],
+    [duration, onSubtitleCueRangeChange, updateClipRange],
   );
 
   const commitClipRange = useCallback(
@@ -532,12 +609,25 @@ export function useEditorTimeline({
       end: number;
     }) => {
       if (action.id !== "selected-clip") {
+        const cueId = subtitleCueIdFromActionId(action.id);
+        if (cueId) {
+          onSubtitleCueRangeChange?.(
+            [
+              {
+                cueId,
+                startTime: roundTimelineTime(start),
+                endTime: roundTimelineTime(end),
+              },
+            ],
+            duration,
+          );
+        }
         return;
       }
 
       commitClipRange(start, end);
     },
-    [commitClipRange],
+    [commitClipRange, duration, onSubtitleCueRangeChange],
   );
 
   const handleTimelineActionResizeEnd = useCallback(
@@ -551,12 +641,25 @@ export function useEditorTimeline({
       end: number;
     }) => {
       if (action.id !== "selected-clip") {
+        const cueId = subtitleCueIdFromActionId(action.id);
+        if (cueId) {
+          onSubtitleCueRangeChange?.(
+            [
+              {
+                cueId,
+                startTime: roundTimelineTime(start),
+                endTime: roundTimelineTime(end),
+              },
+            ],
+            duration,
+          );
+        }
         return;
       }
 
       commitClipRange(start, end);
     },
-    [commitClipRange],
+    [commitClipRange, duration, onSubtitleCueRangeChange],
   );
 
   return {

--- a/apps/frontend/src/components/editor/useSubtitleCues.test.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.test.ts
@@ -1,0 +1,191 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  downloadSubtitleCues,
+  subtitleCueLoadKey,
+  subtitleResponseDiagnosticFields,
+  subtitleResponseDiagnostics,
+} from "@/components/editor/useSubtitleCues";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+
+const baseTrack = {
+  streamId: "10",
+  index: 2,
+  languageCode: "eng",
+  title: "English",
+  codec: "srt",
+  contentFormat: "srt",
+  isText: true,
+  contentUrl: "/api/media/subtitle-old",
+} satisfies PlaybackSubtitleTrack;
+
+void test("subtitle cue load keys include the selected content URL", () => {
+  assert.notEqual(
+    subtitleCueLoadKey(baseTrack),
+    subtitleCueLoadKey({
+      ...baseTrack,
+      contentUrl: "/api/media/subtitle-new",
+    }),
+  );
+});
+
+void test("subtitle cue load keys change when loadability or format changes", () => {
+  assert.notEqual(
+    subtitleCueLoadKey(baseTrack),
+    subtitleCueLoadKey({
+      ...baseTrack,
+      contentUrl: undefined,
+    }),
+  );
+  assert.notEqual(
+    subtitleCueLoadKey(baseTrack),
+    subtitleCueLoadKey({
+      ...baseTrack,
+      contentFormat: "vtt",
+    }),
+  );
+});
+
+void test("subtitle response diagnostics include empty 200 responses", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("", {
+      status: 200,
+      headers: {
+        "content-length": "0",
+        "content-type": "text/srt",
+      },
+    })) as typeof fetch;
+
+  try {
+    const result = await downloadSubtitleCues(
+      baseTrack,
+      "/api/media/subtitle",
+      new AbortController().signal,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.response.status, 200);
+    assert.equal(result.response.contentType, "text/srt");
+    assert.equal(result.response.contentLength, 0);
+    assert.equal(result.response.charCount, 0);
+    assert.equal(result.response.empty, true);
+    if (result.ok) {
+      assert.equal(result.cues.length, 0);
+    }
+
+    const fields = subtitleResponseDiagnosticFields(result.response, 0);
+    assert.equal(fields["http.status_code"], 200);
+    assert.equal(fields["http.content_type"], "text/srt");
+    assert.equal(fields["http.content_length"], 0);
+    assert.equal(fields["subtitle.response.char_count"], 0);
+    assert.equal(fields["subtitle.response.empty"], true);
+    assert.equal(fields["subtitle.cue.count"], 0);
+    assert.equal(fields["subtitle.empty"], true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("subtitle response diagnostics include non-empty unparsable bodies", async () => {
+  const originalFetch = globalThis.fetch;
+  const body = "not really subtitles";
+  globalThis.fetch = (async () =>
+    new Response(body, {
+      status: 200,
+      headers: {
+        "content-length": String(body.length),
+        "content-type": "text/plain",
+      },
+    })) as typeof fetch;
+
+  try {
+    const result = await downloadSubtitleCues(
+      baseTrack,
+      "/api/media/subtitle",
+      new AbortController().signal,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.response.status, 200);
+    assert.equal(result.response.contentType, "text/plain");
+    assert.equal(result.response.contentLength, body.length);
+    assert.equal(result.response.charCount, body.length);
+    assert.equal(result.response.empty, false);
+    if (result.ok) {
+      assert.equal(result.cues.length, 0);
+    }
+
+    const fields = subtitleResponseDiagnosticFields(result.response, 0);
+    assert.equal(fields["subtitle.response.char_count"], body.length);
+    assert.equal(fields["subtitle.response.empty"], false);
+    assert.equal(fields["subtitle.cue.count"], 0);
+    assert.equal(fields["subtitle.empty"], true);
+    assert.equal(Object.values(fields).includes(body), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("subtitle response diagnostics include non-OK status without body text", async () => {
+  const originalFetch = globalThis.fetch;
+  const body = "missing subtitle body";
+  globalThis.fetch = (async () =>
+    new Response(body, {
+      status: 501,
+      headers: {
+        "content-length": String(body.length),
+        "content-type": "text/html",
+      },
+    })) as typeof fetch;
+
+  try {
+    const result = await downloadSubtitleCues(
+      baseTrack,
+      "/api/media/subtitle",
+      new AbortController().signal,
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.response.status, 501);
+    assert.equal(result.response.contentType, "text/html");
+    assert.equal(result.response.contentLength, body.length);
+    assert.equal(result.response.charCount, body.length);
+    assert.equal(result.response.empty, false);
+    if (!result.ok) {
+      assert.equal(result.failure.status, 501);
+      assert.equal(result.failure.message, "Could not load subtitles (501).");
+    }
+
+    const fields = subtitleResponseDiagnosticFields(result.response, 0);
+    assert.equal(fields["http.status_code"], 501);
+    assert.equal(fields["http.content_type"], "text/html");
+    assert.equal(fields["subtitle.response.char_count"], body.length);
+    assert.equal(fields["subtitle.response.empty"], false);
+    assert.equal(fields["subtitle.cue.count"], 0);
+    assert.equal(Object.values(fields).includes(body), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("subtitle response diagnostics ignore invalid content-length values", () => {
+  const diagnostics = subtitleResponseDiagnostics(
+    new Response("hello", {
+      status: 200,
+      headers: {
+        "content-length": "not-a-number",
+        "content-type": "text/srt",
+      },
+    }),
+    "hello",
+  );
+
+  assert.equal(diagnostics.status, 200);
+  assert.equal(diagnostics.contentType, "text/srt");
+  assert.equal(diagnostics.contentLength, undefined);
+  assert.equal(diagnostics.charCount, 5);
+  assert.equal(diagnostics.empty, false);
+});

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   compactLogFields,
   logDurationFields,
@@ -7,6 +7,7 @@ import {
 } from "@cliparr/shared/logging";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
+  subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
 } from "@/lib/selectPreferredSubtitleTrack";
@@ -28,14 +29,24 @@ interface SubtitleDownloadFailure {
   message: string;
 }
 
-type SubtitleDownloadResult =
+export interface SubtitleResponseDiagnostics {
+  charCount: number;
+  contentLength?: number;
+  contentType?: string;
+  empty: boolean;
+  status: number;
+}
+
+export type SubtitleDownloadResult =
   | {
       ok: true;
       cues: SubtitleCue[];
+      response: SubtitleResponseDiagnostics;
     }
   | {
       ok: false;
       failure: SubtitleDownloadFailure;
+      response: SubtitleResponseDiagnostics;
     };
 
 function subtitleDownloadFailure(status: number): SubtitleDownloadFailure {
@@ -60,26 +71,77 @@ function subtitleTrackLogFields(
   });
 }
 
-async function downloadSubtitleCues(
+function numericHeaderValue(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+export function subtitleResponseDiagnostics(
+  response: Pick<Response, "headers" | "status">,
+  body: string,
+): SubtitleResponseDiagnostics {
+  return {
+    charCount: body.length,
+    contentLength: numericHeaderValue(response.headers.get("content-length")),
+    contentType: response.headers.get("content-type") ?? undefined,
+    empty: body.length === 0,
+    status: response.status,
+  };
+}
+
+export function subtitleResponseDiagnosticFields(
+  response: SubtitleResponseDiagnostics,
+  cueCount: number,
+) {
+  return compactLogFields({
+    "http.status_code": response.status,
+    "http.content_type": response.contentType,
+    "http.content_length": response.contentLength,
+    "subtitle.response.char_count": response.charCount,
+    "subtitle.response.empty": response.empty,
+    "subtitle.cue.count": cueCount,
+    "subtitle.empty": cueCount === 0,
+  });
+}
+
+export function subtitleCueLoadKey(track: PlaybackSubtitleTrack | null) {
+  if (!track) {
+    return "none";
+  }
+
+  return [
+    subtitleTrackKey(track),
+    track.contentFormat ?? "",
+    track.codec ?? "",
+    track.isText ? "text" : "not-text",
+    track.contentUrl ?? "",
+  ].join("\u001f");
+}
+
+export async function downloadSubtitleCues(
   track: PlaybackSubtitleTrack,
   contentUrl: string,
   signal: AbortSignal,
 ): Promise<SubtitleDownloadResult> {
   const response = await fetch(contentUrl, { signal });
+  const body = await response.text();
+  const responseDiagnostics = subtitleResponseDiagnostics(response, body);
   if (!response.ok) {
     return {
       ok: false,
       failure: subtitleDownloadFailure(response.status),
+      response: responseDiagnostics,
     };
   }
 
   return {
     ok: true,
-    cues: await parseSubtitleTextAsync(
-      await response.text(),
-      track.contentFormat,
-      signal,
-    ),
+    cues: await parseSubtitleTextAsync(body, track.contentFormat, signal),
+    response: responseDiagnostics,
   };
 }
 
@@ -91,6 +153,15 @@ export function useSubtitleCues({
   const [subtitleCues, setSubtitleCues] = useState<SubtitleCue[]>([]);
   const [subtitleLoading, setSubtitleLoading] = useState(false);
   const [subtitleError, setSubtitleError] = useState<string | null>(null);
+  const selectedSubtitleTrackRef = useRef(selectedSubtitleTrack);
+  const selectedSubtitleTrackLoadKey = useMemo(
+    () => subtitleCueLoadKey(selectedSubtitleTrack),
+    [selectedSubtitleTrack],
+  );
+
+  useEffect(() => {
+    selectedSubtitleTrackRef.current = selectedSubtitleTrack;
+  }, [selectedSubtitleTrack]);
 
   const resetSubtitleCues = useCallback(() => {
     setSubtitleCues([]);
@@ -110,6 +181,8 @@ export function useSubtitleCues({
     }, subtitleRequestTimeoutMs);
 
     async function loadSubtitleCues() {
+      const selectedSubtitleTrack = selectedSubtitleTrackRef.current;
+
       if (!subtitleEnabled || !selectedSubtitleTrack) {
         resetSubtitleCues();
         return;
@@ -147,8 +220,8 @@ export function useSubtitleCues({
             ...logEventFields("editor.subtitle.load", "failure"),
             ...logDurationFields(startedAt),
             ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
+            ...subtitleResponseDiagnosticFields(downloadResult.response, 0),
             "subtitle.timeout": false,
-            "http.status_code": downloadResult.failure.status,
             "error.name": "SubtitleDownloadFailure",
             "error.message": downloadResult.failure.message,
           });
@@ -158,17 +231,22 @@ export function useSubtitleCues({
         }
 
         const parsedSubtitleCues = downloadResult.cues;
+        const subtitleEmpty = parsedSubtitleCues.length === 0;
         setSubtitleCues(parsedSubtitleCues);
         setSubtitleError(
-          parsedSubtitleCues.length === 0
-            ? "No subtitles found in this track."
-            : null,
+          subtitleEmpty ? "No subtitles found in this track." : null,
         );
         logger.info("Subtitle cues loaded.", {
-          ...logEventFields("editor.subtitle.load", "success"),
+          ...logEventFields(
+            "editor.subtitle.load",
+            subtitleEmpty ? "empty" : "success",
+          ),
           ...logDurationFields(startedAt),
           ...subtitleTrackLogFields(selectedSubtitleTrack, providerId),
-          "subtitle.cue.count": parsedSubtitleCues.length,
+          ...subtitleResponseDiagnosticFields(
+            downloadResult.response,
+            parsedSubtitleCues.length,
+          ),
         });
       } catch (err) {
         if (cancelled || abortController.signal.aborted) {
@@ -212,7 +290,12 @@ export function useSubtitleCues({
       window.clearTimeout(timeout);
       abortController.abort();
     };
-  }, [providerId, resetSubtitleCues, selectedSubtitleTrack, subtitleEnabled]);
+  }, [
+    providerId,
+    resetSubtitleCues,
+    selectedSubtitleTrackLoadKey,
+    subtitleEnabled,
+  ]);
 
   return {
     subtitleCues,

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -596,14 +596,14 @@
   position: relative;
   width: 100%;
   height: 100%;
-  min-height: 154px;
+  min-height: 198px;
   background: var(--editor-panel);
 }
 
 .cliparr-timeline .timeline-editor {
   width: 100%;
   height: 100%;
-  min-height: 154px;
+  min-height: 198px;
   overflow: hidden;
   border: none;
   border-radius: 0;
@@ -726,6 +726,49 @@
   height: 34px !important;
 }
 
+.cliparr-timeline .timeline-editor-action-effect-subtitle {
+  top: 6px !important;
+  height: 32px !important;
+  border-color: color-mix(
+    in oklch,
+    var(--editor-accent) 54%,
+    var(--editor-border)
+  );
+  background: color-mix(
+    in oklch,
+    var(--editor-accent) 24%,
+    var(--editor-panel)
+  );
+  color: var(--foreground);
+}
+
+.cliparr-timeline
+  .timeline-editor-action-effect-subtitle.timeline-editor-action-selected,
+.cliparr-timeline
+  .timeline-editor-action-effect-subtitle[aria-selected="true"] {
+  border-color: var(--editor-accent);
+  background: color-mix(
+    in oklch,
+    var(--editor-accent) 36%,
+    var(--editor-panel)
+  );
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklch, var(--editor-accent) 58%, transparent);
+}
+
+.cliparr-timeline .timeline-editor-action-effect-subtitle-placeholder {
+  top: 8px !important;
+  height: 28px !important;
+  border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--muted-foreground) 42%,
+    var(--editor-border)
+  );
+  background: color-mix(in oklch, var(--editor-control) 72%, transparent);
+  color: var(--muted-foreground);
+}
+
 .cliparr-timeline .timeline-editor-action .timeline-editor-action-left-stretch,
 .cliparr-timeline
   .timeline-editor-action
@@ -796,6 +839,21 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-overflow: ellipsis;
+}
+
+.cliparr-timeline-subtitle-content {
+  justify-content: flex-start;
+  padding: 0 10px;
+}
+
+.cliparr-timeline-subtitle-label {
+  width: 100%;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.cliparr-timeline-subtitle-placeholder {
+  justify-content: center;
 }
 
 .cliparr-timeline-action-time {

--- a/apps/frontend/src/lib/editorMedia.test.ts
+++ b/apps/frontend/src/lib/editorMedia.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   editorSessionFromCurrentlyPlaying,
+  mergeEditorSessionRefresh,
   titleFromUrl,
 } from "@/lib/editorMedia";
 import type { CurrentlyPlayingItem } from "@/providers/types";
@@ -50,4 +51,132 @@ void test("passes provider playhead seconds into editor sessions", () => {
     sourceDurationSeconds: 600,
     sourceBitrateKbps: 1_600,
   });
+});
+
+void test("preserves generated media handles when refreshing the same editor session", () => {
+  const baseItem: CurrentlyPlayingItem = {
+    id: "source-1:session-1",
+    source: {
+      id: "source-1",
+      name: "Plex",
+      providerId: "plex",
+    },
+    title: "Example",
+    type: "movie",
+    duration: 600,
+    playheadSeconds: 120,
+    playerTitle: "Living Room",
+    playerState: "playing",
+    thumbUrl: "/api/media/thumb-old",
+    mediaUrl: "/api/media/direct-old",
+    hlsUrl: "/api/media/hls-old",
+    selectedAudioTrack: {
+      trackNumber: 1,
+      languageCode: "eng",
+      title: "English",
+    },
+    selectedSubtitleTrack: {
+      streamId: "10",
+      languageCode: "eng",
+      title: "English",
+      codec: "srt",
+      contentFormat: "srt",
+      isText: true,
+    },
+    subtitleTracks: [
+      {
+        streamId: "10",
+        languageCode: "eng",
+        title: "English",
+        codec: "srt",
+        contentFormat: "srt",
+        isText: true,
+        contentUrl: "/api/media/subtitle-old",
+      },
+    ],
+  };
+  const current = editorSessionFromCurrentlyPlaying(baseItem);
+  const next = editorSessionFromCurrentlyPlaying({
+    ...baseItem,
+    title: "Example Updated",
+    playheadSeconds: 180,
+    playerState: "paused",
+    thumbUrl: "/api/media/thumb-new",
+    mediaUrl: "/api/media/direct-new",
+    hlsUrl: "/api/media/hls-new",
+    subtitleTracks: [
+      {
+        streamId: "10",
+        languageCode: "eng",
+        title: "English",
+        codec: "srt",
+        contentFormat: "srt",
+        isText: true,
+        contentUrl: "/api/media/subtitle-new",
+      },
+    ],
+  });
+
+  const merged = mergeEditorSessionRefresh(current, next);
+
+  assert.equal(merged.title, "Example Updated");
+  assert.equal(merged.playerState, "paused");
+  assert.equal(merged.initialPlayheadSeconds, 120);
+  assert.equal(merged.thumbUrl, "/api/media/thumb-old");
+  assert.equal(merged.directSource?.kind, "url");
+  assert.equal(
+    merged.directSource?.kind === "url" && merged.directSource.url,
+    "/api/media/direct-old",
+  );
+  assert.equal(merged.hlsSource?.kind, "url");
+  assert.equal(
+    merged.hlsSource?.kind === "url" && merged.hlsSource.url,
+    "/api/media/hls-old",
+  );
+  assert.equal(merged.selectedAudioTrack, current.selectedAudioTrack);
+  assert.equal(merged.selectedSubtitleTrack, current.selectedSubtitleTrack);
+  assert.equal(
+    merged.subtitleTracks?.[0]?.contentUrl,
+    "/api/media/subtitle-old",
+  );
+});
+
+void test("does not preserve generated media handles for a different editor session", () => {
+  const current = editorSessionFromCurrentlyPlaying({
+    id: "source-1:session-1",
+    source: {
+      id: "source-1",
+      name: "Plex",
+      providerId: "plex",
+    },
+    title: "Old",
+    type: "movie",
+    duration: 600,
+    playerTitle: "Living Room",
+    playerState: "playing",
+    hlsUrl: "/api/media/hls-old",
+  });
+  const next = editorSessionFromCurrentlyPlaying({
+    id: "source-1:session-2",
+    source: {
+      id: "source-1",
+      name: "Plex",
+      providerId: "plex",
+    },
+    title: "New",
+    type: "movie",
+    duration: 600,
+    playerTitle: "Living Room",
+    playerState: "playing",
+    hlsUrl: "/api/media/hls-new",
+  });
+
+  const merged = mergeEditorSessionRefresh(current, next);
+
+  assert.equal(merged.id, "source-1:session-2");
+  assert.equal(merged.hlsSource?.kind, "url");
+  assert.equal(
+    merged.hlsSource?.kind === "url" && merged.hlsSource.url,
+    "/api/media/hls-new",
+  );
 });

--- a/apps/frontend/src/lib/editorMedia.ts
+++ b/apps/frontend/src/lib/editorMedia.ts
@@ -8,6 +8,7 @@ import type {
   PlaybackSubtitleTrack,
 } from "@/providers/types";
 import { isHlsPlaylistUrl } from "@/lib/mediabunnyInput";
+import { subtitleTrackKey } from "@/lib/selectPreferredSubtitleTrack";
 
 const LOCAL_PROVIDER_ID = "local";
 
@@ -144,6 +145,117 @@ export function editorSessionFromCurrentlyPlaying(
     exportMetadata: item.exportMetadata,
     exportEstimateMetadata: item.exportEstimateMetadata,
     local: false,
+  };
+}
+
+function preserveUrlSourceHandle(
+  current: EditorMediaSource | undefined,
+  next: EditorMediaSource | undefined,
+) {
+  if (!next) {
+    return undefined;
+  }
+
+  if (
+    current?.kind === "url" &&
+    next.kind === "url" &&
+    current.role === next.role
+  ) {
+    return current;
+  }
+
+  return next;
+}
+
+function audioSelectionsEqual(
+  left: PlaybackAudioSelection | undefined,
+  right: PlaybackAudioSelection | undefined,
+) {
+  return (
+    left?.trackNumber === right?.trackNumber &&
+    left?.languageCode === right?.languageCode &&
+    left?.title === right?.title
+  );
+}
+
+function subtitleSelectionsEqual(
+  left: PlaybackSubtitleSelection | undefined,
+  right: PlaybackSubtitleSelection | undefined,
+) {
+  return (
+    left?.streamId === right?.streamId &&
+    left?.index === right?.index &&
+    left?.languageCode === right?.languageCode &&
+    left?.title === right?.title &&
+    left?.codec === right?.codec &&
+    left?.contentFormat === right?.contentFormat &&
+    left?.isText === right?.isText
+  );
+}
+
+function preserveSubtitleTrackHandles(
+  currentTracks: readonly PlaybackSubtitleTrack[] | undefined,
+  nextTracks: readonly PlaybackSubtitleTrack[] | undefined,
+): PlaybackSubtitleTrack[] | undefined {
+  if (!nextTracks) {
+    return undefined;
+  }
+
+  if (!currentTracks || currentTracks.length === 0) {
+    return [...nextTracks];
+  }
+
+  const currentTrackByKey = new Map(
+    currentTracks.map((track) => [subtitleTrackKey(track), track] as const),
+  );
+
+  return nextTracks.map((track) => {
+    const currentTrack = currentTrackByKey.get(subtitleTrackKey(track));
+    if (!currentTrack?.contentUrl || !track.contentUrl) {
+      return track;
+    }
+
+    return {
+      ...track,
+      contentUrl: currentTrack.contentUrl,
+    };
+  });
+}
+
+export function mergeEditorSessionRefresh(
+  current: EditorSession | null | undefined,
+  next: EditorSession,
+): EditorSession {
+  if (!current || current.id !== next.id || current.local || next.local) {
+    return next;
+  }
+
+  return {
+    ...next,
+    initialPlayheadSeconds: current.initialPlayheadSeconds,
+    thumbUrl:
+      next.thumbUrl && current.thumbUrl ? current.thumbUrl : next.thumbUrl,
+    directSource: preserveUrlSourceHandle(
+      current.directSource,
+      next.directSource,
+    ),
+    hlsSource: preserveUrlSourceHandle(current.hlsSource, next.hlsSource),
+    selectedAudioTrack: audioSelectionsEqual(
+      current.selectedAudioTrack,
+      next.selectedAudioTrack,
+    )
+      ? current.selectedAudioTrack
+      : next.selectedAudioTrack,
+    selectedSubtitleTrack: subtitleSelectionsEqual(
+      current.selectedSubtitleTrack,
+      next.selectedSubtitleTrack,
+    )
+      ? current.selectedSubtitleTrack
+      : next.selectedSubtitleTrack,
+    subtitleTracks: preserveSubtitleTrackHandles(
+      current.subtitleTracks,
+      next.subtitleTracks,
+    ),
   };
 }
 

--- a/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
+++ b/apps/frontend/src/lib/selectPreferredSubtitleTrack.ts
@@ -37,7 +37,7 @@ export function subtitleTrackUnavailableMessage(
   }
 
   if (track.isText && providerId === "plex") {
-    return "Select this embedded subtitle in Plex first.";
+    return "Plex embedded subtitles cannot be downloaded for editing.";
   }
 
   if (track.isText) {

--- a/apps/frontend/src/routes/_app.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/_app.edit.$sessionId.tsx
@@ -4,9 +4,13 @@ import { cliparrClient } from "@/api/cliparrClient";
 import EditorScreen from "@/components/editor/EditorScreen";
 import {
   editorSessionFromCurrentlyPlaying,
+  mergeEditorSessionRefresh,
   type EditorSession,
 } from "@/lib/editorMedia";
-import { getPendingEditorTransitionSession } from "@/lib/viewTransitions";
+import {
+  clearPendingEditorTransitionSession,
+  getPendingEditorTransitionSession,
+} from "@/lib/viewTransitions";
 import { router } from "@/router";
 
 function errorMessage(err: unknown, fallback: string) {
@@ -24,6 +28,7 @@ function EditorRouteComponent() {
   const [error, setError] = useState("");
   const [attempt, setAttempt] = useState(0);
   const sessionRef = useRef(session);
+  const hydratedSessionIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     sessionRef.current = session;
@@ -32,11 +37,15 @@ function EditorRouteComponent() {
   useEffect(() => {
     let cancelled = false;
     const transitionSession = getPendingEditorTransitionSession(sessionId);
+    if (hydratedSessionIdRef.current !== sessionId) {
+      hydratedSessionIdRef.current = null;
+    }
     const hasWarmSession =
       Boolean(transitionSession) || sessionRef.current?.id === sessionId;
 
     if (transitionSession) {
       setSession(transitionSession);
+      clearPendingEditorTransitionSession(sessionId);
     }
 
     async function loadSession() {
@@ -62,7 +71,18 @@ function EditorRouteComponent() {
         }
 
         if (!cancelled) {
-          setSession(editorSessionFromCurrentlyPlaying(activeSession));
+          const nextSession = editorSessionFromCurrentlyPlaying(activeSession);
+          const shouldPreserveGeneratedHandles =
+            hydratedSessionIdRef.current === nextSession.id;
+          setSession((currentSession) =>
+            shouldPreserveGeneratedHandles
+              ? mergeEditorSessionRefresh(
+                  currentSession ?? sessionRef.current,
+                  nextSession,
+                )
+              : nextSession,
+          );
+          hydratedSessionIdRef.current = nextSession.id;
         }
       } catch (err: unknown) {
         if (!cancelled) {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -2,12 +2,14 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { Response } from "express";
-import { isApiError } from "@/http/errors";
+import { createApiError, isApiError } from "@/http/errors";
 import type { ProviderSessionRecord } from "@/session/store";
 import type { MediaHandle } from "@/providers/types";
 import {
   assertAllowedMediaHandleRequestUrl,
   fetchMediaHandleRequest,
+  hlsPlaylistRewriteDiagnosticFields,
+  mediaHandleHlsDiagnosticFields,
   proxyProviderMediaResponse,
   proxyUpstreamMediaResponse,
   sanitizeLoggedMediaPath,
@@ -229,6 +231,34 @@ void test("uses custom media handle URLs when rewriting HLS playlists", async ()
   ]);
 });
 
+void test("uses Plex path session ids for rewritten HLS handles", async () => {
+  const session = createSession();
+  const rootHandle = createMediaHandle({
+    path: "/video/:/transcode/universal/start.m3u8?transcodeSessionId=cliparr-session-1",
+    playbackSessionId: "cliparr-session-1",
+  });
+  const response = createResponseRecorder();
+
+  await proxyUpstreamMediaResponse(
+    session,
+    rootHandle,
+    new globalThis.Response(
+      "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nsession/plex-path-session/base/index.m3u8\n",
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.apple.mpegurl",
+        },
+      },
+    ),
+    response as unknown as Response,
+  );
+
+  assert.equal(session.mediaHandles.size, 1);
+  const childHandle = [...session.mediaHandles.values()][0];
+  assert.equal(childHandle?.playbackSessionId, "plex-path-session");
+});
+
 void test("strips HLS start hints so editor seeks control playback position", async () => {
   const session = createSession();
   const handle = createMediaHandle();
@@ -264,11 +294,21 @@ void test("strips HLS start hints so editor seeks control playback position", as
   assert.equal(session.mediaHandles.size, 1);
 });
 
-void test("does not forward range requests for HLS playlists that Cliparr rewrites", () => {
+void test("does not forward range requests for HLS handles that Cliparr rewrites", () => {
   assert.equal(
     shouldForwardMediaRange(
       createMediaHandle({
         path: "/video/:/transcode/universal/start.m3u8?session=1",
+      }),
+      "bytes=148-",
+    ),
+    undefined,
+  );
+  assert.equal(
+    shouldForwardMediaRange(
+      createMediaHandle({
+        path: "/video/:/transcode/universal/session/abc/base/00000.ts",
+        basePath: "/video/:/transcode/universal/session/abc/base/",
       }),
       "bytes=148-",
     ),
@@ -572,6 +612,37 @@ void test("retries not-yet-generated HLS-derived media responses", async () => {
   }
 });
 
+void test("keeps retrying delayed HLS-derived 404 responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+
+    return new Response(fetchCount < 7 ? "missing" : "ok", {
+      status: fetchCount < 7 ? 404 : 200,
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await fetchMediaHandleRequest(
+      createMediaHandle({
+        path: "/hls/segment0.ts",
+        basePath: "/hls/",
+      }),
+      {
+        retryBaseDelayMs: 0,
+      },
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+    assert.equal(fetchCount, 7);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 void test("sanitizes logged media paths by stripping query strings", () => {
   assert.equal(
     sanitizeLoggedMediaPath(
@@ -583,6 +654,73 @@ void test("sanitizes logged media paths by stripping query strings", () => {
     sanitizeLoggedMediaPath("/video/master.m3u8?token=abc"),
     "/video/master.m3u8",
   );
+});
+
+void test("builds sanitized HLS playlist rewrite diagnostics", () => {
+  const fields = hlsPlaylistRewriteDiagnosticFields(
+    createMediaHandle({
+      id: "playlist-handle",
+      path: "https://cdn.example.com/hls/master.m3u8?token=secret",
+    }),
+    "https://cdn.example.com/hls/?token=secret",
+    200,
+    {
+      firstPlaylistPath: "https://cdn.example.com/hls/child.m3u8?sig=secret",
+      firstSegmentPath: "https://cdn.example.com/hls/00000.ts?sig=secret",
+      keyUriCount: 1,
+      playlistUriCount: 1,
+      rewrittenUriCount: 3,
+      segmentUriCount: 1,
+      strippedStartHintCount: 1,
+    },
+  );
+
+  assert.equal(fields["event.name"], "media.hls.playlist_rewrite");
+  assert.equal(fields["event.outcome"], "success");
+  assert.equal(fields["media.handle.id"], "playlist-handle");
+  assert.equal(fields["provider.id"], "plex");
+  assert.equal(fields["source.id"], "source-1");
+  assert.equal(fields["media.path"], "https://cdn.example.com/hls/master.m3u8");
+  assert.equal(fields["media.base_path"], "https://cdn.example.com/hls/");
+  assert.equal(fields["upstream.status_code"], 200);
+  assert.equal(fields["media.hls.rewritten_uri_count"], 3);
+  assert.equal(fields["media.hls.segment_uri_count"], 1);
+  assert.equal(fields["media.hls.playlist_uri_count"], 1);
+  assert.equal(fields["media.hls.key_uri_count"], 1);
+  assert.equal(
+    fields["media.hls.first_segment.path"],
+    "https://cdn.example.com/hls/00000.ts",
+  );
+  assert.equal(
+    fields["media.hls.first_playlist.path"],
+    "https://cdn.example.com/hls/child.m3u8",
+  );
+  assert.equal(fields["media.hls.stripped_start_hint_count"], 1);
+});
+
+void test("builds HLS segment diagnostics from media handles", () => {
+  const fields = mediaHandleHlsDiagnosticFields(
+    createMediaHandle({
+      path: "/video/:/transcode/universal/session/abc-123/base/00000.ts?token=secret",
+      basePath:
+        "/video/:/transcode/universal/session/abc-123/base/?token=secret",
+    }),
+  );
+
+  assert.equal(
+    fields["media.path"],
+    "/video/:/transcode/universal/session/abc-123/base/00000.ts",
+  );
+  assert.equal(
+    fields["media.base_path"],
+    "/video/:/transcode/universal/session/abc-123/base/",
+  );
+  assert.equal(fields["media.hls.derived"], true);
+  assert.equal(fields["media.hls.playlist"], false);
+  assert.equal(fields["media.hls.segment"], true);
+  assert.equal(fields["media.hls.segment.filename"], "00000.ts");
+  assert.equal(fields["media.hls.segment.index"], 0);
+  assert.equal(fields["plex.transcode.path_session.id"], "abc-123");
 });
 
 void test("does not throw when a proxied media stream terminates early", async () => {
@@ -676,6 +814,7 @@ void test("uses buffered byte length for cached HLS-derived media responses", as
 void test("dedupes concurrent HLS-derived media requests for the same handle", async () => {
   const session = createSession();
   const handle = createMediaHandle({
+    id: "dedupe-hls-handle",
     path: "https://cdn.example.com/hls/segment0.ts",
     basePath: "https://cdn.example.com/hls/",
   });
@@ -721,4 +860,32 @@ void test("dedupes concurrent HLS-derived media requests for the same handle", a
   assert.equal(fetchCount, 1);
   assert.deepEqual(firstResponse.body, Buffer.from([1, 2, 3, 4]));
   assert.deepEqual(secondResponse.body, Buffer.from([1, 2, 3, 4]));
+});
+
+void test("cleans up rejected in-flight HLS responses without orphaned rejections", async () => {
+  const session = createSession();
+  const handle = createMediaHandle({
+    id: "rejected-hls-handle",
+    path: "https://cdn.example.com/hls/segment0.ts",
+    basePath: "https://cdn.example.com/hls/",
+  });
+  const response = createBinaryResponseRecorder();
+
+  await assert.rejects(
+    proxyProviderMediaResponse(
+      session,
+      handle,
+      {
+        accept: "video/mp2t",
+      },
+      async () => {
+        throw createApiError(404, "plex_media_failed", "segment missing");
+      },
+      response as unknown as Response,
+    ),
+    (err) => isApiError(err) && err.code === "plex_media_failed",
+  );
+  await new Promise((resolve) => {
+    setImmediate(resolve);
+  });
 });

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "crypto";
 import type { Request, Response } from "express";
 import {
+  compactLogFields,
   logErrorFields,
   logEventFields,
   sanitizeUrlForLog,
@@ -14,6 +15,7 @@ import { getServerLogger } from "@/logging";
 import type { ProviderSessionRecord } from "@/session/store";
 import type {
   CurrentlyPlayingEntry,
+  MediaHandle,
   MediaExportMetadata,
   PlaybackAudioSelection,
   PlaybackExportEstimateMetadata,
@@ -25,6 +27,7 @@ import type {
 import {
   createProviderMediaHandle,
   fetchMediaHandleRequest,
+  mediaHandleHlsDiagnosticFields,
   mediaHandleRequestUrl,
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
@@ -66,14 +69,13 @@ import {
 
 const logger = getServerLogger(["provider", "plex", "playback"]);
 const HD_ARTWORK_SIZE = 1920;
-const PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH = 16;
 const PLEX_METADATA_PATH_PREFIX = "/library/metadata/";
 
 function createMediaHandle(
   session: ProviderSessionRecord,
   context: PlexSourceContext,
   path: string,
-  options: { basePath?: string } = {},
+  options: { basePath?: string; playbackSessionId?: string } = {},
 ) {
   return createProviderMediaHandle(
     session,
@@ -435,27 +437,64 @@ export function createCliparrPlexTranscodeSessionId(
   sourceId: string,
   playbackSessionId: string,
 ) {
-  const safeSourceId =
-    sourceId
-      .replace(/[^a-z0-9_-]+/gi, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH) || "source";
   const digest = createHash("sha256")
-    .update(`${sourceId}:${playbackSessionId}`)
-    .digest("hex")
-    .slice(0, 16);
+    .update(`cliparr:${sourceId}:${playbackSessionId}`)
+    .digest();
+  digest[6] = (digest[6] & 0x0f) | 0x50;
+  digest[8] = (digest[8] & 0x3f) | 0x80;
+  const hex = digest.subarray(0, 16).toString("hex");
 
-  return `cliparr-${safeSourceId}-${digest}`;
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
 }
 
-function transcodeSessionId(path: string) {
+export function plexPlaybackSessionIdFromPath(path: string) {
   try {
-    return new URL(path, "http://cliparr.local").searchParams.get(
-      "transcodeSessionId",
-    );
+    const querySessionId = new URL(
+      path,
+      "http://cliparr.local",
+    ).searchParams.get("transcodeSessionId");
+    if (querySessionId) {
+      return querySessionId;
+    }
   } catch {
-    return null;
+    // Continue with path extraction below.
   }
+
+  const match = /\/video\/:\/transcode\/universal\/session\/([^/]+)/.exec(path);
+  return match?.[1] ?? null;
+}
+
+export function plexMediaFailureLogFields(args: {
+  accept: string | undefined;
+  handle: MediaHandle;
+  mediaRangePresent: boolean;
+  playbackSessionId: string | null;
+  providerAuthAttached: boolean;
+  sessionId: string;
+  upstreamDetail: string;
+  upstreamStatus: number;
+  upstreamUrl: string;
+}) {
+  return compactLogFields({
+    ...logEventFields("media.proxy.upstream", "failure"),
+    "media.handle.id": args.handle.id,
+    "session.id": args.sessionId,
+    "source.id": args.handle.sourceId,
+    ...mediaHandleHlsDiagnosticFields(args.handle),
+    "upstream.url": sanitizeLoggedMediaPath(args.upstreamUrl),
+    "upstream.status_code": args.upstreamStatus,
+    "upstream.detail": args.upstreamDetail,
+    "provider.auth.attached": args.providerAuthAttached,
+    "media.range.present": args.mediaRangePresent,
+    "http.accept": args.accept,
+    "plex.playback_session.id": args.playbackSessionId,
+  });
 }
 
 function isRetryableConnectionError(err: unknown) {
@@ -860,80 +899,19 @@ function plexDirectSubtitleContentFormat(codec: unknown) {
   return subtitleContentFormat(codec);
 }
 
-function buildSelectedPlexSubtitleTranscodePath(
-  item: PlexMetadataItem,
-  playbackSessionId: string,
-  selection: PlexMediaSelection | undefined,
-  stream: PlexStream,
-) {
-  const path = metadataPath(item);
-  const codec = normalizeSubtitleCodec(stream?.codec);
-  if (!path || !canTranscodeSelectedPlexSubtitle(codec, stream)) {
-    return undefined;
-  }
-
-  const resolvedSelection = resolveSelectedPart(item, selection);
-  const params = new URLSearchParams({
-    path,
-    transcodeSessionId: playbackSessionId,
-    mediaIndex: String(resolvedSelection?.mediaIndex ?? 0),
-    partIndex: String(resolvedSelection?.partIndex ?? 0),
-    subtitles: "sidecar",
-    advancedSubtitles: "text",
-    autoAdjustSubtitle: "0",
-  });
-
-  return `/video/:/transcode/universal/subtitles?${params.toString()}`;
-}
-
-function canTranscodeSelectedPlexSubtitle(codec: unknown, stream: PlexStream) {
-  return isSelectedEntry(stream) && isTextSubtitleCodec(codec);
-}
-
-function plexSubtitleContentFormat(
-  codec: unknown,
-  directSubtitlePath: string | undefined,
-  transcodeSubtitleAvailable: boolean,
-) {
-  if (directSubtitlePath) {
-    return plexDirectSubtitleContentFormat(codec);
-  }
-
-  if (transcodeSubtitleAvailable) {
-    return "srt";
-  }
-
-  return subtitleContentFormat(codec);
+function plexSubtitleContentFormat(codec: unknown) {
+  return plexDirectSubtitleContentFormat(codec) ?? subtitleContentFormat(codec);
 }
 
 function plexSubtitleTrack(
   session: ProviderSessionRecord,
   context: PlexSourceContext,
-  item: PlexMetadataItem,
-  playbackSessionId: string,
-  selection: PlexMediaSelection | undefined,
   stream: PlexStream,
 ): PlaybackSubtitleTrack {
   const codec = normalizeSubtitleCodec(stream?.codec);
   const directSubtitlePath = buildPlexSubtitlePath(stream);
   const isText = isTextSubtitleCodec(codec);
-  const transcodeSubtitleAvailable =
-    Boolean(metadataPath(item)) &&
-    canTranscodeSelectedPlexSubtitle(codec, stream);
-  const transcodeSubtitlePath = directSubtitlePath
-    ? undefined
-    : buildSelectedPlexSubtitleTranscodePath(
-        item,
-        playbackSessionId,
-        selection,
-        stream,
-      );
-  const contentFormat = plexSubtitleContentFormat(
-    codec,
-    directSubtitlePath,
-    transcodeSubtitleAvailable,
-  );
-  const contentPath = directSubtitlePath ?? transcodeSubtitlePath;
+  const contentFormat = plexSubtitleContentFormat(codec);
 
   return {
     streamId: idValue(stream?.id),
@@ -948,17 +926,39 @@ function plexSubtitleTrack(
     isForced: booleanFlag(stream?.forced),
     isHearingImpaired: booleanFlag(stream?.hearingImpaired),
     isExternal: Boolean(stringValue(stream?.key)),
-    contentUrl: contentPath
-      ? createMediaHandle(session, context, contentPath)
+    contentUrl: directSubtitlePath
+      ? createMediaHandle(session, context, directSubtitlePath)
       : undefined,
   };
+}
+
+function plexSubtitleStreamDiagnostic(stream: PlexStream) {
+  const codec = normalizeSubtitleCodec(stream?.codec);
+  const directSubtitlePath = buildPlexSubtitlePath(stream);
+
+  return compactLogFields({
+    streamId: idValue(stream?.id),
+    index: numberValue(stream?.index) ?? numberValue(stream?.streamIdentifier),
+    codec,
+    languageCode:
+      stringValue(stream?.languageCode) ?? stringValue(stream?.languageTag),
+    title: selectedSubtitleTrackTitle(stream),
+    selected: isSelectedEntry(stream),
+    default: booleanFlag(stream?.default),
+    forced: booleanFlag(stream?.forced),
+    hearingImpaired: booleanFlag(stream?.hearingImpaired),
+    external: Boolean(stringValue(stream?.key)),
+    hasKey: Boolean(stringValue(stream?.key)),
+    contentFormat: plexSubtitleContentFormat(codec),
+    contentUrlAvailable: Boolean(directSubtitlePath),
+  });
 }
 
 export function deriveSubtitleTracks(
   session: ProviderSessionRecord,
   context: PlexSourceContext,
   item: PlexMetadataItem,
-  playbackSessionId: string,
+  _playbackSessionId: string,
   selection?: PlexMediaSelection,
 ) {
   const resolvedPart = resolveSelectedPart(item, selection);
@@ -969,16 +969,7 @@ export function deriveSubtitleTracks(
 
   return streamEntries(part)
     .filter((stream) => isSubtitleStream(stream))
-    .map((stream) =>
-      plexSubtitleTrack(
-        session,
-        context,
-        item,
-        playbackSessionId,
-        selection,
-        stream,
-      ),
-    );
+    .map((stream) => plexSubtitleTrack(session, context, stream));
 }
 
 export function deriveSelectedSubtitleTrack(
@@ -998,10 +989,6 @@ export function deriveSelectedSubtitleTrack(
   }
 
   const codec = normalizeSubtitleCodec(selectedSubtitleStream?.codec);
-  const directSubtitlePath = buildPlexSubtitlePath(selectedSubtitleStream);
-  const transcodeSubtitleAvailable =
-    Boolean(metadataPath(item)) &&
-    canTranscodeSelectedPlexSubtitle(codec, selectedSubtitleStream);
 
   return {
     streamId: idValue(selectedSubtitleStream?.id),
@@ -1013,11 +1000,7 @@ export function deriveSelectedSubtitleTrack(
       stringValue(selectedSubtitleStream?.languageTag),
     title: selectedSubtitleTrackTitle(selectedSubtitleStream),
     codec,
-    contentFormat: plexSubtitleContentFormat(
-      codec,
-      directSubtitlePath,
-      transcodeSubtitleAvailable,
-    ),
+    contentFormat: plexSubtitleContentFormat(codec),
     isText: isTextSubtitleCodec(codec),
   };
 }
@@ -1249,13 +1232,16 @@ async function normalizeCurrentPlayback(
         enrichedItem,
         mediaSelection,
       );
-      const subtitleTracks = deriveSubtitleTracks(
+      const allSubtitleTracks = deriveSubtitleTracks(
         session,
         context,
         enrichedItem,
         transcodeSessionId,
         mediaSelection,
-      ).filter((track) => subtitleTrackSupportsBurnIn(track));
+      );
+      const subtitleTracks = allSubtitleTracks.filter((track) =>
+        subtitleTrackSupportsBurnIn(track),
+      );
       const selectedPart = resolveSelectedPart(
         enrichedItem,
         mediaSelection,
@@ -1265,6 +1251,11 @@ async function normalizeCurrentPlayback(
         : [];
       const videoStreams = selectedPart
         ? streamEntries(selectedPart).filter((stream) => isVideoStream(stream))
+        : [];
+      const subtitleStreams = selectedPart
+        ? streamEntries(selectedPart).filter((stream) =>
+            isSubtitleStream(stream),
+          )
         : [];
       const duration =
         Number(
@@ -1287,7 +1278,9 @@ async function normalizeCurrentPlayback(
         ? createMediaHandle(session, context, mediaPath)
         : undefined;
       const hlsUrl = previewPath
-        ? createMediaHandle(session, context, previewPath)
+        ? createMediaHandle(session, context, previewPath, {
+            playbackSessionId: transcodeSessionId,
+          })
         : undefined;
       const missingPreviewPath =
         !previewPath && itemTypeValue(enrichedItem) !== "track";
@@ -1310,15 +1303,22 @@ async function normalizeCurrentPlayback(
           mediaUrl: mediaUrl ?? null,
           hlsUrl: hlsUrl ?? null,
           selectedAudioTrack: selectedAudioTrack ?? null,
+          selectedSubtitleTrack: selectedSubtitleTrack ?? null,
           exportEstimateMetadata: exportEstimateMetadata ?? null,
         },
         metadataPath: metadataPath(enrichedItem) ?? null,
+        "playback.hls.path": sanitizeLoggedMediaPath(previewPath),
+        "playback.direct.path": sanitizeLoggedMediaPath(mediaPath),
+        "playback.subtitle.track_count": allSubtitleTracks.length,
+        "playback.subtitle.supported_track_count": subtitleTracks.length,
         mediaId: mediaSelection?.mediaId ?? null,
         mediaIndex: mediaSelection?.mediaIndex ?? null,
         partId: mediaSelection?.partId ?? null,
         partIndex: mediaSelection?.partIndex ?? null,
         videoStreamCount: videoStreams.length,
         audioStreamCount: audioStreams.length,
+        subtitleStreamCount: subtitleStreams.length,
+        selectedSubtitleTrack: selectedSubtitleTrack ?? null,
         videoStreams: videoStreams.map((stream, index) => ({
           trackNumber: index + 1,
           streamId: idValue(stream?.id) ?? null,
@@ -1344,6 +1344,9 @@ async function normalizeCurrentPlayback(
           codec: stringValue(stream?.codec) ?? null,
           selected: isSelectedEntry(stream),
         })),
+        subtitleStreams: subtitleStreams.map((stream) =>
+          plexSubtitleStreamDiagnostic(stream),
+        ),
       };
 
       logger.debug(
@@ -1440,7 +1443,7 @@ export async function proxyMedia(
   }
 
   const playbackSessionId = useProviderAuth
-    ? transcodeSessionId(handle.path)
+    ? (handle.playbackSessionId ?? plexPlaybackSessionIdFromPath(handle.path))
     : null;
   if (playbackSessionId) {
     headers.set("X-Plex-Session-Identifier", playbackSessionId);
@@ -1471,19 +1474,20 @@ export async function proxyMedia(
           .slice(0, 400)
           .replace(/\s+/g, " ")
           .trim();
-        logger.warn("Plex media request failed.", {
-          ...logEventFields("media.proxy.upstream", "failure"),
-          "media.handle.id": handle.id,
-          "session.id": session.id,
-          "source.id": handle.sourceId,
-          "upstream.url": sanitizeLoggedMediaPath(url.toString()),
-          "upstream.status_code": upstream.status,
-          "upstream.detail": detail,
-          "provider.auth.attached": useProviderAuth,
-          "media.range.present": Boolean(range),
-          "http.accept": accept,
-          "plex.playback_session.id": playbackSessionId,
-        });
+        logger.warn(
+          "Plex media request failed.",
+          plexMediaFailureLogFields({
+            accept,
+            handle,
+            mediaRangePresent: Boolean(range),
+            playbackSessionId,
+            providerAuthAttached: useProviderAuth,
+            sessionId: session.id,
+            upstreamDetail: detail,
+            upstreamStatus: upstream.status,
+            upstreamUrl: url.toString(),
+          }),
+        );
         throw createApiError(
           upstream.status,
           "plex_media_failed",

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ProviderSessionRecord } from "@/session/store";
+import type { MediaHandle } from "@/providers/types";
 import {
   createPlexExportEstimateMetadata,
   createCliparrPlexTranscodeSessionId,
@@ -9,6 +10,8 @@ import {
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
   playheadSecondsFromViewOffset,
+  plexPlaybackSessionIdFromPath,
+  plexMediaFailureLogFields,
 } from "@/providers/plex/playback";
 import type { PlexSourceContext } from "@/providers/plex/shared";
 
@@ -87,7 +90,10 @@ void test("creates a Cliparr-owned Plex transcode session id", () => {
   assert.equal(firstId, secondId);
   assert.notEqual(firstId, differentPlaybackId);
   assert.notEqual(firstId, differentSourceId);
-  assert.match(firstId, /^cliparr-source-1-[a-f0-9]{16}$/);
+  assert.match(
+    firstId,
+    /^[a-f0-9]{8}-[a-f0-9]{4}-5[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/,
+  );
 });
 
 void test("does not create Plex HLS preview paths for audio tracks", () => {
@@ -217,7 +223,7 @@ void test("proxies Plex viewer avatar URLs through provider media handles", () =
   assert.equal(handle.path, "https://plex.tv/users/user-1/avatar?c=123");
 });
 
-void test("creates a subtitle transcode content URL for the selected embedded Plex text subtitle", () => {
+void test("leaves selected embedded Plex text subtitles unsupported for editing", () => {
   const session = createSession();
   const context = createContext();
   const item = {
@@ -247,29 +253,28 @@ void test("creates a subtitle transcode content URL for the selected embedded Pl
   };
 
   const tracks = deriveSubtitleTracks(session, context, item, "plex-session-1");
-  const handle = onlyMediaHandle(session);
-  const transcodeUrl = new URL(handle.path, "http://cliparr.local");
 
   assert.equal(tracks.length, 1);
-  assert.equal(tracks[0]?.contentUrl, `/api/media/${handle.id}`);
+  assert.equal(tracks[0]?.isText, true);
   assert.equal(tracks[0]?.contentFormat, "srt");
+  assert.equal(tracks[0]?.contentUrl, undefined);
+  assert.equal(session.mediaHandles.size, 0);
+});
+
+void test("extracts Plex playback session ids from start and segment paths", () => {
   assert.equal(
-    handle.path.startsWith("/video/:/transcode/universal/subtitles?"),
-    true,
+    plexPlaybackSessionIdFromPath(
+      "/video/:/transcode/universal/start.m3u8?path=%2Flibrary%2Fmetadata%2F123&transcodeSessionId=cliparr-session-1",
+    ),
+    "cliparr-session-1",
   );
   assert.equal(
-    transcodeUrl.searchParams.get("path"),
-    "/library/metadata/12345",
+    plexPlaybackSessionIdFromPath(
+      "/video/:/transcode/universal/session/plex-path-session/base/00000.ts",
+    ),
+    "plex-path-session",
   );
-  assert.equal(
-    transcodeUrl.searchParams.get("transcodeSessionId"),
-    "plex-session-1",
-  );
-  assert.equal(transcodeUrl.searchParams.get("mediaIndex"), "0");
-  assert.equal(transcodeUrl.searchParams.get("partIndex"), "0");
-  assert.equal(transcodeUrl.searchParams.get("subtitles"), "sidecar");
-  assert.equal(transcodeUrl.searchParams.get("advancedSubtitles"), "text");
-  assert.equal(transcodeUrl.searchParams.get("autoAdjustSubtitle"), "0");
+  assert.equal(plexPlaybackSessionIdFromPath("/library/parts/1/file"), null);
 });
 
 void test("prefers direct raw SRT for the selected external Plex text subtitle", () => {
@@ -345,7 +350,7 @@ void test("reports selected external Plex SRT content format consistently", () =
   assert.equal(selectedTrack?.contentFormat, "srt");
 });
 
-void test("reports selected embedded Plex text subtitle transcode format", () => {
+void test("reports selected embedded Plex text subtitle codec format", () => {
   const item = {
     ratingKey: "12345",
     Media: [
@@ -377,7 +382,7 @@ void test("reports selected embedded Plex text subtitle transcode format", () =>
   assert.equal(selectedTrack?.contentFormat, "srt");
 });
 
-void test("leaves unselected embedded Plex text subtitles visible but unsupported", () => {
+void test("leaves unselected embedded Plex text subtitles unsupported", () => {
   const session = createSession();
   const context = createContext();
   const item = {
@@ -448,4 +453,61 @@ void test("leaves Plex image subtitle streams unsupported for burn-in", () => {
   assert.equal(tracks[0]?.isText, false);
   assert.equal(tracks[0]?.contentUrl, undefined);
   assert.equal(session.mediaHandles.size, 0);
+});
+
+void test("builds sanitized Plex media failure diagnostics for HLS segments", () => {
+  const handle: MediaHandle = {
+    id: "segment-handle",
+    providerId: "plex",
+    sourceId: "source-1",
+    baseUrl: "http://plex.local:32400",
+    path: "/video/:/transcode/universal/session/plex-path-session/base/00000.ts?token=secret",
+    basePath:
+      "/video/:/transcode/universal/session/plex-path-session/base/?token=secret",
+    token: "provider-token",
+    lastAccessedAt: 0,
+  };
+
+  const fields = plexMediaFailureLogFields({
+    accept: "video/mp2t",
+    handle,
+    mediaRangePresent: false,
+    playbackSessionId: "playback-session-1",
+    providerAuthAttached: true,
+    sessionId: "session-1",
+    upstreamDetail: "404 not found",
+    upstreamStatus: 404,
+    upstreamUrl:
+      "http://plex.local:32400/video/:/transcode/universal/session/plex-path-session/base/00000.ts?token=secret",
+  });
+
+  assert.equal(fields["event.name"], "media.proxy.upstream");
+  assert.equal(fields["event.outcome"], "failure");
+  assert.equal(fields["media.handle.id"], "segment-handle");
+  assert.equal(fields["session.id"], "session-1");
+  assert.equal(fields["source.id"], "source-1");
+  assert.equal(
+    fields["media.path"],
+    "/video/:/transcode/universal/session/plex-path-session/base/00000.ts",
+  );
+  assert.equal(
+    fields["media.base_path"],
+    "/video/:/transcode/universal/session/plex-path-session/base/",
+  );
+  assert.equal(fields["media.hls.derived"], true);
+  assert.equal(fields["media.hls.playlist"], false);
+  assert.equal(fields["media.hls.segment"], true);
+  assert.equal(fields["media.hls.segment.filename"], "00000.ts");
+  assert.equal(fields["media.hls.segment.index"], 0);
+  assert.equal(fields["plex.transcode.path_session.id"], "plex-path-session");
+  assert.equal(
+    fields["upstream.url"],
+    "http://plex.local:32400/video/:/transcode/universal/session/plex-path-session/base/00000.ts",
+  );
+  assert.equal(fields["upstream.status_code"], 404);
+  assert.equal(fields["upstream.detail"], "404 not found");
+  assert.equal(fields["provider.auth.attached"], true);
+  assert.equal(fields["media.range.present"], false);
+  assert.equal(fields["http.accept"], "video/mp2t");
+  assert.equal(fields["plex.playback_session.id"], "playback-session-1");
 });

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -5,7 +5,11 @@ import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import type { ReadableStream as WebReadableStream } from "stream/web";
 import type { Response } from "express";
-import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
+import {
+  compactLogFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
 import { createApiError, isApiError } from "@/http/errors";
 import { getServerLogger } from "@/logging";
 import type { ProviderSessionRecord } from "@/session/store";
@@ -21,6 +25,7 @@ interface MediaHandleContext {
 
 interface CreateMediaHandleOptions {
   basePath?: string;
+  playbackSessionId?: string;
 }
 
 interface ProxyMediaRequestOptions {
@@ -49,6 +54,16 @@ interface CachedProxyMediaResponse {
   body: Buffer;
 }
 
+export interface HlsPlaylistRewriteDiagnostics {
+  firstPlaylistPath?: string;
+  firstSegmentPath?: string;
+  keyUriCount: number;
+  playlistUriCount: number;
+  rewrittenUriCount: number;
+  segmentUriCount: number;
+  strippedStartHintCount: number;
+}
+
 interface ResolvedHostnameCacheEntry {
   expiresAt: number;
   addresses: string[];
@@ -69,7 +84,7 @@ const HLS_PROXY_RESPONSE_CACHE_TTL_MS = 4_000;
 const HLS_PROXY_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const MEDIA_PROXY_MAX_REDIRECTS = 5;
 const MEDIA_PROXY_FETCH_ATTEMPTS = 3;
-const HLS_MEDIA_PROXY_FETCH_ATTEMPTS = 5;
+const HLS_MEDIA_PROXY_FETCH_ATTEMPTS = 8;
 const MEDIA_PROXY_FETCH_RETRY_BASE_DELAY_MS = 150;
 const MEDIA_PROXY_FETCH_RETRY_MAX_DELAY_MS = 1_000;
 const DNS_VALIDATION_CACHE_TTL_MS = 60_000;
@@ -634,6 +649,7 @@ export function createProviderMediaHandle(
   const normalizedBasePath = options.basePath
     ? normalizeMediaPath(options.basePath)
     : undefined;
+  const playbackSessionId = options.playbackSessionId?.trim() || undefined;
   const accessedAt = Date.now();
 
   for (const existingHandle of session.mediaHandles.values()) {
@@ -644,7 +660,8 @@ export function createProviderMediaHandle(
       existingHandle.path === normalizedPath &&
       existingHandle.token === context.token &&
       existingHandle.deviceId === context.deviceId &&
-      existingHandle.basePath === normalizedBasePath
+      existingHandle.basePath === normalizedBasePath &&
+      existingHandle.playbackSessionId === playbackSessionId
     ) {
       existingHandle.lastAccessedAt = accessedAt;
       logger.trace("Reused provider media handle.", {
@@ -669,6 +686,7 @@ export function createProviderMediaHandle(
     token: context.token,
     deviceId: context.deviceId,
     basePath: normalizedBasePath,
+    playbackSessionId,
     lastAccessedAt: accessedAt,
   };
   session.mediaHandles.set(handle.id, handle);
@@ -710,11 +728,9 @@ function resolvePlaylistUri(basePath: string, uri: string) {
 function rewritePlaylistUri(
   session: ProviderSessionRecord,
   handle: MediaHandle,
-  basePath: string,
-  uri: string,
+  nextPath: string,
   options: ProxyMediaResponseOptions = {},
 ) {
-  const nextPath = resolvePlaylistUri(basePath, uri);
   if (options.createMediaHandleUrl) {
     return options.createMediaHandleUrl(
       session,
@@ -736,6 +752,8 @@ function rewritePlaylistUri(
     nextPath,
     {
       basePath: playlistBasePath(nextPath),
+      playbackSessionId:
+        plexTranscodePathSessionId(nextPath) ?? handle.playbackSessionId,
     },
   );
 }
@@ -748,8 +766,17 @@ async function rewriteHlsPlaylist(
 ) {
   const body = await upstream.text();
   const basePath = handle.basePath ?? playlistBasePath(handle.path);
-  let rewrittenUriCount = 0;
-  let strippedStartHintCount = 0;
+  let diagnostics = createHlsPlaylistRewriteDiagnostics();
+
+  function rewriteResolvedPlaylistUri(uri: string, sourceLine: string) {
+    const nextPath = resolvePlaylistUri(basePath, uri);
+    diagnostics = recordHlsPlaylistRewriteUri(
+      diagnostics,
+      nextPath,
+      sourceLine,
+    );
+    return rewritePlaylistUri(session, handle, nextPath, options);
+  }
 
   const playlist = body
     .split("\n")
@@ -761,33 +788,32 @@ async function rewriteHlsPlaylist(
 
       if (trimmed.startsWith("#")) {
         if (trimmed.toUpperCase().startsWith("#EXT-X-START:")) {
-          strippedStartHintCount += 1;
+          diagnostics = {
+            ...diagnostics,
+            strippedStartHintCount: diagnostics.strippedStartHintCount + 1,
+          };
           return [];
         }
 
         return [
           line.replace(/URI="([^"]+)"/g, (_match, uri: string) => {
-            rewrittenUriCount += 1;
-            return `URI="${rewritePlaylistUri(session, handle, basePath, uri, options)}"`;
+            return `URI="${rewriteResolvedPlaylistUri(uri, line)}"`;
           }),
         ];
       }
 
-      rewrittenUriCount += 1;
-      return [rewritePlaylistUri(session, handle, basePath, trimmed, options)];
+      return [rewriteResolvedPlaylistUri(trimmed, line)];
     })
     .join("\n");
 
-  logger.trace("Rewrote HLS playlist for media handle.", {
-    ...logEventFields("media.hls.playlist_rewrite", "success"),
-    "media.handle.id": handle.id,
+  logger.debug("Rewrote HLS playlist for media handle.", {
+    ...hlsPlaylistRewriteDiagnosticFields(
+      handle,
+      basePath,
+      upstream.status,
+      diagnostics,
+    ),
     "session.id": session.id,
-    "provider.id": handle.providerId,
-    "media.path": sanitizeLoggedMediaPath(handle.path),
-    "media.base_path": sanitizeLoggedMediaPath(basePath),
-    "upstream.status_code": upstream.status,
-    "media.hls.rewritten_uri_count": rewrittenUriCount,
-    "media.hls.stripped_start_hint_count": strippedStartHintCount,
   });
 
   return playlist;
@@ -827,7 +853,7 @@ export function shouldForwardMediaRange(
   handle: MediaHandle,
   range: string | undefined,
 ) {
-  if (!range || isHlsPlaylist(handle, "")) {
+  if (!range || isHlsDerivedHandle(handle)) {
     return undefined;
   }
 
@@ -865,10 +891,142 @@ function handlePathname(path: string) {
   }
 }
 
+function originalHandlePathname(path: string) {
+  try {
+    return new URL(path, RELATIVE_MEDIA_BASE_URL).pathname;
+  } catch {
+    return path.split(/[?#]/, 1)[0] ?? path;
+  }
+}
+
+function pathBasename(path: string) {
+  const pathname = originalHandlePathname(path);
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.at(-1);
+}
+
+function isHlsPlaylistPath(path: string) {
+  return handlePathname(path).endsWith(".m3u8");
+}
+
 function isHlsDerivedHandle(handle: MediaHandle) {
-  return (
-    Boolean(handle.basePath) || handlePathname(handle.path).endsWith(".m3u8")
+  return Boolean(handle.basePath) || isHlsPlaylistPath(handle.path);
+}
+
+function isHlsKeyLine(line: string) {
+  return line.trim().toUpperCase().startsWith("#EXT-X-KEY:");
+}
+
+function createHlsPlaylistRewriteDiagnostics(): HlsPlaylistRewriteDiagnostics {
+  return {
+    keyUriCount: 0,
+    playlistUriCount: 0,
+    rewrittenUriCount: 0,
+    segmentUriCount: 0,
+    strippedStartHintCount: 0,
+  };
+}
+
+function recordHlsPlaylistRewriteUri(
+  diagnostics: HlsPlaylistRewriteDiagnostics,
+  nextPath: string,
+  sourceLine: string,
+) {
+  const updatedDiagnostics = {
+    ...diagnostics,
+    rewrittenUriCount: diagnostics.rewrittenUriCount + 1,
+  };
+
+  if (isHlsKeyLine(sourceLine)) {
+    return {
+      ...updatedDiagnostics,
+      keyUriCount: diagnostics.keyUriCount + 1,
+    };
+  }
+
+  if (isHlsPlaylistPath(nextPath)) {
+    return {
+      ...updatedDiagnostics,
+      firstPlaylistPath: diagnostics.firstPlaylistPath ?? nextPath,
+      playlistUriCount: diagnostics.playlistUriCount + 1,
+    };
+  }
+
+  return {
+    ...updatedDiagnostics,
+    firstSegmentPath: diagnostics.firstSegmentPath ?? nextPath,
+    segmentUriCount: diagnostics.segmentUriCount + 1,
+  };
+}
+
+export function hlsPlaylistRewriteDiagnosticFields(
+  handle: Pick<MediaHandle, "id" | "providerId" | "sourceId" | "path">,
+  basePath: string,
+  upstreamStatus: number,
+  diagnostics: HlsPlaylistRewriteDiagnostics,
+) {
+  return compactLogFields({
+    ...logEventFields("media.hls.playlist_rewrite", "success"),
+    "media.handle.id": handle.id,
+    "provider.id": handle.providerId,
+    "source.id": handle.sourceId,
+    "media.path": sanitizeLoggedMediaPath(handle.path),
+    "media.base_path": sanitizeLoggedMediaPath(basePath),
+    "upstream.status_code": upstreamStatus,
+    "media.hls.rewritten_uri_count": diagnostics.rewrittenUriCount,
+    "media.hls.segment_uri_count": diagnostics.segmentUriCount,
+    "media.hls.playlist_uri_count": diagnostics.playlistUriCount,
+    "media.hls.key_uri_count": diagnostics.keyUriCount,
+    "media.hls.first_segment.path": sanitizeLoggedMediaPath(
+      diagnostics.firstSegmentPath,
+    ),
+    "media.hls.first_playlist.path": sanitizeLoggedMediaPath(
+      diagnostics.firstPlaylistPath,
+    ),
+    "media.hls.stripped_start_hint_count": diagnostics.strippedStartHintCount,
+  });
+}
+
+function hlsSegmentIndexFromFilename(filename: string | undefined) {
+  if (!filename) {
+    return undefined;
+  }
+
+  const match = /(\d+)/.exec(filename);
+  if (!match) {
+    return undefined;
+  }
+
+  const index = Number(match[1]);
+  return Number.isSafeInteger(index) ? index : undefined;
+}
+
+function plexTranscodePathSessionId(path: string) {
+  const pathname = originalHandlePathname(path);
+  const match = /\/video\/:\/transcode\/universal\/session\/([^/]+)/.exec(
+    pathname,
   );
+  return match?.[1];
+}
+
+export function mediaHandleHlsDiagnosticFields(
+  handle: Pick<MediaHandle, "path" | "basePath">,
+) {
+  const hlsPlaylist = isHlsPlaylistPath(handle.path);
+  const hlsDerived = Boolean(handle.basePath) || hlsPlaylist;
+  const segmentFilename =
+    hlsDerived && !hlsPlaylist ? pathBasename(handle.path) : undefined;
+
+  return compactLogFields({
+    "media.path": sanitizeLoggedMediaPath(handle.path),
+    "media.base_path": sanitizeLoggedMediaPath(handle.basePath),
+    "media.hls.derived": hlsDerived,
+    "media.hls.playlist": hlsPlaylist,
+    "media.hls.segment": hlsDerived && !hlsPlaylist,
+    "media.hls.segment.filename": segmentFilename,
+    "media.hls.segment.index": hlsSegmentIndexFromFilename(segmentFilename),
+    "plex.transcode.path_session.id": plexTranscodePathSessionId(handle.path),
+  });
 }
 
 function buildProxyCacheKey(
@@ -1110,11 +1268,15 @@ export async function proxyProviderMediaResponse(
     })();
 
     inflightProxyResponses.set(cacheKey, inflightResponse);
-    void inflightResponse.finally(() => {
-      if (inflightProxyResponses.get(cacheKey) === inflightResponse) {
-        inflightProxyResponses.delete(cacheKey);
-      }
-    });
+    void inflightResponse
+      .finally(() => {
+        if (inflightProxyResponses.get(cacheKey) === inflightResponse) {
+          inflightProxyResponses.delete(cacheKey);
+        }
+      })
+      .catch(() => {
+        // The request below awaits the original promise; this only settles cleanup.
+      });
   } else {
     logger.trace("Waiting for in-flight proxied media response.", {
       ...logEventFields("media.proxy.cache", "wait"),

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -87,6 +87,7 @@ export interface MediaHandle {
   token: string;
   deviceId?: string;
   basePath?: string;
+  playbackSessionId?: string;
   lastAccessedAt: number;
 }
 


### PR DESCRIPTION

## Summary
- add an editable subtitle timeline row with cue previews, selection, drag/resize timing edits, and sidebar text/timing controls
- normalize imported subtitle cues into stable editable cue state and feed edited cues into preview/export paths
- add Plex/HLS subtitle diagnostics and media proxy fixes for HLS segment readiness and embedded Plex subtitle loading

## Validation
- pnpm preflight

## Notes
- Subtitle styling remains global for v1; per-cue visual styling is intentionally out of scope.
- HLS playback buffering and subtitle cue loading remain separate; subtitle cues load whole-file per selected track.
