### PR TITLE
feat(frontend): smooth app state transitions

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   AlertTriangle,
   FolderOpen,
@@ -27,6 +28,7 @@ import {
   flattenDashboardPlaybackItems,
   formatViewerSessionCount,
 } from "@/components/dashboardPlaybackItems";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
 import type { DashboardPlaybackCardItem } from "@/components/dashboardPlaybackItems";
 import type {
   CurrentlyPlayingItem,
@@ -78,6 +80,26 @@ const DASHBOARD_VIDEO_STYLE_BODY_CLASS =
   "flex flex-1 flex-col gap-3 p-3 md:p-4";
 const DASHBOARD_PLAYBACK_GRID_CLASS =
   "grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3";
+const DASHBOARD_PLAYBACK_STATE_INITIAL = {
+  opacity: 0,
+  y: 6,
+  filter: "blur(8px)",
+};
+const DASHBOARD_PLAYBACK_STATE_VISIBLE = {
+  opacity: 1,
+  y: 0,
+  filter: "blur(0px)",
+};
+const DASHBOARD_PLAYBACK_STATE_EXIT = {
+  opacity: 0,
+  y: -4,
+  filter: "blur(6px)",
+};
+const DASHBOARD_SKELETON_BREAKPOINT_CLASSES = [
+  "",
+  "hidden md:block",
+  "hidden xl:block",
+] as const;
 
 function ViewerAvatar({
   name,
@@ -262,6 +284,157 @@ function DashboardPlaybackCardSkeleton({ className }: { className?: string }) {
         <div className="h-5 w-24 rounded bg-muted/70" />
         <div className="mt-auto h-9 w-full rounded-lg bg-primary/10" />
       </div>
+    </div>
+  );
+}
+
+function dashboardSkeletonExit(index: number, loadedCardCount: number) {
+  const loadedIndex = Math.max(loadedCardCount - 1, 0);
+  const targetIndex = Math.min(index, loadedIndex);
+
+  return {
+    opacity: 0,
+    x: `${(targetIndex - index) * 104}%`,
+    scale: 0.98,
+    filter: "blur(8px)",
+  };
+}
+
+function DashboardPlaybackMotionRegion({
+  loading,
+  error,
+  playbackCards,
+  emptyMessage,
+  activeViewTransitionSessionId,
+  onSelectSession,
+}: {
+  loading: boolean;
+  error: string;
+  playbackCards: DashboardPlaybackCardItem[];
+  emptyMessage: string;
+  activeViewTransitionSessionId?: string | null;
+  onSelectSession: (session: CurrentlyPlayingItem) => void;
+}) {
+  const reduceMotion = useReducedMotion();
+  const hasPlaybackCards = playbackCards.length > 0;
+  const stateTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.standard;
+  const exitTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
+  const layoutTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.layout;
+
+  return (
+    <div data-dashboard-playback-motion>
+      <AnimatePresence mode="popLayout" initial={false}>
+        {loading && !error && (
+          <motion.div
+            key="dashboard-playback-loading"
+            layout={!reduceMotion}
+            role="status"
+            aria-live="polite"
+            aria-label="Loading currently playing sessions"
+            className={DASHBOARD_PLAYBACK_GRID_CLASS}
+            data-dashboard-loading-grid
+            data-dashboard-loading-items={
+              DASHBOARD_SKELETON_BREAKPOINT_CLASSES.length
+            }
+            transition={layoutTransition}
+          >
+            {DASHBOARD_SKELETON_BREAKPOINT_CLASSES.map((className, index) => (
+              <motion.div
+                key={index}
+                layout={!reduceMotion}
+                className={className}
+                exit={
+                  reduceMotion
+                    ? { opacity: 0 }
+                    : dashboardSkeletonExit(index, playbackCards.length)
+                }
+                transition={
+                  reduceMotion
+                    ? exitTransition
+                    : {
+                        ...exitTransition,
+                        delay: index * 0.03,
+                      }
+                }
+              >
+                <DashboardPlaybackCardSkeleton />
+              </motion.div>
+            ))}
+          </motion.div>
+        )}
+
+        {!loading && hasPlaybackCards && !error && (
+          <motion.div
+            key="dashboard-playback-cards"
+            layout={!reduceMotion}
+            className={DASHBOARD_PLAYBACK_GRID_CLASS}
+            data-dashboard-playback-grid
+            initial={DASHBOARD_PLAYBACK_STATE_INITIAL}
+            animate={DASHBOARD_PLAYBACK_STATE_VISIBLE}
+            exit={DASHBOARD_PLAYBACK_STATE_EXIT}
+            transition={stateTransition}
+          >
+            {playbackCards.map((card, index) => (
+              <motion.div
+                key={card.session.id}
+                layout={!reduceMotion}
+                initial={
+                  reduceMotion
+                    ? { opacity: 1 }
+                    : DASHBOARD_PLAYBACK_STATE_INITIAL
+                }
+                animate={DASHBOARD_PLAYBACK_STATE_VISIBLE}
+                exit={DASHBOARD_PLAYBACK_STATE_EXIT}
+                transition={
+                  reduceMotion
+                    ? stateTransition
+                    : {
+                        ...stateTransition,
+                        delay: Math.min(index * 0.04, 0.12),
+                      }
+                }
+              >
+                <DashboardPlaybackCard
+                  card={card}
+                  activeViewTransitionSessionId={activeViewTransitionSessionId}
+                  onSelectSession={onSelectSession}
+                />
+              </motion.div>
+            ))}
+          </motion.div>
+        )}
+
+        {!loading && !hasPlaybackCards && !error && (
+          <motion.div
+            key="dashboard-playback-empty"
+            layout={!reduceMotion}
+            className="bg-card text-card-foreground border border-border rounded-2xl p-12 text-center"
+            data-dashboard-empty-state
+            initial={
+              reduceMotion ? { opacity: 1 } : DASHBOARD_PLAYBACK_STATE_INITIAL
+            }
+            animate={DASHBOARD_PLAYBACK_STATE_VISIBLE}
+            exit={DASHBOARD_PLAYBACK_STATE_EXIT}
+            transition={stateTransition}
+          >
+            <div className="bg-background w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Play className="w-6 h-6 text-muted-foreground" />
+            </div>
+            <h3 className="text-lg font-medium mb-2">
+              Nothing is playing right now
+            </h3>
+            <p className="text-muted-foreground text-sm max-w-sm mx-auto">
+              {emptyMessage}
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }
@@ -523,46 +696,14 @@ export default function DashboardScreen({
 
           {!error && <WarningBanner sourceErrors={sourceErrors} />}
 
-          {!loading && !hasPlaybackCards && !error && (
-            <div className="bg-card text-card-foreground border border-border rounded-2xl p-12 text-center">
-              <div className="bg-background w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Play className="w-6 h-6 text-muted-foreground" />
-              </div>
-              <h3 className="text-lg font-medium mb-2">
-                Nothing is playing right now
-              </h3>
-              <p className="text-muted-foreground text-sm max-w-sm mx-auto">
-                {emptyMessage}
-              </p>
-            </div>
-          )}
-
-          {loading && !error && (
-            <div
-              role="status"
-              aria-live="polite"
-              aria-label="Loading currently playing sessions"
-              className={DASHBOARD_PLAYBACK_GRID_CLASS}
-              data-dashboard-loading-grid
-            >
-              <DashboardPlaybackCardSkeleton />
-              <DashboardPlaybackCardSkeleton className="hidden md:flex" />
-              <DashboardPlaybackCardSkeleton className="hidden xl:flex" />
-            </div>
-          )}
-
-          {!loading && hasPlaybackCards && (
-            <div className={DASHBOARD_PLAYBACK_GRID_CLASS}>
-              {playbackCards.map((card) => (
-                <DashboardPlaybackCard
-                  key={card.session.id}
-                  card={card}
-                  activeViewTransitionSessionId={activeViewTransitionSessionId}
-                  onSelectSession={onSelectSession}
-                />
-              ))}
-            </div>
-          )}
+          <DashboardPlaybackMotionRegion
+            loading={loading}
+            error={error}
+            playbackCards={playbackCards}
+            emptyMessage={emptyMessage}
+            activeViewTransitionSessionId={activeViewTransitionSessionId}
+            onSelectSession={onSelectSession}
+          />
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -375,7 +375,11 @@ function DashboardPlaybackMotionRegion({
             layout={!reduceMotion}
             className={DASHBOARD_PLAYBACK_GRID_CLASS}
             data-dashboard-playback-grid
-            initial={DASHBOARD_PLAYBACK_STATE_INITIAL}
+            initial={
+              reduceMotion
+                ? DASHBOARD_PLAYBACK_STATE_VISIBLE
+                : DASHBOARD_PLAYBACK_STATE_INITIAL
+            }
             animate={DASHBOARD_PLAYBACK_STATE_VISIBLE}
             exit={DASHBOARD_PLAYBACK_STATE_EXIT}
             transition={stateTransition}

--- a/apps/frontend/src/components/editor/EditorLayout.tsx
+++ b/apps/frontend/src/components/editor/EditorLayout.tsx
@@ -1,5 +1,6 @@
 import { Eye } from "lucide-react";
 import type { ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -10,8 +11,25 @@ import {
   EDITOR_RESIZE_TARGET_MINIMUM_SIZE,
 } from "@/components/editor/editorLayoutSizing";
 import { EditorSidebar } from "@/components/editor/EditorSidebar";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
 
 export type EditorLayoutVariant = "desktop" | "mobile";
+
+const EDITOR_READY_STATE_INITIAL = {
+  opacity: 0,
+  y: 4,
+  filter: "blur(6px)",
+};
+const EDITOR_READY_STATE_VISIBLE = {
+  opacity: 1,
+  y: 0,
+  filter: "blur(0px)",
+};
+const EDITOR_READY_STATE_EXIT = {
+  opacity: 0,
+  y: -3,
+  filter: "blur(6px)",
+};
 
 export function EditorPreviewPane({
   error,
@@ -22,6 +40,10 @@ export function EditorPreviewPane({
   variant: EditorLayoutVariant;
   children: ReactNode;
 }) {
+  const reduceMotion = useReducedMotion();
+  const stateTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
   const previewStage = (
     <section
       className={
@@ -40,11 +62,21 @@ export function EditorPreviewPane({
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
-      {error && (
-        <div className="shrink-0 border border-destructive/35 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {error}
-        </div>
-      )}
+      <AnimatePresence initial={false}>
+        {error && (
+          <motion.div
+            key="editor-preview-error"
+            layout={!reduceMotion}
+            className="shrink-0 border border-destructive/35 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            initial={reduceMotion ? { opacity: 1 } : EDITOR_READY_STATE_INITIAL}
+            animate={EDITOR_READY_STATE_VISIBLE}
+            exit={EDITOR_READY_STATE_EXIT}
+            transition={stateTransition}
+          >
+            {error}
+          </motion.div>
+        )}
+      </AnimatePresence>
       {previewStage}
     </div>
   );
@@ -61,6 +93,11 @@ export function EditorTimelinePane({
   hasDuration: boolean;
   timeline: ReactNode;
 }) {
+  const reduceMotion = useReducedMotion();
+  const stateTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.standard;
+
   return (
     <section
       className={
@@ -71,18 +108,35 @@ export function EditorTimelinePane({
     >
       {controls}
 
-      {!hasDuration && (
-        <div className="border-t border-editor-border px-3 py-3 text-sm text-muted-foreground">
-          Waiting for media duration.
-        </div>
-      )}
-
-      {hasDuration &&
-        (variant === "desktop" ? (
-          <div className="min-h-0 flex-1">{timeline}</div>
+      <AnimatePresence mode="popLayout" initial={false}>
+        {!hasDuration ? (
+          <motion.div
+            key="editor-waiting-duration"
+            layout={!reduceMotion}
+            className="border-t border-editor-border px-3 py-3 text-sm text-muted-foreground"
+            data-editor-waiting-duration
+            initial={reduceMotion ? { opacity: 1 } : EDITOR_READY_STATE_INITIAL}
+            animate={EDITOR_READY_STATE_VISIBLE}
+            exit={EDITOR_READY_STATE_EXIT}
+            transition={stateTransition}
+          >
+            Waiting for media duration.
+          </motion.div>
         ) : (
-          timeline
-        ))}
+          <motion.div
+            key="editor-timeline-ready"
+            layout={!reduceMotion}
+            className={variant === "desktop" ? "min-h-0 flex-1" : undefined}
+            data-editor-timeline-ready
+            initial={reduceMotion ? { opacity: 1 } : EDITOR_READY_STATE_INITIAL}
+            animate={EDITOR_READY_STATE_VISIBLE}
+            exit={EDITOR_READY_STATE_EXIT}
+            transition={stateTransition}
+          >
+            {timeline}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 }

--- a/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorPlaybackSourcePanel.tsx
@@ -1,4 +1,6 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
 
 interface EditorPlaybackSourcePanelProps {
   previewSourceLabel: string;
@@ -19,12 +21,32 @@ function displaySourceLabel(label: string) {
   return label;
 }
 
+const SOURCE_NOTE_INITIAL = {
+  opacity: 0,
+  y: 4,
+  filter: "blur(6px)",
+};
+const SOURCE_NOTE_VISIBLE = {
+  opacity: 1,
+  y: 0,
+  filter: "blur(0px)",
+};
+const SOURCE_NOTE_EXIT = {
+  opacity: 0,
+  y: -3,
+  filter: "blur(6px)",
+};
+
 export function EditorPlaybackSourcePanel({
   previewSourceLabel,
   fallbackMessage,
   hasHlsSource,
   className,
 }: EditorPlaybackSourcePanelProps) {
+  const reduceMotion = useReducedMotion();
+  const transition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
   const sourceNote =
     fallbackMessage ??
     (!hasHlsSource && previewSourceLabel === "Direct source"
@@ -45,11 +67,21 @@ export function EditorPlaybackSourcePanel({
             {displaySourceLabel(previewSourceLabel)}
           </div>
 
-          {sourceNote && (
-            <p className="mt-2.5 border-t border-editor-border pt-2.5 text-xs leading-5 text-muted-foreground">
-              {sourceNote}
-            </p>
-          )}
+          <AnimatePresence initial={false}>
+            {sourceNote && (
+              <motion.p
+                key={sourceNote}
+                layout={!reduceMotion}
+                className="mt-2.5 border-t border-editor-border pt-2.5 text-xs leading-5 text-muted-foreground"
+                initial={reduceMotion ? { opacity: 1 } : SOURCE_NOTE_INITIAL}
+                animate={SOURCE_NOTE_VISIBLE}
+                exit={SOURCE_NOTE_EXIT}
+                transition={transition}
+              >
+                {sourceNote}
+              </motion.p>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </section>

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -371,6 +371,8 @@ void test("reserves dashboard playback card space before sessions load", () => {
   );
 
   assert.match(markup, /data-dashboard-loading-grid/);
+  assert.match(markup, /data-dashboard-playback-motion/);
+  assert.match(markup, /data-dashboard-loading-items="3"/);
   assert.match(markup, /role="status"/);
   assert.match(markup, /aria-live="polite"/);
   assert.match(markup, /aria-label="Loading currently playing sessions"/);

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -16,6 +16,7 @@ import { EditorControls } from "@/components/editor/EditorControls";
 import { EditorExportDialog } from "@/components/editor/EditorExportDialog";
 import { EditorFramegrabDialog } from "@/components/editor/EditorFramegrabDialog";
 import { EditorHeader } from "@/components/editor/EditorHeader";
+import { EditorTimelinePane } from "@/components/editor/EditorLayout";
 import { EditorPreview } from "@/components/editor/EditorPreview";
 import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
 import ProviderConnectScreen from "@/components/provider-connect/ProviderConnectScreen";
@@ -539,6 +540,29 @@ void test("renders mobile editor controls trigger and compact range summary", ()
   assert.match(markup, />In</);
   assert.match(markup, />Out</);
   assert.match(markup, />Duration</);
+});
+
+void test("renders editor readiness transition hooks", () => {
+  const waitingMarkup = renderToStaticMarkup(
+    createElement(EditorTimelinePane, {
+      variant: "desktop",
+      controls: createElement("div"),
+      hasDuration: false,
+      timeline: createElement("div"),
+    }),
+  );
+  const readyMarkup = renderToStaticMarkup(
+    createElement(EditorTimelinePane, {
+      variant: "desktop",
+      controls: createElement("div"),
+      hasDuration: true,
+      timeline: createElement("div"),
+    }),
+  );
+
+  assert.match(waitingMarkup, /data-editor-waiting-duration/);
+  assert.match(waitingMarkup, /Waiting for media duration/);
+  assert.match(readyMarkup, /data-editor-timeline-ready/);
 });
 
 void test("renders editor poster with the shared thumbnail view transition", () => {

--- a/apps/frontend/src/components/sources/SourcesDialog.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialog.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { DialogWindow } from "@/components/ui/dialog";
 import {
   SourceCard,
@@ -9,6 +10,7 @@ import {
   SourcesDialogHeader,
 } from "@/components/sources/SourcesDialogSections";
 import { useSourcesState } from "@/components/sources/useSourcesState";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
 
 interface Props {
   isOpen: boolean;
@@ -16,12 +18,29 @@ interface Props {
   onSourcesChanged?: () => Promise<void> | void;
 }
 
+const SOURCES_STATE_INITIAL = {
+  opacity: 0,
+  y: 6,
+  filter: "blur(8px)",
+};
+const SOURCES_STATE_VISIBLE = {
+  opacity: 1,
+  y: 0,
+  filter: "blur(0px)",
+};
+const SOURCES_STATE_EXIT = {
+  opacity: 0,
+  y: -4,
+  filter: "blur(6px)",
+};
+
 export default function SourcesDialog({
   isOpen,
   onClose,
   onSourcesChanged,
 }: Props) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const reduceMotion = useReducedMotion();
   const {
     sources,
     filteredSources,
@@ -58,6 +77,15 @@ export default function SourcesDialog({
     isOpen,
     onSourcesChanged,
   });
+  const stateTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.standard;
+  const exitTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
+  const layoutTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.layout;
 
   return (
     <DialogWindow
@@ -98,57 +126,132 @@ export default function SourcesDialog({
         <div className="space-y-3">
           <SourcesDialogAlerts error={error} feedback={feedback} />
 
-          {showConnectPanel && (
-            <SourcesConnectSection
-              forceAddSourceOpen={forceAddSourceOpen}
-              onClosePanel={() => setShowAddSource(false)}
-              onConnected={handleSourceConnected}
-            />
-          )}
+          <AnimatePresence mode="popLayout" initial={false}>
+            {showConnectPanel && (
+              <motion.div
+                key="sources-connect-panel"
+                layout={!reduceMotion}
+                initial={reduceMotion ? { opacity: 1 } : SOURCES_STATE_INITIAL}
+                animate={SOURCES_STATE_VISIBLE}
+                exit={SOURCES_STATE_EXIT}
+                transition={stateTransition}
+              >
+                <SourcesConnectSection
+                  forceAddSourceOpen={forceAddSourceOpen}
+                  onClosePanel={() => setShowAddSource(false)}
+                  onConnected={handleSourceConnected}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
-          {loading ? (
-            <div className="flex flex-col gap-3">
-              {Array.from({ length: 4 }).map((_, index) => (
-                <div
-                  key={index}
-                  className="h-56 animate-pulse rounded-lg border border-border bg-muted/60"
+          <AnimatePresence mode="popLayout" initial={false}>
+            {loading ? (
+              <motion.div
+                key="sources-loading"
+                layout={!reduceMotion}
+                className="flex flex-col gap-3"
+                data-sources-loading-list
+                transition={layoutTransition}
+              >
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <motion.div
+                    key={index}
+                    layout={!reduceMotion}
+                    className="h-56 animate-pulse rounded-lg border border-border bg-muted/60"
+                    exit={SOURCES_STATE_EXIT}
+                    transition={
+                      reduceMotion
+                        ? exitTransition
+                        : {
+                            ...exitTransition,
+                            delay: index * 0.025,
+                          }
+                    }
+                  />
+                ))}
+              </motion.div>
+            ) : sources.length === 0 ? (
+              <motion.div
+                key="sources-empty"
+                layout={!reduceMotion}
+                data-sources-empty-state
+                initial={reduceMotion ? { opacity: 1 } : SOURCES_STATE_INITIAL}
+                animate={SOURCES_STATE_VISIBLE}
+                exit={SOURCES_STATE_EXIT}
+                transition={stateTransition}
+              >
+                <SourcesEmptyState
+                  title="No sources connected yet"
+                  description="Connect a Plex or Jellyfin server to get started."
                 />
-              ))}
-            </div>
-          ) : sources.length === 0 ? (
-            <SourcesEmptyState
-              title="No sources connected yet"
-              description="Connect a Plex or Jellyfin server to get started."
-            />
-          ) : filteredSources.length === 0 ? (
-            <SourcesEmptyState
-              title="No sources match this view"
-              description="Try another filter or search."
-            />
-          ) : (
-            <div className="flex flex-col gap-3">
-              {filteredSources.map((source) => (
-                <SourceCard
-                  key={source.id}
-                  source={source}
-                  draftName={draftNames[source.id] ?? source.name}
-                  draftBaseUrl={draftBaseUrls[source.id] ?? source.baseUrl}
-                  busyAction={busyActions[source.id]}
-                  refreshingAll={refreshingAll}
-                  onDraftNameChange={(value) =>
-                    updateDraftName(source.id, value)
-                  }
-                  onDraftBaseUrlChange={(value) =>
-                    updateDraftBaseUrl(source.id, value)
-                  }
-                  onSave={() => saveSourceEdits(source)}
-                  onToggleEnabled={() => toggleSourceEnabled(source)}
-                  onRefresh={() => checkSource(source)}
-                  onRemove={() => deleteSource(source)}
+              </motion.div>
+            ) : filteredSources.length === 0 ? (
+              <motion.div
+                key="sources-filtered-empty"
+                layout={!reduceMotion}
+                data-sources-empty-state
+                initial={reduceMotion ? { opacity: 1 } : SOURCES_STATE_INITIAL}
+                animate={SOURCES_STATE_VISIBLE}
+                exit={SOURCES_STATE_EXIT}
+                transition={stateTransition}
+              >
+                <SourcesEmptyState
+                  title="No sources match this view"
+                  description="Try another filter or search."
                 />
-              ))}
-            </div>
-          )}
+              </motion.div>
+            ) : (
+              <motion.div
+                key="sources-list"
+                layout={!reduceMotion}
+                className="flex flex-col gap-3"
+                data-sources-list
+                initial={reduceMotion ? { opacity: 1 } : SOURCES_STATE_INITIAL}
+                animate={SOURCES_STATE_VISIBLE}
+                exit={SOURCES_STATE_EXIT}
+                transition={stateTransition}
+              >
+                {filteredSources.map((source, index) => (
+                  <motion.div
+                    key={source.id}
+                    layout={!reduceMotion}
+                    initial={
+                      reduceMotion ? { opacity: 1 } : SOURCES_STATE_INITIAL
+                    }
+                    animate={SOURCES_STATE_VISIBLE}
+                    exit={SOURCES_STATE_EXIT}
+                    transition={
+                      reduceMotion
+                        ? stateTransition
+                        : {
+                            ...stateTransition,
+                            delay: Math.min(index * 0.03, 0.12),
+                          }
+                    }
+                  >
+                    <SourceCard
+                      source={source}
+                      draftName={draftNames[source.id] ?? source.name}
+                      draftBaseUrl={draftBaseUrls[source.id] ?? source.baseUrl}
+                      busyAction={busyActions[source.id]}
+                      refreshingAll={refreshingAll}
+                      onDraftNameChange={(value) =>
+                        updateDraftName(source.id, value)
+                      }
+                      onDraftBaseUrlChange={(value) =>
+                        updateDraftBaseUrl(source.id, value)
+                      }
+                      onSave={() => saveSourceEdits(source)}
+                      onToggleEnabled={() => toggleSourceEnabled(source)}
+                      onRefresh={() => checkSource(source)}
+                      onRemove={() => deleteSource(source)}
+                    />
+                  </motion.div>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </DialogWindow>

--- a/apps/frontend/src/components/sources/SourcesDialogSections.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialogSections.tsx
@@ -1,4 +1,5 @@
 import type { KeyboardEvent, RefObject } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -22,6 +23,7 @@ import {
   iconButtonClasses,
   textInputClasses as inputClasses,
 } from "@/components/ui/control-styles";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
 import type { MediaSource, ProviderSession } from "@/providers/types";
 import { formatProviderName } from "@/components/providers/ProviderGlyph";
 import SourceConnectPanel from "@/components/sources/SourceConnectPanel";
@@ -86,6 +88,21 @@ const healthySurfaceClasses = "border-primary/30 bg-primary/10 text-foreground";
 const attentionSurfaceClasses =
   "border-destructive/30 bg-destructive/10 text-destructive";
 const secondarySurfaceClasses = "border-border bg-muted text-muted-foreground";
+const SOURCE_STATE_INITIAL = {
+  opacity: 0,
+  y: 4,
+  filter: "blur(6px)",
+};
+const SOURCE_STATE_VISIBLE = {
+  opacity: 1,
+  y: 0,
+  filter: "blur(0px)",
+};
+const SOURCE_STATE_EXIT = {
+  opacity: 0,
+  y: -3,
+  filter: "blur(6px)",
+};
 
 function stringValue(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -390,12 +407,32 @@ export function SourcesDialogAlerts({
   error,
   feedback,
 }: SourcesDialogAlertsProps) {
+  const reduceMotion = useReducedMotion();
+  const transition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
+
   return (
-    <>
-      {error && <div className={destructiveAlertClasses}>{error}</div>}
+    <AnimatePresence mode="popLayout" initial={false}>
+      {error && (
+        <motion.div
+          key="sources-error"
+          layout={!reduceMotion}
+          className={destructiveAlertClasses}
+          data-sources-error-alert
+          initial={reduceMotion ? { opacity: 1 } : SOURCE_STATE_INITIAL}
+          animate={SOURCE_STATE_VISIBLE}
+          exit={SOURCE_STATE_EXIT}
+          transition={transition}
+        >
+          {error}
+        </motion.div>
+      )}
 
       {feedback && (
-        <div
+        <motion.div
+          key={`sources-feedback-${feedback.tone}-${feedback.message}`}
+          layout={!reduceMotion}
           className={cn(
             "rounded-md border px-3 py-2 text-sm",
             feedback.tone === "error" &&
@@ -403,11 +440,16 @@ export function SourcesDialogAlerts({
             feedback.tone === "success" && healthySurfaceClasses,
             feedback.tone === "warning" && attentionSurfaceClasses,
           )}
+          data-sources-feedback-alert
+          initial={reduceMotion ? { opacity: 1 } : SOURCE_STATE_INITIAL}
+          animate={SOURCE_STATE_VISIBLE}
+          exit={SOURCE_STATE_EXIT}
+          transition={transition}
         >
           {feedback.message}
-        </div>
+        </motion.div>
       )}
-    </>
+    </AnimatePresence>
   );
 }
 
@@ -532,6 +574,10 @@ export function SourceCard({
     : null;
   const product = stringValue(source.metadata.product);
   const platform = stringValue(source.metadata.platform);
+  const reduceMotion = useReducedMotion();
+  const stateTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key !== "Enter" || !canSaveEdits) {
@@ -553,35 +599,47 @@ export function SourceCard({
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <span
+          <motion.span
+            layout={!reduceMotion}
             className={joinClassNames(
               statusBadgeClasses,
               "border-border bg-card text-muted-foreground",
             )}
+            transition={stateTransition}
           >
             {formatProviderName(source.providerId)}
-          </span>
-          <span
+          </motion.span>
+          <motion.span
+            layout={!reduceMotion}
             className={joinClassNames(
               statusBadgeClasses,
               "min-w-36 justify-center",
               status.className,
             )}
+            transition={stateTransition}
           >
             <StatusIcon className="h-3.5 w-3.5" />
             {status.label}
-          </span>
-          {busyAction && (
-            <span
-              className={joinClassNames(
-                statusBadgeClasses,
-                "w-32 justify-center border-primary/30 bg-primary/10 text-primary",
-              )}
-            >
-              <RefreshCw className="h-3.5 w-3.5 animate-spin" />
-              {busyAction}
-            </span>
-          )}
+          </motion.span>
+          <AnimatePresence mode="popLayout" initial={false}>
+            {busyAction && (
+              <motion.span
+                key="busy-action"
+                layout={!reduceMotion}
+                className={joinClassNames(
+                  statusBadgeClasses,
+                  "w-32 justify-center border-primary/30 bg-primary/10 text-primary",
+                )}
+                initial={reduceMotion ? { opacity: 1 } : SOURCE_STATE_INITIAL}
+                animate={SOURCE_STATE_VISIBLE}
+                exit={SOURCE_STATE_EXIT}
+                transition={stateTransition}
+              >
+                <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                {busyAction}
+              </motion.span>
+            )}
+          </AnimatePresence>
         </div>
         <div className="text-right text-xs text-muted-foreground">
           <div>Checked {formatTimestamp(source.lastCheckedAt)}</div>
@@ -629,22 +687,30 @@ export function SourceCard({
         </div>
       </dl>
 
-      {source.lastError && (
-        <div
-          className={cn(
-            "mt-3 rounded-md border px-3 py-2 text-sm",
-            attentionSurfaceClasses,
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <div>
-              <div className="font-medium">Last check failed</div>
-              <div className="mt-1">{source.lastError}</div>
+      <AnimatePresence initial={false}>
+        {source.lastError && (
+          <motion.div
+            key="source-last-error"
+            layout={!reduceMotion}
+            className={cn(
+              "mt-3 rounded-md border px-3 py-2 text-sm",
+              attentionSurfaceClasses,
+            )}
+            initial={reduceMotion ? { opacity: 1 } : SOURCE_STATE_INITIAL}
+            animate={SOURCE_STATE_VISIBLE}
+            exit={SOURCE_STATE_EXIT}
+            transition={stateTransition}
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <div className="font-medium">Last check failed</div>
+                <div className="mt-1">{source.lastError}</div>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <div className="mt-4 flex flex-wrap gap-2">
         <TooltipWrap message={!canSaveEdits ? saveDisabledReason : null}>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -161,8 +161,12 @@
   --editor-sidebar-max-width: 85vw;
   --editor-preview-fallback-font-size: 1.5rem;
   --text-editor-preview-fallback: var(--editor-preview-fallback-font-size);
-  --editor-view-transition-duration: 280ms;
-  --editor-view-transition-easing: cubic-bezier(0.2, 0, 0, 1);
+  --motion-duration-fast: 180ms;
+  --motion-duration-medium: 280ms;
+  --motion-duration-standard: 300ms;
+  --motion-easing-standard: cubic-bezier(0.2, 0, 0, 1);
+  --editor-view-transition-duration: var(--motion-duration-medium);
+  --editor-view-transition-easing: var(--motion-easing-standard);
   --status-warning: color-mix(in oklch, var(--primary) 14%, var(--background));
   --status-warning-border: color-mix(in oklch, var(--primary) 28%, transparent);
   --status-warning-foreground: color-mix(
@@ -427,6 +431,10 @@
   --shadow-lg: var(--shadow-lg);
   --shadow-xl: var(--shadow-xl);
   --shadow-2xl: var(--shadow-2xl);
+  --duration-motion-fast: var(--motion-duration-fast);
+  --duration-motion-medium: var(--motion-duration-medium);
+  --duration-motion-standard: var(--motion-duration-standard);
+  --ease-motion-standard: var(--motion-easing-standard);
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
   --tracking-tight: calc(var(--tracking-normal) - 0.025em);
   --tracking-normal: var(--tracking-normal);

--- a/apps/frontend/src/lib/motionPresets.ts
+++ b/apps/frontend/src/lib/motionPresets.ts
@@ -1,0 +1,28 @@
+import type { Transition } from "motion/react";
+
+const cliparrMotionEase = [0.2, 0, 0, 1] as [number, number, number, number];
+
+const cliparrMotionDurations = {
+  fast: 0.18,
+  medium: 0.28,
+  standard: 0.3,
+} as const;
+
+export const cliparrMotionTransitions = {
+  fast: {
+    duration: cliparrMotionDurations.fast,
+    ease: cliparrMotionEase,
+  },
+  medium: {
+    duration: cliparrMotionDurations.medium,
+    ease: cliparrMotionEase,
+  },
+  standard: {
+    duration: cliparrMotionDurations.standard,
+    ease: cliparrMotionEase,
+  },
+  layout: {
+    duration: cliparrMotionDurations.standard,
+    ease: cliparrMotionEase,
+  },
+} satisfies Record<string, Transition>;


### PR DESCRIPTION
## Summary
- add shared frontend motion tokens and motion presets
- smooth dashboard currently-playing loading, empty, and loaded state changes
- smooth source dialog state swaps and editor readiness transitions

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm preflight