### PR TITLE
ci(cliparr): ignore www features for release bumps

### DIFF
--- a/scripts/release/conventional.mjs
+++ b/scripts/release/conventional.mjs
@@ -19,6 +19,7 @@ const releaseTypeByCommitType = new Map([
   ["security", "patch"],
   ["feat", "minor"],
 ]);
+const ignoredReleaseScopes = new Set(["www"]);
 
 const conventionalTitlePattern =
   /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?: (?<subject>.+)$/;
@@ -68,6 +69,10 @@ export function parseConventionalTitle(title) {
 
 export function releaseTypeForChange(change) {
   if (!change.valid) {
+    return "none";
+  }
+
+  if (ignoredReleaseScopes.has(change.scope)) {
     return "none";
   }
 

--- a/scripts/release/conventional.test.mjs
+++ b/scripts/release/conventional.test.mjs
@@ -63,6 +63,35 @@ void test("chooses the highest release level in a change set", () => {
   assert.equal(maxReleaseType(changes), "minor");
 });
 
+void test("ignores website-scoped changes for release planning", () => {
+  assert.equal(
+    releaseTypeForChange(
+      parseConventionalTitle("feat(www): add release page permalinks"),
+    ),
+    "none",
+  );
+  assert.equal(
+    releaseTypeForChange(
+      parseConventionalTitle("fix(www): restore Astro view transitions"),
+    ),
+    "none",
+  );
+  assert.equal(
+    releaseTypeForChange(
+      parseConventionalTitle("feat(www)!: redesign the marketing site"),
+    ),
+    "none",
+  );
+
+  assert.equal(
+    maxReleaseType([
+      parseConventionalTitle("docs: update setup copy"),
+      parseConventionalTitle("feat(www): add blog rss"),
+    ]),
+    "none",
+  );
+});
+
 void test("rejects unknown conventional commit types", () => {
   const change = parseConventionalTitle("release: publish next version");
 


### PR DESCRIPTION
## Summary
- Ignore `www`-scoped Conventional Commit titles when planning release bump levels.
- Cover `feat(www)`, `fix(www)`, and breaking `www` changes with release planner tests.

## Validation
- `pnpm test:release`
- `pnpm preflight`