### PR TITLE
fix(cliparr): disconnect Plex sources cleanly

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -59,8 +59,8 @@ export default function App() {
     void router.invalidate();
   }, [loading, providerSession]);
 
-  const logout = async () => {
-    await cliparrClient.logout().catch(() => undefined);
+  const disconnect = async () => {
+    await cliparrClient.disconnect().catch(() => undefined);
     setProviderSession(null);
   };
 
@@ -92,7 +92,7 @@ export default function App() {
         auth={{
           providerSession,
           setProviderSession,
-          logout,
+          disconnect,
         }}
       >
         <RouterProvider
@@ -101,7 +101,7 @@ export default function App() {
             auth: {
               providerSession,
               setProviderSession,
-              logout,
+              disconnect,
             },
           }}
         />

--- a/apps/frontend/src/api/cliparrClient.test.ts
+++ b/apps/frontend/src/api/cliparrClient.test.ts
@@ -36,7 +36,7 @@ void test("handles 204 responses without trying to parse JSON", async () => {
       return new Response(null, { status: 204 });
     },
     async () => {
-      await cliparrClient.logout();
+      await cliparrClient.disconnect();
     },
   );
 });

--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -203,7 +203,7 @@ export const cliparrClient = {
     return data.session;
   },
 
-  async logout() {
+  async disconnect() {
     await request<void>("/api/session", { method: "DELETE" });
   },
 

--- a/apps/frontend/src/components/DashboardMobileMenu.tsx
+++ b/apps/frontend/src/components/DashboardMobileMenu.tsx
@@ -29,10 +29,10 @@ export function GithubIcon({ className }: { className?: string }) {
 
 export function DashboardMobileMenu({
   appVersion,
-  onLogout,
+  onDisconnect,
 }: {
   appVersion: string;
-  onLogout: () => Promise<void> | void;
+  onDisconnect: () => Promise<void> | void;
 }) {
   const menuItemClassName =
     "flex min-h-14 w-full items-center justify-between gap-3 px-4 text-base font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none";
@@ -96,7 +96,7 @@ export function DashboardMobileMenu({
             <DrawerClose asChild>
               <button
                 type="button"
-                onClick={() => void onLogout()}
+                onClick={() => void onDisconnect()}
                 className={menuItemClassName}
               >
                 <span className="flex min-w-0 items-center gap-3">

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -39,7 +39,7 @@ interface Props {
   onSelectSession: (session: CurrentlyPlayingItem) => void;
   onOpenLocalVideo: () => void;
   onOpenSources: () => void;
-  onLogout: () => Promise<void> | void;
+  onDisconnect: () => Promise<void> | void;
 }
 
 function errorMessage(err: unknown, fallback: string) {
@@ -307,7 +307,7 @@ export default function DashboardScreen({
   onSelectSession,
   onOpenLocalVideo,
   onOpenSources,
-  onLogout,
+  onDisconnect,
 }: Props) {
   const [viewers, setViewers] = useState<ViewerPlaybackGroup[]>([]);
   const [sourceErrors, setSourceErrors] = useState<SourcePlaybackError[]>([]);
@@ -413,7 +413,7 @@ export default function DashboardScreen({
             </div>
             <DashboardMobileMenu
               appVersion={versionLabel}
-              onLogout={onLogout}
+              onDisconnect={onDisconnect}
             />
           </div>
           <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.75rem] gap-2 sm:hidden">
@@ -496,7 +496,7 @@ export default function DashboardScreen({
             </a>
             <button
               type="button"
-              onClick={onLogout}
+              onClick={onDisconnect}
               className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
             >
               <LogOut className="w-4 h-4" />

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -312,7 +312,7 @@ void test("renders dashboard mobile menu trigger", () => {
   const markup = renderToStaticMarkup(
     createElement(DashboardMobileMenu, {
       appVersion: "1.2.3",
-      onLogout: () => undefined,
+      onDisconnect: () => undefined,
     }),
   );
 
@@ -352,7 +352,7 @@ void test("does not render dashboard PWA nudge in default server markup", () => 
       onSelectSession: () => undefined,
       onOpenLocalVideo: () => undefined,
       onOpenSources: () => undefined,
-      onLogout: () => undefined,
+      onDisconnect: () => undefined,
     }),
   );
 
@@ -366,7 +366,7 @@ void test("reserves dashboard playback card space before sessions load", () => {
       onSelectSession: () => undefined,
       onOpenLocalVideo: () => undefined,
       onOpenSources: () => undefined,
-      onLogout: () => undefined,
+      onDisconnect: () => undefined,
     }),
   );
 
@@ -385,7 +385,7 @@ void test("reserves dashboard version badge space before health loads", () => {
       onSelectSession: () => undefined,
       onOpenLocalVideo: () => undefined,
       onOpenSources: () => undefined,
-      onLogout: () => undefined,
+      onDisconnect: () => undefined,
     }),
   );
 

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -5,7 +5,7 @@ import { routeTree } from "@/routeTree.gen";
 export interface RouterAuthContext {
   providerSession: ProviderSession | null;
   setProviderSession: (session: ProviderSession | null) => void;
-  logout: () => Promise<void>;
+  disconnect: () => Promise<void>;
 }
 
 export interface RouterContext {

--- a/apps/frontend/src/routes/_app.dashboard.tsx
+++ b/apps/frontend/src/routes/_app.dashboard.tsx
@@ -59,7 +59,7 @@ function DashboardRouteComponent() {
         onOpenSources={() => {
           void router.navigate({ to: "/sources" });
         }}
-        onLogout={auth.logout}
+        onDisconnect={auth.disconnect}
       />
       <LocalVideoOpenDialog
         isOpen={localVideoOpen}

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -101,6 +101,15 @@ export function getProviderAccount(id: string) {
   return row ? mapProviderAccount(row) : undefined;
 }
 
+export function deleteProviderAccount(id: string) {
+  const result = getDatabase()
+    .delete(providerAccounts)
+    .where(eq(providerAccounts.id, id))
+    .run();
+
+  return result.changes > 0;
+}
+
 function getProviderAccountByAccessToken(
   providerId: string,
   accessToken: string,

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -672,7 +672,10 @@ void test("deletes individual source rows and excludes them from dashboard disco
 
     const originalListCurrentlyPlaying =
       plexProvider.listCurrentlyPlaying.bind(plexProvider);
+    const originalSupportsCurrentlyPlayingSource =
+      plexProvider.supportsCurrentlyPlayingSource?.bind(plexProvider);
     const discoveryCalls: string[] = [];
+    plexProvider.supportsCurrentlyPlayingSource = () => true;
     plexProvider.listCurrentlyPlaying = async (_session, source) => {
       discoveryCalls.push(source.id);
       return [];
@@ -691,6 +694,12 @@ void test("deletes individual source rows and excludes them from dashboard disco
       assert.deepEqual(discoveryCalls, [keptSource.id]);
     } finally {
       plexProvider.listCurrentlyPlaying = originalListCurrentlyPlaying;
+      if (originalSupportsCurrentlyPlayingSource) {
+        plexProvider.supportsCurrentlyPlayingSource =
+          originalSupportsCurrentlyPlayingSource;
+      } else {
+        delete plexProvider.supportsCurrentlyPlayingSource;
+      }
     }
   });
 });

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/mediaSourcesRepository";
 import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
 import { createApp } from "@/app";
+import { plexProvider } from "@/providers/plex/provider";
 import { createProviderSession, getSessionCookieName } from "@/session/store";
 import { PLEX_BASE_URL_MODE_MANUAL } from "@/providers/plex/connectionState";
 
@@ -597,6 +598,100 @@ void test("updates sources across connected accounts and preserves Plex manual U
       listed.sources?.map((item) => item.id).sort(),
       [jellyfinSource.id, otherSource.id, source.id].sort(),
     );
+  });
+});
+
+void test("deletes individual source rows and excludes them from dashboard discovery", async () => {
+  await withTestApp(async (baseUrl, fetchLocal) => {
+    const account = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "user-token",
+    });
+    assert(account);
+
+    const removedSource = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: account.id,
+      externalId: "removed-server",
+      name: "Removed Plex",
+      baseUrl: "http://removed.example:32400",
+    });
+    const keptSource = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: account.id,
+      externalId: "kept-server",
+      name: "Kept Plex",
+      baseUrl: "http://kept.example:32400",
+      credentials: {
+        accessToken: "kept-server-token",
+      },
+      metadata: {
+        owned: true,
+        provides: ["server"],
+      },
+    });
+    assert(removedSource);
+    assert(keptSource);
+
+    const session = createProviderSession({
+      providerId: "plex",
+      providerAccountId: account.id,
+      userToken: "user-token",
+    });
+    const sessionCookie = `${getSessionCookieName()}=${session.id}`;
+
+    const deleteResponse = await fetchLocal(
+      `${baseUrl}/api/sources/${removedSource.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          cookie: sessionCookie,
+        },
+      },
+    );
+    assert.equal(deleteResponse.status, 204);
+    assert.equal(
+      getMediaSourceForAccount(removedSource.id, account.id),
+      undefined,
+    );
+
+    const listResponse = await fetchLocal(`${baseUrl}/api/sources`, {
+      headers: {
+        cookie: sessionCookie,
+      },
+    });
+    assert.equal(listResponse.status, 200);
+    const listed = (await listResponse.json()) as {
+      sources?: Array<{ id: string }>;
+    };
+    assert.deepEqual(
+      listed.sources?.map((item) => item.id),
+      [keptSource.id],
+    );
+
+    const originalListCurrentlyPlaying =
+      plexProvider.listCurrentlyPlaying.bind(plexProvider);
+    const discoveryCalls: string[] = [];
+    plexProvider.listCurrentlyPlaying = async (_session, source) => {
+      discoveryCalls.push(source.id);
+      return [];
+    };
+
+    try {
+      const currentlyPlayingResponse = await fetchLocal(
+        `${baseUrl}/api/media/currently-playing`,
+        {
+          headers: {
+            cookie: sessionCookie,
+          },
+        },
+      );
+      assert.equal(currentlyPlayingResponse.status, 200);
+      assert.deepEqual(discoveryCalls, [keptSource.id]);
+    } finally {
+      plexProvider.listCurrentlyPlaying = originalListCurrentlyPlaying;
+    }
   });
 });
 

--- a/apps/server/src/routes/session.ts
+++ b/apps/server/src/routes/session.ts
@@ -9,10 +9,12 @@ import {
   getRememberedProviderSession,
   revokeRememberedProviderSession,
 } from "@/db/rememberedProviderSessionsRepository";
+import { deleteProviderAccount } from "@/db/providerAccountsRepository";
 import { asyncHandler, createApiError } from "@/http/errors";
 import { getProvider } from "@/providers/registry";
 import {
   deleteProviderSession,
+  deleteProviderSessionsForProviderAccount,
   getRememberedProviderSessionCookieClearOptions,
   getRememberedProviderSessionCookieName,
   getRememberedProviderSessionCookieOptions,
@@ -112,13 +114,27 @@ sessionRouter.get(
 
 sessionRouter.delete("/", (req, res) => {
   setNoStore(res);
-  const session = getProviderSession(getRequestSessionId(req));
+  const startedAt = Date.now();
+  const requestSessionId = getRequestSessionId(req);
+  const session = getProviderSession(requestSessionId);
   const rememberedToken = readCookie(
     req.header("cookie"),
     getRememberedProviderSessionCookieName(),
   );
+  const rememberedSession = getRememberedProviderSession(rememberedToken);
+  const providerAccountId =
+    session?.providerAccountId ?? rememberedSession?.providerAccountId;
   revokeRememberedProviderSession(rememberedToken);
-  deleteProviderSession(getRequestSessionId(req));
+  let deletedSessionCount = 0;
+  if (providerAccountId) {
+    deletedSessionCount =
+      deleteProviderSessionsForProviderAccount(providerAccountId);
+  } else {
+    deleteProviderSession(requestSessionId);
+  }
+  const deletedProviderAccount = providerAccountId
+    ? deleteProviderAccount(providerAccountId)
+    : false;
   res.clearCookie(
     getSessionCookieName(),
     getSessionCookieClearOptions(req.secure),
@@ -129,13 +145,16 @@ sessionRouter.delete("/", (req, res) => {
   );
   res.status(204).end();
 
-  logger.info("Provider session logged out.", {
-    ...logEventFields("session.logout", "success"),
+  logger.info("Provider account disconnected.", {
+    ...logEventFields("session.disconnect", "success"),
+    ...logDurationFields(startedAt),
     ...compactLogFields({
       "provider.id": session?.providerId,
-      "provider.account.id": session?.providerAccountId,
+      "provider.account.id": providerAccountId,
       "session.id": session?.id,
+      "session.deleted_count": deletedSessionCount,
       "session.remembered.present": Boolean(rememberedToken),
+      "provider.account.deleted": deletedProviderAccount,
     }),
   });
 });

--- a/apps/server/src/session/store.test.ts
+++ b/apps/server/src/session/store.test.ts
@@ -13,6 +13,8 @@ const appModuleSpecifier = "@/app";
 const databaseModuleSpecifier = "@/db/database";
 const providerAccountsRepositoryModuleSpecifier =
   "@/db/providerAccountsRepository";
+const mediaSourcesRepositoryModuleSpecifier = "@/db/mediaSourcesRepository";
+const providerPersistenceModuleSpecifier = "@/db/providerPersistence";
 const rememberedProviderSessionsRepositoryModuleSpecifier =
   "@/db/rememberedProviderSessionsRepository";
 const storeModuleSpecifier = "@/session/store";
@@ -271,7 +273,7 @@ void test("clears invalid remembered provider session cookies from /api/session"
   }
 });
 
-void test("logout revokes the remembered provider session token", () => {
+void test("disconnect removes the provider account and cascades saved sources", () => {
   const dataDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "cliparr-session-route-"),
   );
@@ -283,13 +285,23 @@ void test("logout revokes the remembered provider session token", () => {
 
       const { createApp } = await import(${JSON.stringify(appModuleSpecifier)});
       const { closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
-      const { upsertProviderAccountByAccessToken } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
+      const {
+        getProviderAccount,
+        upsertProviderAccountByAccessToken,
+      } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
+      const {
+        getMediaSourceByProviderExternalId,
+        listMediaSources,
+        upsertMediaSource,
+      } = await import(${JSON.stringify(mediaSourcesRepositoryModuleSpecifier)});
+      const { persistProviderAuth } = await import(${JSON.stringify(providerPersistenceModuleSpecifier)});
       const {
         createRememberedProviderSession,
         getRememberedProviderSession,
       } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
       const {
         createProviderSession,
+        getProviderSession,
         getRememberedProviderSessionCookieName,
         getSessionCookieName,
       } = await import(${JSON.stringify(storeModuleSpecifier)});
@@ -308,8 +320,21 @@ void test("logout revokes the remembered provider session token", () => {
           accessToken: "persisted-user-token",
         });
         assert(account);
+        const source = upsertMediaSource({
+          providerId: "plex",
+          providerAccountId: account.id,
+          externalId: "plex-server-1",
+          name: "Living Room Plex",
+          baseUrl: "http://192.0.2.10:32400",
+        });
+        assert(source);
 
         const session = createProviderSession({
+          providerId: "plex",
+          providerAccountId: account.id,
+          userToken: "persisted-user-token",
+        });
+        const otherSession = createProviderSession({
           providerId: "plex",
           providerAccountId: account.id,
           userToken: "persisted-user-token",
@@ -329,13 +354,138 @@ void test("logout revokes the remembered provider session token", () => {
         );
 
         assert.equal(response.status, 204);
+        assert.equal(getProviderAccount(account.id), undefined);
+        assert.equal(getProviderSession(session.id), undefined);
+        assert.equal(getProviderSession(otherSession.id), undefined);
         assert.equal(getRememberedProviderSession(rememberedSession.token), undefined);
+        assert.equal(
+          getMediaSourceByProviderExternalId("plex", account.id, "plex-server-1"),
+          undefined
+        );
+        assert.equal(listMediaSources({ providerAccountId: account.id }).length, 0);
+
+        const reauthenticatedAccount = persistProviderAuth({
+          provider: {
+            id: "plex",
+            name: "Plex",
+            auth: "pin",
+          },
+          userToken: "new-persisted-user-token",
+          resources: [
+            {
+              id: "plex-server-1",
+              name: "Living Room Plex",
+              accessToken: "new-plex-server-token",
+              connections: [
+                {
+                  id: "auto-connection",
+                  uri: "http://192.0.2.10:32400",
+                  local: true,
+                  relay: false,
+                },
+              ],
+            },
+          ],
+        });
+        assert(reauthenticatedAccount);
+        assert.notEqual(reauthenticatedAccount.id, account.id);
+        assert.deepEqual(
+          listMediaSources({ providerId: "plex" }).map((item) => item.externalId),
+          ["plex-server-1"]
+        );
 
         const setCookies = response.headers.getSetCookie();
         assert(setCookies.some((cookie) =>
           cookie.startsWith(\`\${getSessionCookieName()}=\`)
           && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
         ));
+        assert(setCookies.some((cookie) =>
+          cookie.startsWith(\`\${getRememberedProviderSessionCookieName()}=\`)
+          && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+        ));
+      } finally {
+        await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve(undefined)));
+        closeDatabase();
+      }
+    `,
+      { dataDir },
+    );
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+void test("disconnect uses the remembered provider account when the session cookie is missing", () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "cliparr-session-route-"),
+  );
+
+  try {
+    runStoreScript(
+      `
+      import assert from "node:assert/strict";
+
+      const { createApp } = await import(${JSON.stringify(appModuleSpecifier)});
+      const { closeDatabase } = await import(${JSON.stringify(databaseModuleSpecifier)});
+      const {
+        getProviderAccount,
+        upsertProviderAccountByAccessToken,
+      } = await import(${JSON.stringify(providerAccountsRepositoryModuleSpecifier)});
+      const {
+        getMediaSourceByProviderExternalId,
+        upsertMediaSource,
+      } = await import(${JSON.stringify(mediaSourcesRepositoryModuleSpecifier)});
+      const {
+        createRememberedProviderSession,
+        getRememberedProviderSession,
+      } = await import(${JSON.stringify(rememberedProviderSessionsRepositoryModuleSpecifier)});
+      const {
+        getRememberedProviderSessionCookieName,
+      } = await import(${JSON.stringify(storeModuleSpecifier)});
+
+      const { app } = await createApp();
+      const server = app.listen(0, "127.0.0.1");
+
+      try {
+        await new Promise((resolve) => server.once("listening", resolve));
+        const address = server.address();
+        assert(address && typeof address === "object");
+
+        const account = upsertProviderAccountByAccessToken({
+          providerId: "plex",
+          label: "Plex Account",
+          accessToken: "persisted-user-token",
+        });
+        assert(account);
+        const source = upsertMediaSource({
+          providerId: "plex",
+          providerAccountId: account.id,
+          externalId: "plex-server-1",
+          name: "Living Room Plex",
+          baseUrl: "http://192.0.2.10:32400",
+        });
+        assert(source);
+
+        const rememberedSession = createRememberedProviderSession(account.id);
+        const response = await fetch(
+          \`http://127.0.0.1:\${address.port}/api/session\`,
+          {
+            method: "DELETE",
+            headers: {
+              cookie: \`\${getRememberedProviderSessionCookieName()}=\${rememberedSession.token}\`,
+            },
+          }
+        );
+
+        assert.equal(response.status, 204);
+        assert.equal(getProviderAccount(account.id), undefined);
+        assert.equal(getRememberedProviderSession(rememberedSession.token), undefined);
+        assert.equal(
+          getMediaSourceByProviderExternalId("plex", account.id, "plex-server-1"),
+          undefined
+        );
+
+        const setCookies = response.headers.getSetCookie();
         assert(setCookies.some((cookie) =>
           cookie.startsWith(\`\${getRememberedProviderSessionCookieName()}=\`)
           && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT")

--- a/apps/server/src/session/store.ts
+++ b/apps/server/src/session/store.ts
@@ -175,6 +175,31 @@ export function deleteProviderSession(sessionId?: string) {
   }
 }
 
+export function deleteProviderSessionsForProviderAccount(
+  providerAccountId?: string,
+) {
+  if (!providerAccountId) {
+    return 0;
+  }
+
+  const db = getDatabase();
+  const sessionRows = db
+    .select({ id: providerSessions.id })
+    .from(providerSessions)
+    .where(eq(providerSessions.providerAccountId, providerAccountId))
+    .all();
+  const result = db
+    .delete(providerSessions)
+    .where(eq(providerSessions.providerAccountId, providerAccountId))
+    .run();
+
+  for (const session of sessionRows) {
+    mediaHandlesBySessionId.delete(session.id);
+  }
+
+  return Number(result.changes);
+}
+
 export function getSessionCookieName() {
   return SESSION_COOKIE;
 }


### PR DESCRIPTION
## Summary
- Make dashboard disconnect remove the current provider account and cascade saved sources, remembered sessions, and session rows.
- Clear all in-memory provider sessions for the disconnected account so stale media handles do not survive re-auth.
- Keep individual source deletion as a hard delete and verify dashboard discovery excludes deleted sources.
- Rename frontend intent from logout to disconnect while preserving DELETE /api/session.

## Validation
- pnpm preflight