### PR TITLE
fix(server): dedupe Plex auth sources

### DIFF
--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -3,15 +3,16 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
-import { logErrorFields } from "@cliparr/shared/logging";
+import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
 import { prepareDatabaseForMigrations } from "@/db/migrationState";
+import { cleanupDuplicatePlexSources } from "@/db/plexSourceDeduplication";
 import * as schema from "@/db/schema";
 import {
   resolveConfiguredDataDir,
   serverRoot,
   workspaceRoot,
 } from "@/config/loadEnv";
-import { getServerLogger } from "@/logging";
+import { getServerLogger, warnWithError } from "@/logging";
 import { assertAppKeyConfigured } from "@/security/secrets";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
@@ -55,6 +56,22 @@ function resolveDataDir() {
   return path.join(workspaceRoot, DEFAULT_DEVELOPMENT_DATA_DIR);
 }
 
+function runPostMigrationMaintenance() {
+  try {
+    cleanupDuplicatePlexSources();
+  } catch (error) {
+    warnWithError(
+      logger,
+      error,
+      "Post-migration database maintenance failed.",
+      {
+        ...logEventFields("db.post_migration_maintenance", "failure"),
+        ...logErrorFields(error),
+      },
+    );
+  }
+}
+
 export function initializeDatabase() {
   if (database) {
     return database;
@@ -76,6 +93,7 @@ export function initializeDatabase() {
   database = drizzle({ client: sqlite, schema });
   prepareDatabaseForMigrations(sqlite);
   migrate(database, { migrationsFolder: MIGRATIONS_FOLDER });
+  runPostMigrationMaintenance();
 
   return database;
 }

--- a/apps/server/src/db/database.ts
+++ b/apps/server/src/db/database.ts
@@ -3,16 +3,15 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
-import { logErrorFields, logEventFields } from "@cliparr/shared/logging";
+import { logErrorFields } from "@cliparr/shared/logging";
 import { prepareDatabaseForMigrations } from "@/db/migrationState";
-import { cleanupDuplicatePlexSources } from "@/db/plexSourceDeduplication";
 import * as schema from "@/db/schema";
 import {
   resolveConfiguredDataDir,
   serverRoot,
   workspaceRoot,
 } from "@/config/loadEnv";
-import { getServerLogger, warnWithError } from "@/logging";
+import { getServerLogger } from "@/logging";
 import { assertAppKeyConfigured } from "@/security/secrets";
 
 const DEFAULT_DATABASE_FILE = "cliparr.sqlite";
@@ -56,22 +55,6 @@ function resolveDataDir() {
   return path.join(workspaceRoot, DEFAULT_DEVELOPMENT_DATA_DIR);
 }
 
-function runPostMigrationMaintenance() {
-  try {
-    cleanupDuplicatePlexSources();
-  } catch (error) {
-    warnWithError(
-      logger,
-      error,
-      "Post-migration database maintenance failed.",
-      {
-        ...logEventFields("db.post_migration_maintenance", "failure"),
-        ...logErrorFields(error),
-      },
-    );
-  }
-}
-
 export function initializeDatabase() {
   if (database) {
     return database;
@@ -93,7 +76,6 @@ export function initializeDatabase() {
   database = drizzle({ client: sqlite, schema });
   prepareDatabaseForMigrations(sqlite);
   migrate(database, { migrationsFolder: MIGRATIONS_FOLDER });
-  runPostMigrationMaintenance();
 
   return database;
 }

--- a/apps/server/src/db/plexSourceDeduplication.ts
+++ b/apps/server/src/db/plexSourceDeduplication.ts
@@ -1,0 +1,609 @@
+import { eq } from "drizzle-orm";
+import {
+  compactLogFields,
+  logDurationFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
+import { getDatabase } from "@/db/database";
+import {
+  deleteMediaSource,
+  listMediaSources,
+  type MediaSource,
+  updateMediaSource,
+} from "@/db/mediaSourcesRepository";
+import {
+  deleteProviderAccount,
+  getProviderAccount,
+  type ProviderAccount,
+  updateProviderAccount,
+} from "@/db/providerAccountsRepository";
+import { currentTimestampSql } from "@/db/timestamps";
+import {
+  mediaSources,
+  rememberedProviderSessions,
+  providerSessions,
+} from "@/db/schema";
+import {
+  plexBaseUrlMode,
+  PLEX_BASE_URL_MODE_MANUAL,
+  withPlexBaseUrlMode,
+} from "@/providers/plex/connectionState";
+import {
+  plexSourceIdentity,
+  type PlexSourceIdentity,
+} from "@/providers/plex/sourceIdentity";
+import { getServerLogger } from "@/logging";
+
+const PLEX_PROVIDER_ID = "plex";
+const logger = getServerLogger(["db"]);
+
+interface SourceIdentity {
+  source: MediaSource;
+  identity: PlexSourceIdentity;
+}
+
+interface DuplicateGroupPlan {
+  group: MediaSource[];
+  canonical: MediaSource;
+}
+
+interface CleanupResult {
+  providerAccountId?: string;
+  duplicateSourceCount: number;
+  reassignedSourceCount: number;
+  deletedAccountCount: number;
+  reassignedProviderSessionCount: number;
+  reassignedRememberedSessionCount: number;
+}
+
+function timestampMs(value: string | undefined, fallback: number) {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function sourceUsesManualPlexUrl(source: MediaSource) {
+  return plexBaseUrlMode(source.connection) === PLEX_BASE_URL_MODE_MANUAL;
+}
+
+function hasHealthHistory(source: MediaSource) {
+  return Boolean(source.lastCheckedAt);
+}
+
+function compareCanonicalSources(
+  left: MediaSource,
+  right: MediaSource,
+  preferredAccountId?: string,
+) {
+  const leftManual = sourceUsesManualPlexUrl(left);
+  const rightManual = sourceUsesManualPlexUrl(right);
+  if (leftManual !== rightManual) {
+    return leftManual ? -1 : 1;
+  }
+
+  if (left.enabled !== right.enabled) {
+    return left.enabled ? -1 : 1;
+  }
+
+  const leftChecked = hasHealthHistory(left);
+  const rightChecked = hasHealthHistory(right);
+  if (leftChecked !== rightChecked) {
+    return leftChecked ? -1 : 1;
+  }
+
+  if (
+    preferredAccountId &&
+    left.providerAccountId !== right.providerAccountId
+  ) {
+    const leftPreferred = left.providerAccountId === preferredAccountId;
+    const rightPreferred = right.providerAccountId === preferredAccountId;
+    if (leftPreferred !== rightPreferred) {
+      return leftPreferred ? 1 : -1;
+    }
+  }
+
+  const createdDifference =
+    timestampMs(left.createdAt, Number.POSITIVE_INFINITY) -
+    timestampMs(right.createdAt, Number.POSITIVE_INFINITY);
+  if (createdDifference !== 0) {
+    return createdDifference;
+  }
+
+  const updatedDifference =
+    timestampMs(right.updatedAt, Number.NEGATIVE_INFINITY) -
+    timestampMs(left.updatedAt, Number.NEGATIVE_INFINITY);
+  if (updatedDifference !== 0) {
+    return updatedDifference;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function compareCanonicalAccounts(
+  left: ProviderAccount,
+  right: ProviderAccount,
+) {
+  const createdDifference =
+    timestampMs(left.createdAt, Number.POSITIVE_INFINITY) -
+    timestampMs(right.createdAt, Number.POSITIVE_INFINITY);
+  if (createdDifference !== 0) {
+    return createdDifference;
+  }
+
+  const updatedDifference =
+    timestampMs(right.updatedAt, Number.NEGATIVE_INFINITY) -
+    timestampMs(left.updatedAt, Number.NEGATIVE_INFINITY);
+  if (updatedDifference !== 0) {
+    return updatedDifference;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function latestUpdatedSource(sources: MediaSource[]) {
+  return sources.toSorted(
+    (left, right) =>
+      timestampMs(right.updatedAt, Number.NEGATIVE_INFINITY) -
+      timestampMs(left.updatedAt, Number.NEGATIVE_INFINITY),
+  )[0];
+}
+
+function latestUpdatedAccount(accounts: ProviderAccount[]) {
+  return accounts.toSorted(
+    (left, right) =>
+      timestampMs(right.updatedAt, Number.NEGATIVE_INFINITY) -
+      timestampMs(left.updatedAt, Number.NEGATIVE_INFINITY),
+  )[0];
+}
+
+function latestCheckedSource(sources: MediaSource[]) {
+  return sources
+    .filter((source) => source.lastCheckedAt)
+    .toSorted(
+      (left, right) =>
+        timestampMs(right.lastCheckedAt, Number.NEGATIVE_INFINITY) -
+        timestampMs(left.lastCheckedAt, Number.NEGATIVE_INFINITY),
+    )[0];
+}
+
+function preferredMergeSource(
+  canonical: MediaSource,
+  sources: MediaSource[],
+  preferredAccountId?: string,
+) {
+  return (
+    latestUpdatedSource(
+      sources.filter(
+        (source) => source.providerAccountId === preferredAccountId,
+      ),
+    ) ??
+    latestUpdatedSource(
+      sources.filter(
+        (source) => source.providerAccountId !== canonical.providerAccountId,
+      ),
+    ) ??
+    latestUpdatedSource(sources) ??
+    canonical
+  );
+}
+
+function uniqueSorted(values: Iterable<string | undefined>) {
+  return [
+    ...new Set(
+      [...values].filter((value): value is string => value !== undefined),
+    ),
+  ].toSorted();
+}
+
+function groupDuplicateSources(sources: MediaSource[]) {
+  const identities = sources
+    .map(
+      (source): SourceIdentity => ({
+        source,
+        identity: plexSourceIdentity(source),
+      }),
+    )
+    .filter(
+      ({ identity }) =>
+        identity.resourceKey !== undefined || identity.urlKeys.length > 0,
+    );
+  const parents = new Map<string, string>();
+
+  for (const { source } of identities) {
+    parents.set(source.id, source.id);
+  }
+
+  function find(sourceId: string): string {
+    const parent = parents.get(sourceId) ?? sourceId;
+    if (parent === sourceId) {
+      return parent;
+    }
+
+    const root = find(parent);
+    parents.set(sourceId, root);
+    return root;
+  }
+
+  function union(left: string, right: string) {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) {
+      parents.set(rightRoot, leftRoot);
+    }
+  }
+
+  const sourceIdByResourceKey = new Map<string, string>();
+  const identitiesByUrlKey = new Map<string, SourceIdentity[]>();
+  for (const identity of identities) {
+    const { source } = identity;
+    if (identity.identity.resourceKey) {
+      const existingSourceId = sourceIdByResourceKey.get(
+        identity.identity.resourceKey,
+      );
+      if (existingSourceId) {
+        union(existingSourceId, source.id);
+      } else {
+        sourceIdByResourceKey.set(identity.identity.resourceKey, source.id);
+      }
+    }
+
+    for (const urlKey of identity.identity.urlKeys) {
+      const urlGroup = identitiesByUrlKey.get(urlKey) ?? [];
+      urlGroup.push(identity);
+      identitiesByUrlKey.set(urlKey, urlGroup);
+    }
+  }
+
+  for (const urlGroup of identitiesByUrlKey.values()) {
+    const resourceKeys = uniqueSorted(
+      urlGroup.map(({ identity }) => identity.resourceKey),
+    );
+    if (resourceKeys.length > 1) {
+      continue;
+    }
+
+    const first = urlGroup[0];
+    if (!first) {
+      continue;
+    }
+
+    for (const { source } of urlGroup.slice(1)) {
+      union(first.source.id, source.id);
+    }
+  }
+
+  const groups = new Map<string, MediaSource[]>();
+  for (const { source } of identities) {
+    const root = find(source.id);
+    const group = groups.get(root) ?? [];
+    group.push(source);
+    groups.set(root, group);
+  }
+
+  return [...groups.values()].filter((group) => group.length > 1);
+}
+
+function mergeCanonicalSource(
+  canonical: MediaSource,
+  sources: MediaSource[],
+  preferredAccountId?: string,
+) {
+  const latest = preferredMergeSource(canonical, sources, preferredAccountId);
+  const checked = latestCheckedSource(sources);
+  const manual = sourceUsesManualPlexUrl(canonical);
+
+  return updateMediaSource(canonical.id, {
+    enabled: sources.some((source) => source.enabled),
+    baseUrl: manual ? canonical.baseUrl : latest.baseUrl,
+    connection: manual
+      ? withPlexBaseUrlMode(latest.connection, PLEX_BASE_URL_MODE_MANUAL)
+      : latest.connection,
+    credentials: latest.credentials,
+    metadata: {
+      ...canonical.metadata,
+      ...latest.metadata,
+    },
+    ...(checked
+      ? {
+          lastCheckedAt: checked.lastCheckedAt ?? null,
+          lastError: checked.lastError ?? null,
+        }
+      : {}),
+  });
+}
+
+function providerAccountSourceMetadata(providerAccountId: string) {
+  const sources = listMediaSources({
+    providerId: PLEX_PROVIDER_ID,
+    providerAccountId,
+  });
+
+  return {
+    resourceCount: sources.length,
+    resourceIds: uniqueSorted(sources.map((source) => source.externalId)),
+  };
+}
+
+function buildAccountMergePlan(duplicateGroups: DuplicateGroupPlan[]) {
+  const accountIds = uniqueSorted(
+    duplicateGroups.flatMap(({ group }) =>
+      group.map((source) => source.providerAccountId),
+    ),
+  );
+  const canonicalAccountRank = new Map<string, number>();
+  const parents = new Map<string, string>();
+
+  for (const accountId of accountIds) {
+    parents.set(accountId, accountId);
+  }
+
+  function find(accountId: string): string {
+    const parent = parents.get(accountId) ?? accountId;
+    if (parent === accountId) {
+      return parent;
+    }
+
+    const root = find(parent);
+    parents.set(accountId, root);
+    return root;
+  }
+
+  function union(left: string, right: string) {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) {
+      parents.set(rightRoot, leftRoot);
+    }
+  }
+
+  for (const [index, { canonical, group }] of duplicateGroups.entries()) {
+    if (!canonicalAccountRank.has(canonical.providerAccountId)) {
+      canonicalAccountRank.set(canonical.providerAccountId, index);
+    }
+
+    const [first, ...rest] = group;
+    if (!first) {
+      continue;
+    }
+
+    for (const source of rest) {
+      union(first.providerAccountId, source.providerAccountId);
+    }
+  }
+
+  const accountsByRoot = new Map<string, ProviderAccount[]>();
+  for (const accountId of accountIds) {
+    const account = getProviderAccount(accountId);
+    if (!account) {
+      continue;
+    }
+
+    const root = find(accountId);
+    const accounts = accountsByRoot.get(root) ?? [];
+    accounts.push(account);
+    accountsByRoot.set(root, accounts);
+  }
+
+  const canonicalAccountIdByAccountId = new Map<string, string>();
+  const componentAccountsByCanonicalId = new Map<string, ProviderAccount[]>();
+  for (const accounts of accountsByRoot.values()) {
+    const canonicalAccount = accounts.toSorted((left, right) => {
+      const leftRank =
+        canonicalAccountRank.get(left.id) ?? Number.POSITIVE_INFINITY;
+      const rightRank =
+        canonicalAccountRank.get(right.id) ?? Number.POSITIVE_INFINITY;
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+
+      return compareCanonicalAccounts(left, right);
+    })[0];
+    if (!canonicalAccount) {
+      continue;
+    }
+
+    for (const account of accounts) {
+      canonicalAccountIdByAccountId.set(account.id, canonicalAccount.id);
+    }
+    componentAccountsByCanonicalId.set(canonicalAccount.id, accounts);
+  }
+
+  return {
+    canonicalAccountIdByAccountId,
+    componentAccountsByCanonicalId,
+  };
+}
+
+function reassignProviderAccountReferences(
+  fromAccountId: string,
+  toAccountId: string,
+) {
+  const db = getDatabase();
+  const sessionResult = db
+    .update(providerSessions)
+    .set({
+      providerAccountId: toAccountId,
+      updatedAt: currentTimestampSql(),
+    })
+    .where(eq(providerSessions.providerAccountId, fromAccountId))
+    .run();
+  const rememberedResult = db
+    .update(rememberedProviderSessions)
+    .set({
+      providerAccountId: toAccountId,
+      updatedAt: currentTimestampSql(),
+    })
+    .where(eq(rememberedProviderSessions.providerAccountId, fromAccountId))
+    .run();
+
+  return {
+    providerSessionCount: Number(sessionResult.changes),
+    rememberedSessionCount: Number(rememberedResult.changes),
+  };
+}
+
+function reassignMediaSourcesForProviderAccount(
+  fromAccountId: string,
+  toAccountId: string,
+) {
+  const result = getDatabase()
+    .update(mediaSources)
+    .set({
+      providerAccountId: toAccountId,
+      updatedAt: currentTimestampSql(),
+    })
+    .where(eq(mediaSources.providerAccountId, fromAccountId))
+    .run();
+
+  return Number(result.changes);
+}
+
+function updateMergedProviderAccount(
+  canonicalAccountId: string,
+  accounts: ProviderAccount[],
+) {
+  const canonicalAccount = getProviderAccount(canonicalAccountId);
+  if (!canonicalAccount) {
+    return;
+  }
+
+  const latestAccount = latestUpdatedAccount(accounts) ?? canonicalAccount;
+  updateProviderAccount(canonicalAccountId, {
+    label: canonicalAccount.label,
+    accessToken: latestAccount.accessToken,
+    metadata: {
+      ...canonicalAccount.metadata,
+      ...latestAccount.metadata,
+      ...providerAccountSourceMetadata(canonicalAccountId),
+    },
+  });
+}
+
+function resolvePreferredAccountId(
+  preferredAccountId: string | undefined,
+  canonicalAccountIdByAccountId: Map<string, string>,
+) {
+  if (!preferredAccountId) {
+    return;
+  }
+
+  return (
+    canonicalAccountIdByAccountId.get(preferredAccountId) ?? preferredAccountId
+  );
+}
+
+function cleanupDuplicatePlexSourcesInTransaction(
+  options: {
+    preferredAccountId?: string;
+  } = {},
+): CleanupResult {
+  const startedAt = Date.now();
+  const sources = listMediaSources({ providerId: PLEX_PROVIDER_ID });
+  const duplicateGroups = groupDuplicateSources(sources);
+  const duplicateGroupPlans = duplicateGroups
+    .map((group): DuplicateGroupPlan | undefined => {
+      const canonical = group.toSorted((left, right) =>
+        compareCanonicalSources(left, right, options.preferredAccountId),
+      )[0];
+      return canonical ? { group, canonical } : undefined;
+    })
+    .filter((plan): plan is DuplicateGroupPlan => plan !== undefined);
+  const { canonicalAccountIdByAccountId, componentAccountsByCanonicalId } =
+    buildAccountMergePlan(duplicateGroupPlans);
+  let duplicateSourceCount = 0;
+  let reassignedSourceCount = 0;
+  let deletedAccountCount = 0;
+  let reassignedProviderSessionCount = 0;
+  let reassignedRememberedSessionCount = 0;
+
+  for (const { canonical, group } of duplicateGroupPlans) {
+    mergeCanonicalSource(canonical, group, options.preferredAccountId);
+
+    for (const source of group) {
+      if (source.id === canonical.id) {
+        continue;
+      }
+
+      deleteMediaSource(source.id);
+      duplicateSourceCount += 1;
+    }
+  }
+
+  const nonCanonicalAccountIds = uniqueSorted(
+    [...canonicalAccountIdByAccountId.entries()]
+      .filter(
+        ([accountId, canonicalAccountId]) => accountId !== canonicalAccountId,
+      )
+      .map(([accountId]) => accountId),
+  );
+  for (const accountId of nonCanonicalAccountIds) {
+    const redirectedAccountId = canonicalAccountIdByAccountId.get(accountId);
+    if (!redirectedAccountId) {
+      continue;
+    }
+
+    reassignedSourceCount += reassignMediaSourcesForProviderAccount(
+      accountId,
+      redirectedAccountId,
+    );
+    const reassigned = reassignProviderAccountReferences(
+      accountId,
+      redirectedAccountId,
+    );
+    reassignedProviderSessionCount += reassigned.providerSessionCount;
+    reassignedRememberedSessionCount += reassigned.rememberedSessionCount;
+    if (deleteProviderAccount(accountId)) {
+      deletedAccountCount += 1;
+    }
+  }
+
+  for (const [canonicalAccountId, accounts] of componentAccountsByCanonicalId) {
+    updateMergedProviderAccount(canonicalAccountId, accounts);
+  }
+
+  const providerAccountId = resolvePreferredAccountId(
+    options.preferredAccountId,
+    canonicalAccountIdByAccountId,
+  );
+
+  if (duplicateSourceCount > 0) {
+    logger.info("Cleaned up duplicate Plex sources.", {
+      ...logEventFields("db.plex_source_dedupe", "success"),
+      ...logDurationFields(startedAt),
+      ...compactLogFields({
+        "provider.id": PLEX_PROVIDER_ID,
+        "source.duplicate_group.count": duplicateGroups.length,
+        "source.deleted_count": duplicateSourceCount,
+        "source.reassigned_count": reassignedSourceCount,
+        "provider.account.deleted_count": deletedAccountCount,
+        "provider.session.reassigned_count": reassignedProviderSessionCount,
+        "session.remembered.reassigned_count": reassignedRememberedSessionCount,
+      }),
+    });
+  }
+
+  return {
+    providerAccountId:
+      providerAccountId && getProviderAccount(providerAccountId)
+        ? providerAccountId
+        : undefined,
+    duplicateSourceCount,
+    reassignedSourceCount,
+    deletedAccountCount,
+    reassignedProviderSessionCount,
+    reassignedRememberedSessionCount,
+  };
+}
+
+export function cleanupDuplicatePlexSources(
+  options: {
+    preferredAccountId?: string;
+  } = {},
+): CleanupResult {
+  return getDatabase().transaction(() =>
+    cleanupDuplicatePlexSourcesInTransaction(options),
+  );
+}

--- a/apps/server/src/db/plexSourceDeduplication.ts
+++ b/apps/server/src/db/plexSourceDeduplication.ts
@@ -76,7 +76,7 @@ function hasHealthHistory(source: MediaSource) {
 function compareCanonicalSources(
   left: MediaSource,
   right: MediaSource,
-  preferredAccountId?: string,
+  newlyAuthenticatedAccountId?: string,
 ) {
   const leftManual = sourceUsesManualPlexUrl(left);
   const rightManual = sourceUsesManualPlexUrl(right);
@@ -94,14 +94,17 @@ function compareCanonicalSources(
     return leftChecked ? -1 : 1;
   }
 
+  // Fresh auth rows carry newer tokens, but existing rows are safer canonicals.
   if (
-    preferredAccountId &&
+    newlyAuthenticatedAccountId &&
     left.providerAccountId !== right.providerAccountId
   ) {
-    const leftPreferred = left.providerAccountId === preferredAccountId;
-    const rightPreferred = right.providerAccountId === preferredAccountId;
-    if (leftPreferred !== rightPreferred) {
-      return leftPreferred ? 1 : -1;
+    const leftNewlyAuthenticated =
+      left.providerAccountId === newlyAuthenticatedAccountId;
+    const rightNewlyAuthenticated =
+      right.providerAccountId === newlyAuthenticatedAccountId;
+    if (leftNewlyAuthenticated !== rightNewlyAuthenticated) {
+      return leftNewlyAuthenticated ? 1 : -1;
     }
   }
 
@@ -169,15 +172,15 @@ function latestCheckedSource(sources: MediaSource[]) {
     )[0];
 }
 
-function preferredMergeSource(
+function mergeDataSource(
   canonical: MediaSource,
   sources: MediaSource[],
-  preferredAccountId?: string,
+  newlyAuthenticatedAccountId?: string,
 ) {
   return (
     latestUpdatedSource(
       sources.filter(
-        (source) => source.providerAccountId === preferredAccountId,
+        (source) => source.providerAccountId === newlyAuthenticatedAccountId,
       ),
     ) ??
     latestUpdatedSource(
@@ -289,9 +292,13 @@ function groupDuplicateSources(sources: MediaSource[]) {
 function mergeCanonicalSource(
   canonical: MediaSource,
   sources: MediaSource[],
-  preferredAccountId?: string,
+  newlyAuthenticatedAccountId?: string,
 ) {
-  const latest = preferredMergeSource(canonical, sources, preferredAccountId);
+  const latest = mergeDataSource(
+    canonical,
+    sources,
+    newlyAuthenticatedAccountId,
+  );
   const checked = latestCheckedSource(sources);
   const manual = sourceUsesManualPlexUrl(canonical);
 
@@ -482,22 +489,20 @@ function updateMergedProviderAccount(
   });
 }
 
-function resolvePreferredAccountId(
-  preferredAccountId: string | undefined,
+function resolveCanonicalAccountId(
+  accountId: string | undefined,
   canonicalAccountIdByAccountId: Map<string, string>,
 ) {
-  if (!preferredAccountId) {
+  if (!accountId) {
     return;
   }
 
-  return (
-    canonicalAccountIdByAccountId.get(preferredAccountId) ?? preferredAccountId
-  );
+  return canonicalAccountIdByAccountId.get(accountId) ?? accountId;
 }
 
 function cleanupDuplicatePlexSourcesInTransaction(
   options: {
-    preferredAccountId?: string;
+    newlyAuthenticatedAccountId?: string;
   } = {},
 ): CleanupResult {
   const startedAt = Date.now();
@@ -506,7 +511,11 @@ function cleanupDuplicatePlexSourcesInTransaction(
   const duplicateGroupPlans = duplicateGroups
     .map((group): DuplicateGroupPlan | undefined => {
       const canonical = group.toSorted((left, right) =>
-        compareCanonicalSources(left, right, options.preferredAccountId),
+        compareCanonicalSources(
+          left,
+          right,
+          options.newlyAuthenticatedAccountId,
+        ),
       )[0];
       return canonical ? { group, canonical } : undefined;
     })
@@ -520,7 +529,7 @@ function cleanupDuplicatePlexSourcesInTransaction(
   let reassignedRememberedSessionCount = 0;
 
   for (const { canonical, group } of duplicateGroupPlans) {
-    mergeCanonicalSource(canonical, group, options.preferredAccountId);
+    mergeCanonicalSource(canonical, group, options.newlyAuthenticatedAccountId);
 
     for (const source of group) {
       if (source.id === canonical.id) {
@@ -564,8 +573,8 @@ function cleanupDuplicatePlexSourcesInTransaction(
     updateMergedProviderAccount(canonicalAccountId, accounts);
   }
 
-  const providerAccountId = resolvePreferredAccountId(
-    options.preferredAccountId,
+  const providerAccountId = resolveCanonicalAccountId(
+    options.newlyAuthenticatedAccountId,
     canonicalAccountIdByAccountId,
   );
 
@@ -600,7 +609,7 @@ function cleanupDuplicatePlexSourcesInTransaction(
 
 export function cleanupDuplicatePlexSources(
   options: {
-    preferredAccountId?: string;
+    newlyAuthenticatedAccountId?: string;
   } = {},
 ): CleanupResult {
   return getDatabase().transaction(() =>

--- a/apps/server/src/db/providerAccountsRepository.ts
+++ b/apps/server/src/db/providerAccountsRepository.ts
@@ -66,7 +66,10 @@ function createProviderAccount(input: CreateProviderAccountInput) {
   return getProviderAccount(id);
 }
 
-function updateProviderAccount(id: string, input: UpdateProviderAccountInput) {
+export function updateProviderAccount(
+  id: string,
+  input: UpdateProviderAccountInput,
+) {
   const accessToken =
     input.accessToken === undefined
       ? undefined

--- a/apps/server/src/db/providerPersistence.test.ts
+++ b/apps/server/src/db/providerPersistence.test.ts
@@ -8,11 +8,32 @@ import {
   getMediaSourceByProviderExternalId,
   listMediaSources,
   updateMediaSource,
+  upsertMediaSource,
 } from "@/db/mediaSourcesRepository";
+import { cleanupDuplicatePlexSources } from "@/db/plexSourceDeduplication";
 import { persistProviderAuth } from "@/db/providerPersistence";
+import {
+  getProviderAccount,
+  upsertProviderAccountByAccessToken,
+} from "@/db/providerAccountsRepository";
+import {
+  createRememberedProviderSession,
+  getRememberedProviderSession,
+} from "@/db/rememberedProviderSessionsRepository";
+import { createProviderSession, getProviderSession } from "@/session/store";
 import { PLEX_BASE_URL_MODE_MANUAL } from "@/providers/plex/connectionState";
 
 const TEST_APP_KEY = "provider-persistence-test-key-with-32-characters";
+const plexProvider = {
+  id: "plex",
+  name: "Plex",
+  auth: "pin" as const,
+};
+const jellyfinProvider = {
+  id: "jellyfin",
+  name: "Jellyfin",
+  auth: "credentials" as const,
+};
 
 function restoreEnv(name: string, value: string | undefined) {
   if (value === undefined) {
@@ -46,14 +67,8 @@ function withDatabase<T>(callback: () => T) {
 
 void test("preserves manual Plex source URLs and disables stale resources", () => {
   withDatabase(() => {
-    const provider = {
-      id: "plex",
-      name: "Plex",
-      auth: "pin" as const,
-    };
-
     const account = persistProviderAuth({
-      provider,
+      provider: plexProvider,
       userToken: "user-token",
       resources: [
         {
@@ -100,7 +115,7 @@ void test("preserves manual Plex source URLs and disables stale resources", () =
     });
 
     persistProviderAuth({
-      provider,
+      provider: plexProvider,
       userToken: "user-token",
       resources: [
         {
@@ -139,5 +154,564 @@ void test("preserves manual Plex source URLs and disables stale resources", () =
     assert.equal(keptAfter.credentials.accessToken, "server-token-after");
     assert.equal(staleAfter.enabled, false);
     assert.equal(listMediaSources({ providerAccountId: account.id }).length, 2);
+  });
+});
+
+void test("deduplicates Plex sources across logins with different user tokens", () => {
+  withDatabase(() => {
+    const firstAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "desktop-user-token",
+      resources: [
+        {
+          id: "plex-server-1",
+          name: "Living Room Plex",
+          accessToken: "desktop-server-token",
+          connections: [
+            {
+              id: "desktop-connection",
+              uri: "https://plex.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const secondAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "phone-user-token",
+      resources: [
+        {
+          id: "plex-server-1",
+          name: "Living Room Plex",
+          accessToken: "phone-server-token",
+          connections: [
+            {
+              id: "phone-connection",
+              uri: "https://plex.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const sources = listMediaSources({ providerId: "plex" });
+    assert.equal(sources.length, 1);
+    assert.equal(secondAccount.id, firstAccount.id);
+    assert.equal(sources[0]?.credentials.accessToken, "phone-server-token");
+    assert.equal(
+      getProviderAccount(firstAccount.id)?.accessToken,
+      "phone-user-token",
+    );
+  });
+});
+
+void test("keeps unique Plex servers when deduplicating a repeated login", () => {
+  withDatabase(() => {
+    const firstAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "desktop-user-token",
+      resources: [
+        {
+          id: "plex-server-a",
+          name: "Server A",
+          accessToken: "desktop-server-a-token",
+          connections: [
+            {
+              id: "desktop-a-connection",
+              uri: "https://server-a.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const secondAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "phone-user-token",
+      resources: [
+        {
+          id: "plex-server-a",
+          name: "Server A",
+          accessToken: "phone-server-a-token",
+          connections: [
+            {
+              id: "phone-a-connection",
+              uri: "https://server-a.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+        {
+          id: "plex-server-b",
+          name: "Server B",
+          accessToken: "phone-server-b-token",
+          connections: [
+            {
+              id: "phone-b-connection",
+              uri: "https://server-b.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const sources = listMediaSources({ providerId: "plex" }).toSorted(
+      (left, right) =>
+        (left.externalId ?? "").localeCompare(right.externalId ?? ""),
+    );
+
+    assert.equal(secondAccount.id, firstAccount.id);
+    assert.deepEqual(
+      sources.map((source) => source.externalId),
+      ["plex-server-a", "plex-server-b"],
+    );
+    assert.deepEqual(
+      sources.map((source) => source.providerAccountId),
+      [firstAccount.id, firstAccount.id],
+    );
+    assert.equal(sources[0]?.credentials.accessToken, "phone-server-a-token");
+    assert.equal(sources[1]?.credentials.accessToken, "phone-server-b-token");
+    assert.deepEqual(
+      getProviderAccount(firstAccount.id)?.metadata.resourceIds,
+      ["plex-server-a", "plex-server-b"],
+    );
+  });
+});
+
+void test("does not merge different Plex server IDs that share a URL", () => {
+  withDatabase(() => {
+    const firstAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "first-user-token",
+    });
+    const secondAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "second-user-token",
+    });
+    assert.ok(firstAccount);
+    assert.ok(secondAccount);
+
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: firstAccount.id,
+      externalId: "plex-server-a",
+      name: "Server A",
+      baseUrl: "https://plex.example:32400",
+      connection: {
+        connections: [
+          {
+            id: "a-connection",
+            uri: "https://plex.example:32400",
+            local: false,
+            relay: false,
+          },
+        ],
+      },
+    });
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: secondAccount.id,
+      externalId: "plex-server-b",
+      name: "Server B",
+      baseUrl: "https://plex.example:32400",
+      connection: {
+        connections: [
+          {
+            id: "b-connection",
+            uri: "https://plex.example:32400",
+            local: false,
+            relay: false,
+          },
+        ],
+      },
+    });
+
+    const cleanup = cleanupDuplicatePlexSources();
+    const sources = listMediaSources({ providerId: "plex" }).toSorted(
+      (left, right) =>
+        (left.externalId ?? "").localeCompare(right.externalId ?? ""),
+    );
+
+    assert.equal(cleanup.duplicateSourceCount, 0);
+    assert.deepEqual(
+      sources.map((source) => source.externalId),
+      ["plex-server-a", "plex-server-b"],
+    );
+    assert.ok(getProviderAccount(firstAccount.id));
+    assert.ok(getProviderAccount(secondAccount.id));
+  });
+});
+
+void test("merges Plex account components bridged by a repeated login", () => {
+  withDatabase(() => {
+    const firstAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "first-user-token",
+    });
+    const secondAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "second-user-token",
+    });
+    const phoneAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "phone-user-token",
+    });
+    assert.ok(firstAccount);
+    assert.ok(secondAccount);
+    assert.ok(phoneAccount);
+
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: firstAccount.id,
+      externalId: "plex-server-a",
+      name: "Server A",
+      baseUrl: "https://server-a.example:32400",
+      credentials: {
+        accessToken: "first-server-a-token",
+      },
+    });
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: secondAccount.id,
+      externalId: "plex-server-c",
+      name: "Server C",
+      baseUrl: "https://server-c.example:32400",
+      credentials: {
+        accessToken: "second-server-c-token",
+      },
+    });
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: phoneAccount.id,
+      externalId: "plex-server-a",
+      name: "Server A",
+      baseUrl: "https://server-a.example:32400",
+      credentials: {
+        accessToken: "phone-server-a-token",
+      },
+    });
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: phoneAccount.id,
+      externalId: "plex-server-c",
+      name: "Server C",
+      baseUrl: "https://server-c.example:32400",
+      credentials: {
+        accessToken: "phone-server-c-token",
+      },
+    });
+
+    const cleanup = cleanupDuplicatePlexSources({
+      preferredAccountId: phoneAccount.id,
+    });
+    const sources = listMediaSources({ providerId: "plex" }).toSorted(
+      (left, right) =>
+        (left.externalId ?? "").localeCompare(right.externalId ?? ""),
+    );
+
+    assert.equal(cleanup.providerAccountId, firstAccount.id);
+    assert.equal(cleanup.duplicateSourceCount, 2);
+    assert.equal(cleanup.deletedAccountCount, 2);
+    assert.deepEqual(
+      sources.map((source) => source.externalId),
+      ["plex-server-a", "plex-server-c"],
+    );
+    assert.deepEqual(
+      sources.map((source) => source.providerAccountId),
+      [firstAccount.id, firstAccount.id],
+    );
+    assert.equal(sources[0]?.credentials.accessToken, "phone-server-a-token");
+    assert.equal(sources[1]?.credentials.accessToken, "phone-server-c-token");
+    assert.equal(
+      getProviderAccount(firstAccount.id)?.accessToken,
+      "phone-user-token",
+    );
+    assert.equal(getProviderAccount(secondAccount.id), undefined);
+    assert.equal(getProviderAccount(phoneAccount.id), undefined);
+  });
+});
+
+void test("disables stale Plex sources on the canonical account after dedupe", () => {
+  withDatabase(() => {
+    const firstAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "desktop-user-token",
+      resources: [
+        {
+          id: "plex-server-a",
+          name: "Server A",
+          accessToken: "desktop-server-a-token",
+          connections: [
+            {
+              id: "desktop-a-connection",
+              uri: "https://server-a.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+        {
+          id: "plex-server-stale",
+          name: "Stale Server",
+          accessToken: "desktop-stale-token",
+          connections: [
+            {
+              id: "desktop-stale-connection",
+              uri: "https://stale.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const secondAccount = persistProviderAuth({
+      provider: plexProvider,
+      userToken: "phone-user-token",
+      resources: [
+        {
+          id: "plex-server-a",
+          name: "Server A",
+          accessToken: "phone-server-a-token",
+          connections: [
+            {
+              id: "phone-a-connection",
+              uri: "https://server-a.example:32400",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const keptSource = getMediaSourceByProviderExternalId(
+      "plex",
+      firstAccount.id,
+      "plex-server-a",
+    );
+    const staleSource = getMediaSourceByProviderExternalId(
+      "plex",
+      firstAccount.id,
+      "plex-server-stale",
+    );
+
+    assert.equal(secondAccount.id, firstAccount.id);
+    assert.equal(keptSource?.enabled, true);
+    assert.equal(keptSource?.credentials.accessToken, "phone-server-a-token");
+    assert.equal(staleSource?.enabled, false);
+    assert.deepEqual(
+      getProviderAccount(firstAccount.id)?.metadata.resourceIds,
+      ["plex-server-a"],
+    );
+  });
+});
+
+void test("cleans existing duplicate Plex sources and preserves manual URL mode", () => {
+  withDatabase(() => {
+    const canonicalAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "desktop-user-token",
+    });
+    const duplicateAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "phone-user-token",
+    });
+    assert.ok(canonicalAccount);
+    assert.ok(duplicateAccount);
+
+    const canonicalSource = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: canonicalAccount.id,
+      externalId: "plex-server-1",
+      name: "plex.rackserver.dev",
+      baseUrl: "https://manual.example:32400",
+      connection: {
+        baseUrlMode: PLEX_BASE_URL_MODE_MANUAL,
+        connections: [
+          {
+            id: "manual-connection",
+            uri: "https://auto-before.example:32400",
+            local: false,
+            relay: false,
+          },
+        ],
+        selectedConnectionId: "manual-connection",
+      },
+      credentials: {
+        accessToken: "desktop-server-token",
+      },
+      metadata: {
+        product: "Plex Media Server",
+        platform: "Linux",
+        owned: true,
+        provides: ["server"],
+      },
+    });
+    const duplicateSource = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: duplicateAccount.id,
+      externalId: "plex-server-1",
+      name: "plex.rackserver.dev",
+      baseUrl: "https://172-18-0-29.example.plex.direct:32400",
+      connection: {
+        connections: [
+          {
+            id: "phone-connection",
+            uri: "https://172-18-0-29.example.plex.direct:32400",
+            local: false,
+            relay: false,
+          },
+        ],
+        selectedConnectionId: "phone-connection",
+      },
+      credentials: {
+        accessToken: "phone-server-token",
+      },
+      metadata: {
+        product: "Plex Media Server",
+        platform: "Linux",
+        owned: true,
+        provides: ["server"],
+      },
+    });
+    assert.ok(canonicalSource);
+    assert.ok(duplicateSource);
+
+    const duplicateSession = createProviderSession({
+      providerId: "plex",
+      providerAccountId: duplicateAccount.id,
+      userToken: "phone-user-token",
+    });
+    const rememberedSession = createRememberedProviderSession(
+      duplicateAccount.id,
+    );
+
+    const cleanup = cleanupDuplicatePlexSources({
+      preferredAccountId: duplicateAccount.id,
+    });
+
+    assert.equal(cleanup.providerAccountId, canonicalAccount.id);
+    assert.equal(cleanup.duplicateSourceCount, 1);
+    assert.equal(cleanup.deletedAccountCount, 1);
+    assert.equal(
+      getProviderSession(duplicateSession.id)?.providerAccountId,
+      canonicalAccount.id,
+    );
+    assert.equal(
+      getRememberedProviderSession(rememberedSession.token)?.providerAccountId,
+      canonicalAccount.id,
+    );
+    assert.equal(getProviderAccount(duplicateAccount.id), undefined);
+
+    const sources = listMediaSources({ providerId: "plex" });
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0]?.id, canonicalSource.id);
+    assert.equal(sources[0]?.baseUrl, "https://manual.example:32400");
+    assert.equal(sources[0]?.connection.baseUrlMode, PLEX_BASE_URL_MODE_MANUAL);
+    assert.equal(sources[0]?.credentials.accessToken, "phone-server-token");
+  });
+});
+
+void test("does not merge distinct Plex server identities", () => {
+  withDatabase(() => {
+    const firstAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "first-user-token",
+    });
+    const secondAccount = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "second-user-token",
+    });
+    assert.ok(firstAccount);
+    assert.ok(secondAccount);
+
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: firstAccount.id,
+      externalId: "plex-server-1",
+      name: "Plex",
+      baseUrl: "https://first.example:32400",
+    });
+    upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: secondAccount.id,
+      externalId: "plex-server-2",
+      name: "Plex",
+      baseUrl: "https://second.example:32400",
+    });
+
+    const cleanup = cleanupDuplicatePlexSources();
+
+    assert.equal(cleanup.duplicateSourceCount, 0);
+    assert.equal(listMediaSources({ providerId: "plex" }).length, 2);
+    assert.ok(getProviderAccount(firstAccount.id));
+    assert.ok(getProviderAccount(secondAccount.id));
+  });
+});
+
+void test("keeps Jellyfin provider accounts token based", () => {
+  withDatabase(() => {
+    const firstAccount = persistProviderAuth({
+      provider: jellyfinProvider,
+      userToken: "first-jellyfin-token",
+      resources: [
+        {
+          id: "jellyfin-server-1",
+          name: "Jellyfin",
+          accessToken: "first-jellyfin-token",
+          connections: [
+            {
+              id: "first-connection",
+              uri: "https://jellyfin.example",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+    const secondAccount = persistProviderAuth({
+      provider: jellyfinProvider,
+      userToken: "second-jellyfin-token",
+      resources: [
+        {
+          id: "jellyfin-server-1",
+          name: "Jellyfin",
+          accessToken: "second-jellyfin-token",
+          connections: [
+            {
+              id: "second-connection",
+              uri: "https://jellyfin.example",
+              local: false,
+              relay: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.notEqual(firstAccount.id, secondAccount.id);
+    assert.equal(listMediaSources({ providerId: "jellyfin" }).length, 2);
   });
 });

--- a/apps/server/src/db/providerPersistence.test.ts
+++ b/apps/server/src/db/providerPersistence.test.ts
@@ -417,7 +417,7 @@ void test("merges Plex account components bridged by a repeated login", () => {
     });
 
     const cleanup = cleanupDuplicatePlexSources({
-      preferredAccountId: phoneAccount.id,
+      newlyAuthenticatedAccountId: phoneAccount.id,
     });
     const sources = listMediaSources({ providerId: "plex" }).toSorted(
       (left, right) =>
@@ -606,7 +606,7 @@ void test("cleans existing duplicate Plex sources and preserves manual URL mode"
     );
 
     const cleanup = cleanupDuplicatePlexSources({
-      preferredAccountId: duplicateAccount.id,
+      newlyAuthenticatedAccountId: duplicateAccount.id,
     });
 
     assert.equal(cleanup.providerAccountId, canonicalAccount.id);

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -137,7 +137,7 @@ export function persistProviderAuth(input: {
 
   if (input.provider.id === "plex") {
     const cleanup = cleanupDuplicatePlexSources({
-      preferredAccountId: account.id,
+      newlyAuthenticatedAccountId: account.id,
     });
     const resolvedAccount = cleanup.providerAccountId
       ? (getProviderAccount(cleanup.providerAccountId) ?? account)

--- a/apps/server/src/db/providerPersistence.ts
+++ b/apps/server/src/db/providerPersistence.ts
@@ -10,7 +10,12 @@ import {
   updateMediaSource,
   upsertMediaSource,
 } from "@/db/mediaSourcesRepository";
-import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
+import { cleanupDuplicatePlexSources } from "@/db/plexSourceDeduplication";
+import {
+  getProviderAccount,
+  updateProviderAccount,
+  upsertProviderAccountByAccessToken,
+} from "@/db/providerAccountsRepository";
 import {
   plexBaseUrlMode,
   PLEX_BASE_URL_MODE_AUTO,
@@ -41,6 +46,63 @@ function preferredConnection(
   )[0];
 }
 
+function providerAccountMetadata(input: {
+  provider: ProviderDefinition;
+  resources: ProviderResource[];
+}) {
+  return {
+    resourceCount: input.resources.length,
+    lastAuthenticatedAt: new Date().toISOString(),
+    ...(input.provider.id === "plex"
+      ? {
+          resourceIds: input.resources
+            .map((resource) => resource.id)
+            .toSorted(),
+        }
+      : {}),
+  };
+}
+
+function disableStaleProviderSources(input: {
+  providerId: string;
+  providerAccountId: string;
+  activeResourceIds: Set<string>;
+}) {
+  const staleSources = listMediaSources({
+    providerId: input.providerId,
+    providerAccountId: input.providerAccountId,
+  }).filter(
+    (source) =>
+      typeof source.externalId === "string" &&
+      !input.activeResourceIds.has(source.externalId) &&
+      source.enabled,
+  );
+
+  for (const source of staleSources) {
+    updateMediaSource(source.id, { enabled: false });
+  }
+}
+
+function refreshProviderAuthMetadata(
+  providerAccountId: string,
+  input: {
+    provider: ProviderDefinition;
+    resources: ProviderResource[];
+  },
+) {
+  const account = getProviderAccount(providerAccountId);
+  if (!account) {
+    return;
+  }
+
+  updateProviderAccount(providerAccountId, {
+    metadata: {
+      ...account.metadata,
+      ...providerAccountMetadata(input),
+    },
+  });
+}
+
 export function persistProviderAuth(input: {
   provider: ProviderDefinition;
   userToken: string;
@@ -50,10 +112,7 @@ export function persistProviderAuth(input: {
     providerId: input.provider.id,
     label: `${input.provider.name} Account`,
     accessToken: input.userToken,
-    metadata: {
-      resourceCount: input.resources.length,
-      lastAuthenticatedAt: new Date().toISOString(),
-    },
+    metadata: providerAccountMetadata(input),
   });
 
   if (!account) {
@@ -67,19 +126,6 @@ export function persistProviderAuth(input: {
   const activeResourceIds = new Set(
     input.resources.map((resource) => resource.id),
   );
-  const staleSources = listMediaSources({
-    providerId: input.provider.id,
-    providerAccountId: account.id,
-  }).filter(
-    (source) =>
-      typeof source.externalId === "string" &&
-      !activeResourceIds.has(source.externalId) &&
-      source.enabled,
-  );
-
-  for (const source of staleSources) {
-    updateMediaSource(source.id, { enabled: false });
-  }
 
   for (const resource of input.resources) {
     persistProviderResource({
@@ -89,6 +135,27 @@ export function persistProviderAuth(input: {
     });
   }
 
+  if (input.provider.id === "plex") {
+    const cleanup = cleanupDuplicatePlexSources({
+      preferredAccountId: account.id,
+    });
+    const resolvedAccount = cleanup.providerAccountId
+      ? (getProviderAccount(cleanup.providerAccountId) ?? account)
+      : account;
+    disableStaleProviderSources({
+      providerId: input.provider.id,
+      providerAccountId: resolvedAccount.id,
+      activeResourceIds,
+    });
+    refreshProviderAuthMetadata(resolvedAccount.id, input);
+    return getProviderAccount(resolvedAccount.id) ?? resolvedAccount;
+  }
+
+  disableStaleProviderSources({
+    providerId: input.provider.id,
+    providerAccountId: account.id,
+    activeResourceIds,
+  });
   return account;
 }
 

--- a/apps/server/src/providers/plex/sourceIdentity.ts
+++ b/apps/server/src/providers/plex/sourceIdentity.ts
@@ -1,0 +1,78 @@
+import type { MediaSource } from "@/db/mediaSourcesRepository";
+
+export interface PlexSourceIdentity {
+  resourceKey?: string;
+  urlKeys: string[];
+}
+
+function normalizePlexSourceUrl(value: string | undefined) {
+  if (!value?.trim()) {
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    return;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return;
+  }
+
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.hostname = parsed.hostname.toLowerCase();
+  parsed.search = "";
+  parsed.hash = "";
+
+  const normalized = parsed.toString();
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+}
+
+function connectionUris(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const connections = (value as { connections?: unknown }).connections;
+  if (!Array.isArray(connections)) {
+    return [];
+  }
+
+  return connections
+    .map((connection) =>
+      connection && typeof connection === "object" && !Array.isArray(connection)
+        ? (connection as { uri?: unknown }).uri
+        : undefined,
+    )
+    .filter((uri): uri is string => typeof uri === "string");
+}
+
+function addUrlKey(keys: Set<string>, url: string | undefined) {
+  const normalized = normalizePlexSourceUrl(url);
+  if (normalized) {
+    keys.add(`url:${normalized}`);
+  }
+}
+
+function plexResourceIdKey(resourceId: string | undefined) {
+  const normalized = resourceId?.trim();
+  if (normalized) {
+    return `resource:${normalized}`;
+  }
+}
+
+export function plexSourceIdentity(source: MediaSource): PlexSourceIdentity {
+  const urlKeys = new Set<string>();
+
+  addUrlKey(urlKeys, source.baseUrl);
+  for (const uri of connectionUris(source.connection)) {
+    addUrlKey(urlKeys, uri);
+  }
+
+  return {
+    resourceKey: plexResourceIdKey(source.externalId),
+    urlKeys: [...urlKeys].toSorted(),
+  };
+}

--- a/apps/server/src/routes/providerSources.test.ts
+++ b/apps/server/src/routes/providerSources.test.ts
@@ -116,14 +116,17 @@ async function withMockedFetch<T>(
 
 void test("completes Plex PIN auth through route cookies and persists sources", async () => {
   await withTestApp(async (baseUrl, fetchLocal) => {
+    let nextPinId = 321;
     await withMockedFetch(
       async (input) => {
         const requestUrl = fetchInputUrl(input);
 
         if (requestUrl === "https://plex.tv/api/v2/pins?strong=true") {
+          const id = nextPinId;
+          nextPinId += 1;
           return jsonResponse({
-            id: 321,
-            code: "WXYZ",
+            id,
+            code: `WXYZ-${id}`,
             expiresIn: 60,
           });
         }
@@ -131,6 +134,12 @@ void test("completes Plex PIN auth through route cookies and persists sources", 
         if (requestUrl === "https://plex.tv/api/v2/pins/321") {
           return jsonResponse({
             authToken: "plex-user-token",
+          });
+        }
+
+        if (requestUrl === "https://plex.tv/api/v2/pins/322") {
+          return jsonResponse({
+            authToken: "plex-phone-token",
           });
         }
 
@@ -225,6 +234,42 @@ void test("completes Plex PIN auth through route cookies and persists sources", 
         assert.equal(sources[0]?.baseUrl, "http://192.0.2.10:32400");
         assert.equal(sources[0]?.credentials.accessToken, "plex-server-token");
         assert.equal(sources[0]?.metadata.product, "Plex Media Server");
+
+        const secondStartResponse = await fetchLocal(
+          `${baseUrl}/api/providers/plex/auth/start`,
+          {
+            method: "POST",
+          },
+        );
+        assert.equal(secondStartResponse.status, 200);
+        const secondStartBody = (await secondStartResponse.json()) as {
+          authId?: string;
+        };
+        assert.equal(typeof secondStartBody.authId, "string");
+        const secondAuthCookie = cookieHeader(secondStartResponse);
+
+        const secondCompleteResponse = await fetchLocal(
+          `${baseUrl}/api/providers/plex/auth/${secondStartBody.authId}`,
+          {
+            headers: {
+              cookie: secondAuthCookie,
+            },
+          },
+        );
+        assert.equal(secondCompleteResponse.status, 200);
+        assert.deepEqual(await secondCompleteResponse.json(), {
+          status: "complete",
+        });
+
+        const sourcesAfterSecondLogin = listMediaSources({
+          providerId: "plex",
+        });
+        assert.equal(sourcesAfterSecondLogin.length, 1);
+        assert.equal(sourcesAfterSecondLogin[0]?.name, "Living Room Plex");
+        assert.equal(
+          sourcesAfterSecondLogin[0]?.baseUrl,
+          "http://192.0.2.10:32400",
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary
- dedupe repeated Plex auth sources by stable server identity instead of per-device user token
- preserve unique Plex servers under the surviving provider account and refresh stale source state after canonicalization
- scope Plex duplicate cleanup to successful Plex auth; existing deployed duplicates are repaired on the next Plex reauth, not on startup

## Validation
- pnpm --filter @cliparr/server test
- pnpm preflight