### PR TITLE
feat(frontend): add update available notice

### DIFF
--- a/apps/frontend/src/api/cliparrClient.test.ts
+++ b/apps/frontend/src/api/cliparrClient.test.ts
@@ -60,6 +60,38 @@ void test("reports app-page responses as API configuration errors", async () => 
   );
 });
 
+void test("loads version info from the version endpoint", async () => {
+  await withMockedFetch(
+    async (input) => {
+      assert.equal(input, "/api/version");
+      return jsonResponse({
+        currentVersion: "v1.2.3",
+        latestRelease: {
+          tagName: "v1.3.0",
+          url: "https://github.com/TechSquidTV/Cliparr/releases/tag/v1.3.0",
+          publishedAt: "2026-06-04T10:30:00.000Z",
+        },
+        updateAvailable: true,
+        checkedAt: "2026-06-04T12:00:00.000Z",
+        status: "update_available",
+      });
+    },
+    async () => {
+      assert.deepEqual(await cliparrClient.getVersionInfo(), {
+        currentVersion: "v1.2.3",
+        latestRelease: {
+          tagName: "v1.3.0",
+          url: "https://github.com/TechSquidTV/Cliparr/releases/tag/v1.3.0",
+          publishedAt: "2026-06-04T10:30:00.000Z",
+        },
+        updateAvailable: true,
+        checkedAt: "2026-06-04T12:00:00.000Z",
+        status: "update_available",
+      });
+    },
+  );
+});
+
 void test("surfaces JSON API errors and coalesces auth failure notifications", async () => {
   await withMockedFetch(
     async () => {

--- a/apps/frontend/src/api/cliparrClient.ts
+++ b/apps/frontend/src/api/cliparrClient.ts
@@ -19,6 +19,26 @@ interface HealthResponse {
   version?: string;
 }
 
+type VersionInfoStatus =
+  | "current"
+  | "update_available"
+  | "unknown"
+  | "unavailable";
+
+export interface LatestReleaseInfo {
+  tagName: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface CliparrVersionInfo {
+  currentVersion?: string;
+  latestRelease?: LatestReleaseInfo;
+  updateAvailable: boolean;
+  checkedAt?: string;
+  status: VersionInfoStatus;
+}
+
 interface LocalMediaUrlResponse {
   mediaUrl: string;
   hls: boolean;
@@ -158,6 +178,10 @@ export function subscribeToAuthFailure(listener: () => void) {
 }
 
 export const cliparrClient = {
+  async getVersionInfo() {
+    return request<CliparrVersionInfo>("/api/version");
+  },
+
   async getHealth() {
     return request<HealthResponse>("/api/health");
   },

--- a/apps/frontend/src/components/DashboardMobileMenu.tsx
+++ b/apps/frontend/src/components/DashboardMobileMenu.tsx
@@ -8,6 +8,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
+import type { LatestReleaseInfo } from "@/api/cliparrClient";
 
 export const CLIPARR_WEBSITE_URL = "https://cliparr.dev/";
 export const CLIPARR_GITHUB_URL = "https://github.com/TechSquidTV/Cliparr";
@@ -29,9 +30,11 @@ export function GithubIcon({ className }: { className?: string }) {
 
 export function DashboardMobileMenu({
   appVersion,
+  latestRelease,
   onDisconnect,
 }: {
   appVersion: string;
+  latestRelease: LatestReleaseInfo | null;
   onDisconnect: () => Promise<void> | void;
 }) {
   const menuItemClassName =
@@ -110,8 +113,28 @@ export function DashboardMobileMenu({
           </div>
 
           {appVersion && (
-            <DrawerFooter className="border-t-0 px-4 pt-4 pb-0 text-center font-mono text-xs text-muted-foreground">
-              Cliparr {appVersion}
+            <DrawerFooter className="border-t-0 px-4 pt-4 pb-0 text-center text-xs text-muted-foreground">
+              {latestRelease ? (
+                <DrawerClose asChild>
+                  <a
+                    href={latestRelease.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex min-h-11 flex-col items-center justify-center gap-1 rounded-lg border border-primary/35 bg-primary/10 px-3 py-2 text-primary transition-colors hover:bg-primary/15 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
+                    data-dashboard-mobile-update-available
+                  >
+                    <span className="font-mono text-muted-foreground">
+                      Cliparr {appVersion}
+                    </span>
+                    <span className="inline-flex items-center gap-1 font-semibold">
+                      {latestRelease.tagName} available
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </span>
+                  </a>
+                </DrawerClose>
+              ) : (
+                <span className="font-mono">Cliparr {appVersion}</span>
+              )}
             </DrawerFooter>
           )}
         </div>

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -546,6 +546,12 @@ export function DashboardVersionBadge({
             aria-hidden="true"
             data-dashboard-update-indicator
           />
+          <span
+            className="text-[11px] leading-none font-medium text-primary/80"
+            data-dashboard-update-label
+          >
+            Update available
+          </span>
         </a>
       </TooltipTrigger>
       <TooltipContent side="top" align="start">

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -488,9 +488,11 @@ function WarningBanner({
 
 export function DashboardVersionBadge({
   latestRelease,
+  releaseChecksDisabledReason,
   versionLabel,
 }: {
   latestRelease: CliparrVersionInfo["latestRelease"] | null;
+  releaseChecksDisabledReason?: string | null;
   versionLabel: string;
 }) {
   if (!versionLabel) {
@@ -509,7 +511,11 @@ export function DashboardVersionBadge({
     return (
       <span
         className={DASHBOARD_VERSION_BADGE_CLASS}
+        title={releaseChecksDisabledReason ?? undefined}
         data-dashboard-version-badge
+        data-dashboard-release-check-disabled={
+          releaseChecksDisabledReason ? true : undefined
+        }
       >
         {versionLabel}
       </span>
@@ -630,6 +636,12 @@ export default function DashboardScreen({
     versionInfo?.status === "update_available" && versionInfo.latestRelease
       ? versionInfo.latestRelease
       : null;
+  const releaseChecksDisabledReason =
+    versionLabel && versionInfo?.status === "unknown"
+      ? versionLabel === "dev"
+        ? "Local development build; release update checks are disabled"
+        : "Non-release build; release update checks are disabled"
+      : null;
 
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
@@ -651,6 +663,7 @@ export default function DashboardScreen({
                   <DashboardVersionBadge
                     versionLabel={versionLabel}
                     latestRelease={latestUpdateRelease}
+                    releaseChecksDisabledReason={releaseChecksDisabledReason}
                   />
                 </div>
                 <p className="text-sm text-muted-foreground">

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -10,7 +10,7 @@ import {
   Settings2,
   Video,
 } from "lucide-react";
-import { cliparrClient } from "@/api/cliparrClient";
+import { cliparrClient, type CliparrVersionInfo } from "@/api/cliparrClient";
 import { cn } from "@/lib/utils";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 import {
@@ -24,6 +24,11 @@ import {
   GithubIcon,
 } from "@/components/DashboardMobileMenu";
 import { MobilePwaInstallNudge } from "@/components/MobilePwaInstallNudge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   flattenDashboardPlaybackItems,
   formatViewerSessionCount,
@@ -80,6 +85,8 @@ const DASHBOARD_VIDEO_STYLE_BODY_CLASS =
   "flex flex-1 flex-col gap-3 p-3 md:p-4";
 const DASHBOARD_PLAYBACK_GRID_CLASS =
   "grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3";
+const DASHBOARD_VERSION_BADGE_CLASS =
+  "hidden min-h-5 min-w-15 items-center justify-center rounded-full border border-border bg-card px-2 py-0.5 text-xs font-medium text-muted-foreground sm:inline-flex";
 const DASHBOARD_PLAYBACK_STATE_INITIAL = {
   opacity: 0,
   y: 6,
@@ -479,6 +486,69 @@ function WarningBanner({
   );
 }
 
+export function DashboardVersionBadge({
+  latestRelease,
+  versionLabel,
+}: {
+  latestRelease: CliparrVersionInfo["latestRelease"] | null;
+  versionLabel: string;
+}) {
+  if (!versionLabel) {
+    return (
+      <span
+        className={cn(DASHBOARD_VERSION_BADGE_CLASS, "invisible")}
+        aria-hidden="true"
+        data-dashboard-version-badge
+      >
+        0.0.0
+      </span>
+    );
+  }
+
+  if (!latestRelease) {
+    return (
+      <span
+        className={DASHBOARD_VERSION_BADGE_CLASS}
+        data-dashboard-version-badge
+      >
+        {versionLabel}
+      </span>
+    );
+  }
+
+  const updateLabel = `${latestRelease.tagName} is available`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <a
+          href={latestRelease.url}
+          target="_blank"
+          rel="noreferrer"
+          className={cn(
+            DASHBOARD_VERSION_BADGE_CLASS,
+            "gap-1.5 border-primary/40 bg-primary/10 text-primary transition-colors hover:bg-primary/15 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+          )}
+          aria-label={`${updateLabel}. View release notes.`}
+          title={updateLabel}
+          data-dashboard-version-badge
+          data-dashboard-update-available
+        >
+          <span>{versionLabel}</span>
+          <span
+            className="h-1.5 w-1.5 rounded-full bg-primary"
+            aria-hidden="true"
+            data-dashboard-update-indicator
+          />
+        </a>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start">
+        {updateLabel}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export default function DashboardScreen({
   activeViewTransitionSessionId,
   onSelectSession,
@@ -488,7 +558,9 @@ export default function DashboardScreen({
 }: Props) {
   const [viewers, setViewers] = useState<ViewerPlaybackGroup[]>([]);
   const [sourceErrors, setSourceErrors] = useState<SourcePlaybackError[]>([]);
-  const [appVersion, setAppVersion] = useState("");
+  const [versionInfo, setVersionInfo] = useState<CliparrVersionInfo | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState("");
@@ -526,15 +598,15 @@ export default function DashboardScreen({
     let cancelled = false;
 
     void cliparrClient
-      .getHealth()
-      .then((health) => {
+      .getVersionInfo()
+      .then((nextVersionInfo) => {
         if (!cancelled) {
-          setAppVersion(health.version ?? "");
+          setVersionInfo(nextVersionInfo);
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setAppVersion("");
+          setVersionInfo(null);
         }
       });
 
@@ -553,7 +625,11 @@ export default function DashboardScreen({
     sourceErrors.length > 0
       ? "No active playback on the available sources."
       : "No one is currently watching anything.";
-  const versionLabel = appVersion;
+  const versionLabel = versionInfo?.currentVersion ?? "";
+  const latestUpdateRelease =
+    versionInfo?.status === "update_available" && versionInfo.latestRelease
+      ? versionInfo.latestRelease
+      : null;
 
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
@@ -572,16 +648,10 @@ export default function DashboardScreen({
               <div className="space-y-1">
                 <div className="flex flex-wrap items-center gap-2">
                   <h1 className="text-2xl font-bold tracking-tight">Cliparr</h1>
-                  <span
-                    className={cn(
-                      "hidden min-h-5 min-w-15 items-center justify-center rounded-full border border-border bg-card px-2 py-0.5 text-xs font-medium text-muted-foreground sm:inline-flex",
-                      !versionLabel && "invisible",
-                    )}
-                    aria-hidden={!versionLabel}
-                    data-dashboard-version-badge
-                  >
-                    {versionLabel || "0.0.0"}
-                  </span>
+                  <DashboardVersionBadge
+                    versionLabel={versionLabel}
+                    latestRelease={latestUpdateRelease}
+                  />
                 </div>
                 <p className="text-sm text-muted-foreground">
                   Export clips from active playback sessions.
@@ -590,6 +660,7 @@ export default function DashboardScreen({
             </div>
             <DashboardMobileMenu
               appVersion={versionLabel}
+              latestRelease={latestUpdateRelease}
               onDisconnect={onDisconnect}
             />
           </div>

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -9,7 +9,10 @@ import {
   formatViewerSessionCount,
 } from "@/components/dashboardPlaybackItems";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
-import { DashboardPlaybackCard } from "@/components/DashboardScreen";
+import {
+  DashboardPlaybackCard,
+  DashboardVersionBadge,
+} from "@/components/DashboardScreen";
 import DashboardScreen from "@/components/DashboardScreen";
 import { DashboardMobileMenu } from "@/components/DashboardMobileMenu";
 import { EditorControls } from "@/components/editor/EditorControls";
@@ -313,11 +316,34 @@ void test("renders dashboard mobile menu trigger", () => {
   const markup = renderToStaticMarkup(
     createElement(DashboardMobileMenu, {
       appVersion: "1.2.3",
+      latestRelease: null,
       onDisconnect: () => undefined,
     }),
   );
 
   assert.match(markup, /Open dashboard menu/);
+});
+
+void test("renders dashboard version badge as a release link when an update is available", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardVersionBadge, {
+        versionLabel: "v1.2.3",
+        latestRelease: {
+          tagName: "v1.3.0",
+          url: "https://github.com/TechSquidTV/Cliparr/releases/tag/v1.3.0",
+          publishedAt: "2026-06-04T10:30:00.000Z",
+        },
+      }),
+    ),
+  );
+
+  assert.match(markup, /data-dashboard-version-badge/);
+  assert.match(markup, /data-dashboard-update-available/);
+  assert.match(markup, /data-dashboard-update-indicator/);
+  assert.match(markup, /v1\.3\.0 is available/);
 });
 
 void test("renders mobile PWA install nudge for native install state", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -343,6 +343,8 @@ void test("renders dashboard version badge as a release link when an update is a
   assert.match(markup, /data-dashboard-version-badge/);
   assert.match(markup, /data-dashboard-update-available/);
   assert.match(markup, /data-dashboard-update-indicator/);
+  assert.match(markup, /data-dashboard-update-label/);
+  assert.match(markup, /Update available/);
   assert.match(markup, /v1\.3\.0 is available/);
 });
 

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -346,6 +346,25 @@ void test("renders dashboard version badge as a release link when an update is a
   assert.match(markup, /v1\.3\.0 is available/);
 });
 
+void test("renders dashboard dev version badge with disabled update checks", () => {
+  const markup = renderToStaticMarkup(
+    createElement(DashboardVersionBadge, {
+      versionLabel: "dev",
+      latestRelease: null,
+      releaseChecksDisabledReason:
+        "Local development build; release update checks are disabled",
+    }),
+  );
+
+  assert.match(markup, /data-dashboard-version-badge/);
+  assert.match(markup, /data-dashboard-release-check-disabled="true"/);
+  assert.match(markup, />dev</);
+  assert.match(
+    markup,
+    /Local development build; release update checks are disabled/,
+  );
+});
+
 void test("renders mobile PWA install nudge for native install state", () => {
   const markup = renderToStaticMarkup(
     createElement(MobilePwaInstallNudgeCard, {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,6 +10,7 @@ import { mediaRouter } from "@/routes/media";
 import { providersRouter } from "@/routes/providers";
 import { sessionRouter } from "@/routes/session";
 import { sourcesRouter } from "@/routes/sources";
+import { versionRouter } from "@/routes/version";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(__dirname, "../../..");
@@ -65,6 +66,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   app.use("/api/session", sessionRouter);
   app.use("/api/sources", sourcesRouter);
   app.use("/api/media", mediaRouter);
+  app.use("/api/version", versionRouter);
   app.use("/api", notFoundHandler);
 
   if (process.env.NODE_ENV !== "production") {

--- a/apps/server/src/config/versionInfo.test.ts
+++ b/apps/server/src/config/versionInfo.test.ts
@@ -111,6 +111,7 @@ void test("does not call GitHub for non-release current versions", async () => {
 void test("uses the local dev version when no release version is injected", async () => {
   let fetchCount = 0;
   const service = createVersionInfoService({
+    env: {},
     now: () => CHECKED_AT,
     fetchImpl: async () => {
       fetchCount += 1;

--- a/apps/server/src/config/versionInfo.test.ts
+++ b/apps/server/src/config/versionInfo.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createVersionInfoService,
+  parseStableSemverTag,
+} from "@/config/versionInfo";
+
+const CHECKED_AT = Date.parse("2026-06-04T12:00:00.000Z");
+const RELEASE_URL =
+  "https://github.com/TechSquidTV/Cliparr/releases/tag/v1.3.0";
+
+function jsonResponse(value: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(value), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+}
+
+function releasePayload(tagName: string) {
+  return {
+    tag_name: tagName,
+    html_url: RELEASE_URL.replace("v1.3.0", tagName),
+    published_at: "2026-06-04T10:30:00.000Z",
+  };
+}
+
+void test("parses only stable semver release tags", () => {
+  assert.deepEqual(parseStableSemverTag("v1.2.3"), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+  });
+  assert.deepEqual(parseStableSemverTag("1.2.3"), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+  });
+  assert.equal(parseStableSemverTag("v1.2.3-beta.1"), undefined);
+  assert.equal(parseStableSemverTag("main@abc1234"), undefined);
+});
+
+void test("reports update availability from the latest stable release", async () => {
+  const service = createVersionInfoService({
+    currentVersion: "v1.2.3",
+    now: () => CHECKED_AT,
+    fetchImpl: async (input, init) => {
+      assert.match(input, /\/releases\/latest$/u);
+      assert.equal(
+        (init?.headers as Record<string, string> | undefined)?.Accept,
+        "application/vnd.github+json",
+      );
+      return jsonResponse(releasePayload("v1.3.0"));
+    },
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "v1.2.3",
+    latestRelease: {
+      tagName: "v1.3.0",
+      url: RELEASE_URL,
+      publishedAt: "2026-06-04T10:30:00.000Z",
+    },
+    updateAvailable: true,
+    checkedAt: "2026-06-04T12:00:00.000Z",
+    status: "update_available",
+  });
+});
+
+void test("treats current or newer installed versions as current", async () => {
+  const service = createVersionInfoService({
+    currentVersion: "v1.3.0",
+    now: () => CHECKED_AT,
+    fetchImpl: async () => jsonResponse(releasePayload("v1.2.9")),
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "v1.3.0",
+    latestRelease: {
+      tagName: "v1.2.9",
+      url: RELEASE_URL.replace("v1.3.0", "v1.2.9"),
+      publishedAt: "2026-06-04T10:30:00.000Z",
+    },
+    updateAvailable: false,
+    checkedAt: "2026-06-04T12:00:00.000Z",
+    status: "current",
+  });
+});
+
+void test("does not call GitHub for non-release current versions", async () => {
+  let fetchCount = 0;
+  const service = createVersionInfoService({
+    currentVersion: "main@abc1234",
+    now: () => CHECKED_AT,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return jsonResponse(releasePayload("v1.3.0"));
+    },
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "main@abc1234",
+    updateAvailable: false,
+    status: "unknown",
+  });
+  assert.equal(fetchCount, 0);
+});
+
+void test("caches successful release checks", async () => {
+  let fetchCount = 0;
+  let now = CHECKED_AT;
+  const service = createVersionInfoService({
+    currentVersion: "v1.2.3",
+    now: () => now,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return jsonResponse(releasePayload("v1.3.0"));
+    },
+  });
+
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-04T12:00:00.000Z",
+  );
+  now += 12 * 60 * 60 * 1000 - 1;
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-04T12:00:00.000Z",
+  );
+  assert.equal(fetchCount, 1);
+
+  now += 2;
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-05T00:00:00.001Z",
+  );
+  assert.equal(fetchCount, 2);
+});
+
+void test("caches failures until GitHub retry headers expire", async () => {
+  let fetchCount = 0;
+  let now = CHECKED_AT;
+  const service = createVersionInfoService({
+    currentVersion: "v1.2.3",
+    now: () => now,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return new Response("rate limited", {
+        status: 403,
+        headers: {
+          "retry-after": "120",
+        },
+      });
+    },
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "v1.2.3",
+    updateAvailable: false,
+    checkedAt: "2026-06-04T12:00:00.000Z",
+    status: "unavailable",
+  });
+
+  now += 119_000;
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-04T12:00:00.000Z",
+  );
+  assert.equal(fetchCount, 1);
+
+  now += 2_000;
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-04T12:02:01.000Z",
+  );
+  assert.equal(fetchCount, 2);
+});
+
+void test("times out stalled release checks and caches the failure", async () => {
+  let fetchCount = 0;
+  let abortObserved = false;
+  const service = createVersionInfoService({
+    currentVersion: "v1.2.3",
+    now: () => CHECKED_AT,
+    releaseCheckTimeoutMs: 1,
+    fetchImpl: async (_input, init) => {
+      fetchCount += 1;
+      assert(init?.signal);
+
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          abortObserved = true;
+          const reason: unknown = init.signal?.reason;
+          reject(reason instanceof Error ? reason : new Error("aborted"));
+        });
+      });
+    },
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "v1.2.3",
+    updateAvailable: false,
+    checkedAt: "2026-06-04T12:00:00.000Z",
+    status: "unavailable",
+  });
+  assert.equal(fetchCount, 1);
+  assert.equal(abortObserved, true);
+
+  assert.equal(
+    (await service.getVersionInfo()).checkedAt,
+    "2026-06-04T12:00:00.000Z",
+  );
+  assert.equal(fetchCount, 1);
+});
+
+void test("coalesces concurrent stale release checks", async () => {
+  let fetchCount = 0;
+  let resolveFetch: ((response: Response) => void) | undefined;
+  const service = createVersionInfoService({
+    currentVersion: "v1.2.3",
+    now: () => CHECKED_AT,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+    },
+  });
+
+  const firstRequest = service.getVersionInfo();
+  const secondRequest = service.getVersionInfo();
+
+  assert.equal(fetchCount, 1);
+  resolveFetch?.(jsonResponse(releasePayload("v1.3.0")));
+
+  const [first, second] = await Promise.all([firstRequest, secondRequest]);
+  assert.equal(first.status, "update_available");
+  assert.deepEqual(first, second);
+  assert.equal(fetchCount, 1);
+});

--- a/apps/server/src/config/versionInfo.test.ts
+++ b/apps/server/src/config/versionInfo.test.ts
@@ -108,6 +108,24 @@ void test("does not call GitHub for non-release current versions", async () => {
   assert.equal(fetchCount, 0);
 });
 
+void test("uses the local dev version when no release version is injected", async () => {
+  let fetchCount = 0;
+  const service = createVersionInfoService({
+    now: () => CHECKED_AT,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return jsonResponse(releasePayload("v1.3.0"));
+    },
+  });
+
+  assert.deepEqual(await service.getVersionInfo(), {
+    currentVersion: "dev",
+    updateAvailable: false,
+    status: "unknown",
+  });
+  assert.equal(fetchCount, 0);
+});
+
 void test("caches successful release checks", async () => {
   let fetchCount = 0;
   let now = CHECKED_AT;

--- a/apps/server/src/config/versionInfo.ts
+++ b/apps/server/src/config/versionInfo.ts
@@ -1,0 +1,409 @@
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
+import { CLIPARR_VERSION } from "@/config/version";
+import { getServerLogger, warnWithError } from "@/logging";
+
+type VersionInfoStatus =
+  | "current"
+  | "update_available"
+  | "unknown"
+  | "unavailable";
+
+interface LatestReleaseInfo {
+  tagName: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface CliparrVersionInfo {
+  currentVersion?: string;
+  latestRelease?: LatestReleaseInfo;
+  updateAvailable: boolean;
+  checkedAt?: string;
+  status: VersionInfoStatus;
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+interface SemverVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+interface ReleaseCheckResult {
+  checkedAt: number;
+  expiresAt: number;
+  release?: LatestReleaseInfo;
+}
+
+interface VersionInfoServiceOptions {
+  currentVersion?: string;
+  failureCacheTtlMs?: number;
+  fetchImpl?: FetchLike;
+  latestReleaseApiUrl?: string;
+  now?: () => number;
+  releaseCheckTimeoutMs?: number;
+  successCacheTtlMs?: number;
+}
+
+const LATEST_RELEASE_API_URL =
+  "https://api.github.com/repos/TechSquidTV/Cliparr/releases/latest";
+const SUCCESS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+const FAILURE_CACHE_TTL_MS = 60 * 60 * 1000;
+const RELEASE_CHECK_TIMEOUT_MS = 10_000;
+const GITHUB_API_VERSION = "2022-11-28";
+const STABLE_SEMVER_TAG_PATTERN =
+  /^v?(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$/u;
+const logger = getServerLogger("lifecycle");
+
+function normalizeVersion(value: string | undefined) {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+export function parseStableSemverTag(tag: string) {
+  const match = STABLE_SEMVER_TAG_PATTERN.exec(tag.trim());
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+  } satisfies SemverVersion;
+}
+
+function compareSemverVersions(left: SemverVersion, right: SemverVersion) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+
+  return left.patch - right.patch;
+}
+
+function latestReleaseFromPayload(payload: unknown) {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const release = payload as Record<string, unknown>;
+  if (
+    typeof release.tag_name !== "string" ||
+    typeof release.html_url !== "string" ||
+    typeof release.published_at !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    tagName: release.tag_name,
+    url: release.html_url,
+    publishedAt: release.published_at,
+  } satisfies LatestReleaseInfo;
+}
+
+function parseRetryAfterExpiresAt(value: string | null, now: number) {
+  if (!value) {
+    return undefined;
+  }
+
+  const retrySeconds = Number(value);
+  if (Number.isFinite(retrySeconds) && retrySeconds > 0) {
+    return now + retrySeconds * 1000;
+  }
+
+  const retryDate = Date.parse(value);
+  if (Number.isFinite(retryDate) && retryDate > now) {
+    return retryDate;
+  }
+
+  return undefined;
+}
+
+function parseRateLimitResetExpiresAt(value: string | null, now: number) {
+  if (!value) {
+    return undefined;
+  }
+
+  const resetSeconds = Number(value);
+  if (!Number.isFinite(resetSeconds)) {
+    return undefined;
+  }
+
+  const resetAt = resetSeconds * 1000;
+  return resetAt > now ? resetAt : undefined;
+}
+
+function failureExpiresAt(
+  response: Response | undefined,
+  now: number,
+  fallbackTtlMs: number,
+) {
+  return (
+    parseRetryAfterExpiresAt(
+      response?.headers.get("retry-after") ?? null,
+      now,
+    ) ??
+    parseRateLimitResetExpiresAt(
+      response?.headers.get("x-ratelimit-reset") ?? null,
+      now,
+    ) ??
+    now + fallbackTtlMs
+  );
+}
+
+function releaseCheckFailureFields({
+  checkedAt,
+  expiresAt,
+  failedAt,
+  reason,
+  response,
+}: {
+  checkedAt: number;
+  expiresAt: number;
+  failedAt: number;
+  reason: string;
+  response?: Response;
+}) {
+  return compactLogFields({
+    ...logEventFields("version.release_check", "failure"),
+    ...logDurationFields(checkedAt, failedAt),
+    "release.check.reason": reason,
+    "release.check.retry_at": new Date(expiresAt).toISOString(),
+    "http.status_code": response?.status,
+    "github.retry_after": response?.headers.get("retry-after") ?? undefined,
+    "github.rate_limit.reset":
+      response?.headers.get("x-ratelimit-reset") ?? undefined,
+  });
+}
+
+async function fetchWithTimeout(
+  fetchImpl: FetchLike,
+  latestReleaseApiUrl: string,
+  timeoutMs: number,
+) {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  if (timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      const timeoutError = new Error("GitHub release check timed out");
+      timeoutError.name = "TimeoutError";
+      controller.abort(timeoutError);
+    }, timeoutMs);
+  }
+
+  try {
+    return await fetchImpl(latestReleaseApiUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "Cliparr",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      },
+      signal: controller.signal,
+    });
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function fetchLatestReleaseCheck({
+  failureCacheTtlMs,
+  fetchImpl,
+  latestReleaseApiUrl,
+  now,
+  releaseCheckTimeoutMs,
+  successCacheTtlMs,
+}: Required<Omit<VersionInfoServiceOptions, "currentVersion">>) {
+  const checkedAt = now();
+
+  try {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      latestReleaseApiUrl,
+      releaseCheckTimeoutMs,
+    );
+
+    if (!response.ok) {
+      const failedAt = now();
+      const expiresAt = failureExpiresAt(response, failedAt, failureCacheTtlMs);
+      logger.warn(
+        "GitHub release check failed.",
+        releaseCheckFailureFields({
+          checkedAt,
+          expiresAt,
+          failedAt,
+          reason: "github_http_error",
+          response,
+        }),
+      );
+
+      return {
+        checkedAt,
+        expiresAt,
+      } satisfies ReleaseCheckResult;
+    }
+
+    const release = latestReleaseFromPayload(await response.json());
+    if (!release) {
+      const failedAt = now();
+      const expiresAt = failedAt + failureCacheTtlMs;
+      logger.warn(
+        "GitHub release check returned an invalid payload.",
+        releaseCheckFailureFields({
+          checkedAt,
+          expiresAt,
+          failedAt,
+          reason: "invalid_release_payload",
+        }),
+      );
+
+      return {
+        checkedAt,
+        expiresAt,
+      } satisfies ReleaseCheckResult;
+    }
+
+    return {
+      checkedAt,
+      expiresAt: checkedAt + successCacheTtlMs,
+      release,
+    } satisfies ReleaseCheckResult;
+  } catch (err) {
+    const failedAt = now();
+    const expiresAt = failedAt + failureCacheTtlMs;
+    warnWithError(logger, err, "GitHub release check failed.", {
+      ...releaseCheckFailureFields({
+        checkedAt,
+        expiresAt,
+        failedAt,
+        reason: "request_error",
+      }),
+      ...logErrorFields(err),
+    });
+
+    return {
+      checkedAt,
+      expiresAt,
+    } satisfies ReleaseCheckResult;
+  }
+}
+
+function unknownVersionInfo(currentVersion: string | undefined) {
+  return {
+    ...(currentVersion ? { currentVersion } : {}),
+    updateAvailable: false,
+    status: "unknown",
+  } satisfies CliparrVersionInfo;
+}
+
+function versionInfoFromReleaseCheck(
+  currentVersion: string,
+  currentSemver: SemverVersion,
+  releaseCheck: ReleaseCheckResult,
+) {
+  const checkedAt = new Date(releaseCheck.checkedAt).toISOString();
+  if (!releaseCheck.release) {
+    return {
+      currentVersion,
+      updateAvailable: false,
+      checkedAt,
+      status: "unavailable",
+    } satisfies CliparrVersionInfo;
+  }
+
+  const latestSemver = parseStableSemverTag(releaseCheck.release.tagName);
+  if (!latestSemver) {
+    return {
+      currentVersion,
+      latestRelease: releaseCheck.release,
+      updateAvailable: false,
+      checkedAt,
+      status: "unknown",
+    } satisfies CliparrVersionInfo;
+  }
+
+  const updateAvailable =
+    compareSemverVersions(latestSemver, currentSemver) > 0;
+
+  return {
+    currentVersion,
+    latestRelease: releaseCheck.release,
+    updateAvailable,
+    checkedAt,
+    status: updateAvailable ? "update_available" : "current",
+  } satisfies CliparrVersionInfo;
+}
+
+export function createVersionInfoService({
+  currentVersion = CLIPARR_VERSION,
+  failureCacheTtlMs = FAILURE_CACHE_TTL_MS,
+  fetchImpl = fetch,
+  latestReleaseApiUrl = LATEST_RELEASE_API_URL,
+  now = Date.now,
+  releaseCheckTimeoutMs = RELEASE_CHECK_TIMEOUT_MS,
+  successCacheTtlMs = SUCCESS_CACHE_TTL_MS,
+}: VersionInfoServiceOptions = {}) {
+  let cachedReleaseCheck: ReleaseCheckResult | null = null;
+  let inflightReleaseCheck: Promise<ReleaseCheckResult> | null = null;
+
+  async function getLatestReleaseCheck() {
+    const currentTime = now();
+    if (cachedReleaseCheck && cachedReleaseCheck.expiresAt > currentTime) {
+      return cachedReleaseCheck;
+    }
+
+    inflightReleaseCheck ??= fetchLatestReleaseCheck({
+      failureCacheTtlMs,
+      fetchImpl,
+      latestReleaseApiUrl,
+      now,
+      releaseCheckTimeoutMs,
+      successCacheTtlMs,
+    })
+      .then((releaseCheck) => {
+        cachedReleaseCheck = releaseCheck;
+        return releaseCheck;
+      })
+      .finally(() => {
+        inflightReleaseCheck = null;
+      });
+
+    return inflightReleaseCheck;
+  }
+
+  return {
+    async getVersionInfo(): Promise<CliparrVersionInfo> {
+      const normalizedCurrentVersion = normalizeVersion(currentVersion);
+      if (!normalizedCurrentVersion) {
+        return unknownVersionInfo(undefined);
+      }
+
+      const currentSemver = parseStableSemverTag(normalizedCurrentVersion);
+      if (!currentSemver) {
+        return unknownVersionInfo(normalizedCurrentVersion);
+      }
+
+      const releaseCheck = await getLatestReleaseCheck();
+      return versionInfoFromReleaseCheck(
+        normalizedCurrentVersion,
+        currentSemver,
+        releaseCheck,
+      );
+    },
+  };
+}
+
+export const versionInfoService = createVersionInfoService();

--- a/apps/server/src/config/versionInfo.ts
+++ b/apps/server/src/config/versionInfo.ts
@@ -4,7 +4,7 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { CLIPARR_CLIENT_VERSION } from "@/config/version";
+import { resolveCliparrClientVersion } from "@/config/version";
 import { getServerLogger, warnWithError } from "@/logging";
 
 type VersionInfoStatus =
@@ -43,6 +43,7 @@ interface ReleaseCheckResult {
 
 interface VersionInfoServiceOptions {
   currentVersion?: string;
+  env?: NodeJS.ProcessEnv;
   failureCacheTtlMs?: number;
   fetchImpl?: FetchLike;
   latestReleaseApiUrl?: string;
@@ -50,6 +51,18 @@ interface VersionInfoServiceOptions {
   releaseCheckTimeoutMs?: number;
   successCacheTtlMs?: number;
 }
+
+type ReleaseCheckOptions = Required<
+  Pick<
+    VersionInfoServiceOptions,
+    | "failureCacheTtlMs"
+    | "fetchImpl"
+    | "latestReleaseApiUrl"
+    | "now"
+    | "releaseCheckTimeoutMs"
+    | "successCacheTtlMs"
+  >
+>;
 
 const LATEST_RELEASE_API_URL =
   "https://api.github.com/repos/TechSquidTV/Cliparr/releases/latest";
@@ -226,7 +239,7 @@ async function fetchLatestReleaseCheck({
   now,
   releaseCheckTimeoutMs,
   successCacheTtlMs,
-}: Required<Omit<VersionInfoServiceOptions, "currentVersion">>) {
+}: ReleaseCheckOptions) {
   const checkedAt = now();
 
   try {
@@ -348,7 +361,8 @@ function versionInfoFromReleaseCheck(
 }
 
 export function createVersionInfoService({
-  currentVersion = CLIPARR_CLIENT_VERSION,
+  env = process.env,
+  currentVersion = resolveCliparrClientVersion(env),
   failureCacheTtlMs = FAILURE_CACHE_TTL_MS,
   fetchImpl = fetch,
   latestReleaseApiUrl = LATEST_RELEASE_API_URL,

--- a/apps/server/src/config/versionInfo.ts
+++ b/apps/server/src/config/versionInfo.ts
@@ -4,7 +4,7 @@ import {
   logErrorFields,
   logEventFields,
 } from "@cliparr/shared/logging";
-import { CLIPARR_VERSION } from "@/config/version";
+import { CLIPARR_CLIENT_VERSION } from "@/config/version";
 import { getServerLogger, warnWithError } from "@/logging";
 
 type VersionInfoStatus =
@@ -348,7 +348,7 @@ function versionInfoFromReleaseCheck(
 }
 
 export function createVersionInfoService({
-  currentVersion = CLIPARR_VERSION,
+  currentVersion = CLIPARR_CLIENT_VERSION,
   failureCacheTtlMs = FAILURE_CACHE_TTL_MS,
   fetchImpl = fetch,
   latestReleaseApiUrl = LATEST_RELEASE_API_URL,

--- a/apps/server/src/routes/version.ts
+++ b/apps/server/src/routes/version.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { versionInfoService } from "@/config/versionInfo";
+import { asyncHandler } from "@/http/errors";
+import { setNoStore } from "@/session/request";
+
+export const versionRouter = Router();
+
+versionRouter.get(
+  "/",
+  asyncHandler(async (_req, res) => {
+    setNoStore(res);
+    res.json(await versionInfoService.getVersionInfo());
+  }),
+);


### PR DESCRIPTION
Adds a server-backed cached GitHub release check through `/api/version` and surfaces update availability from the dashboard version badge.

The notice links to the latest stable release notes, stays quiet for dev/non-release builds, exposes the update state in the mobile drawer, and shows a small `Update available` label next to the dashboard tag when a newer stable release exists.

Validation:
- `pnpm preflight`
