### PR TITLE
fix(www): mention gifenc for GIF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **Instant session discovery**: Automatically loads your media player's currently playing file.
 - **Open local videos**: Open a local file or direct media URL before or after connecting a provider.
 - **Intuitive timeline editor**: Familiar editing controls for choosing the exact clip range.
-- **Browser transcoding**: Video exports are powered by <a href="https://mediabunny.dev/" target="_blank" rel="noreferrer">Mediabunny</a>, with short dithered GIFs encoded in browser workers.
+- **Browser transcoding**: Video exports are powered by <a href="https://mediabunny.dev/" target="_blank" rel="noreferrer">Mediabunny</a>. GIFs are encoded with <a href="https://github.com/KyleTryon/gifenc" target="_blank" rel="noreferrer">gifenc</a>.
 - **Metadata included**: Video exports can include season, episode, and timing metadata from your source.
 - **Subtitle burn-in**: Burn in supported subtitles with customizable styling and local font support in Chromium.
 <!-- CLIPARR_DOCS_SYNC:features:end -->

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -34,7 +34,7 @@ export const features = [
   {
     title: "Browser transcoding",
     description:
-      'Video exports are powered by <a href="https://mediabunny.dev/" target="_blank" rel="noreferrer">Mediabunny</a>, with short dithered GIFs encoded in browser workers.',
+      'Video exports are powered by <a href="https://mediabunny.dev/" target="_blank" rel="noreferrer">Mediabunny</a>. GIFs are encoded with <a href="https://github.com/KyleTryon/gifenc" target="_blank" rel="noreferrer">gifenc</a>.',
   },
   {
     title: "Metadata included",


### PR DESCRIPTION
Updates the website Browser transcoding feature copy to clarify that video exports use Mediabunny and GIFs are encoded with the linked gifenc fork. Validation: pnpm preflight; pnpm docs:check.