### PR TITLE
fix(server): isolate Plex subtitle transcode sessions

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -272,7 +272,7 @@ flowchart TD
     H -- "No" --> J["buildLocalEditorSession stores source as directSource"]
 
     K["GET /api/media/local-url/:handleId"] --> L["Resolve local-url handle"]
-    L --> M["Forward Range only when request is not an HLS playlist"]
+    L --> M["Forward Range only when request is not HLS-derived"]
     M --> N["proxyProviderMediaResponse without provider auth"]
     N --> O["Nested HLS URIs create new local-url handles"]
 ```

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -80,7 +80,11 @@ function createMediaHandle(
       sourceId: context.sourceId,
       baseUrl: context.baseUrl,
       token: context.token,
-      deviceId: context.deviceId,
+      providerMetadata: {
+        jellyfin: {
+          deviceId: context.deviceId,
+        },
+      },
     },
     path,
     options,
@@ -1051,7 +1055,7 @@ export async function proxyMedia(
   const headers = useProviderAuth
     ? jellyfinHeaders({
         token: handle.token,
-        deviceId: handle.deviceId,
+        deviceId: handle.providerMetadata?.jellyfin?.deviceId,
         accept,
       })
     : new Headers(accept ? { Accept: accept } : undefined);

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -551,7 +551,7 @@ function buildStaticStreamPath(
   item: JellyfinItem,
   mediaSourceId: string | undefined,
   context: JellyfinSourceContext,
-  playSessionId: string,
+  jellyfinPlaySessionId: string,
 ) {
   const itemId = stringValue(item?.Id);
   if (!itemId) {
@@ -562,7 +562,7 @@ function buildStaticStreamPath(
   const params = new URLSearchParams({
     static: "true",
     deviceId: context.deviceId,
-    playSessionId,
+    playSessionId: jellyfinPlaySessionId,
     context: "Static",
   });
 
@@ -577,7 +577,7 @@ export function buildPreviewPath(
   item: JellyfinItem,
   mediaSourceId: string | undefined,
   context: JellyfinSourceContext,
-  playSessionId: string,
+  jellyfinPlaySessionId: string,
 ) {
   const itemId = stringValue(item?.Id);
   if (
@@ -591,7 +591,7 @@ export function buildPreviewPath(
   const params = new URLSearchParams({
     mediaSourceId,
     deviceId: context.deviceId,
-    playSessionId,
+    playSessionId: jellyfinPlaySessionId,
     maxAudioChannels: "2",
     audioCodec: "aac",
     enableAdaptiveBitrateStreaming: "false",
@@ -780,13 +780,13 @@ function prunePlaybackInfoCache(now = Date.now()) {
 
 function playbackItemIdentity(
   sourceId: string,
-  clientSessionId: string | undefined,
+  jellyfinClientSessionId: string | undefined,
   itemId: string,
   mediaSourceId: string | undefined,
 ) {
   return [
     sourceId,
-    clientSessionId ?? "unknown-session",
+    jellyfinClientSessionId ?? "unknown-session",
     itemId,
     mediaSourceId ?? "unknown-media-source",
   ].join(":");
@@ -794,14 +794,14 @@ function playbackItemIdentity(
 
 function playbackViewer(
   sourceId: string,
-  sessionId: string,
+  jellyfinClientSessionId: string,
   sessionInfo: JellyfinSessionInfo,
 ) {
   const externalId = stringValue(sessionInfo?.UserId);
   return {
     id: externalId
       ? `jellyfin:user:${externalId}`
-      : `jellyfin:synthetic:${sourceId}:${sessionId}`,
+      : `jellyfin:synthetic:${sourceId}:${jellyfinClientSessionId}`,
     providerId: "jellyfin" as const,
     externalId,
     name: stringValue(sessionInfo?.UserName) ?? "Unknown User",
@@ -828,8 +828,8 @@ async function normalizeCurrentPlayback(
     enrichMetadataItem(context, nowPlayingItem),
     loadPlaybackInfo(session, context, sessionInfo, itemId),
   ]);
-  const playSessionId = stringValue(playbackInfo?.PlaySessionId);
-  const clientSessionId = stringValue(sessionInfo?.Id);
+  const jellyfinPlaySessionId = stringValue(playbackInfo?.PlaySessionId);
+  const jellyfinClientSessionId = stringValue(sessionInfo?.Id);
   const mediaSourceId = currentMediaSourceId(
     sessionInfo,
     enrichedItem,
@@ -841,11 +841,21 @@ async function normalizeCurrentPlayback(
     mediaSourceId,
     playbackInfo,
   );
-  const mediaPath = playSessionId
-    ? buildStaticStreamPath(enrichedItem, mediaSourceId, context, playSessionId)
+  const mediaPath = jellyfinPlaySessionId
+    ? buildStaticStreamPath(
+        enrichedItem,
+        mediaSourceId,
+        context,
+        jellyfinPlaySessionId,
+      )
     : undefined;
-  const previewPath = playSessionId
-    ? buildPreviewPath(enrichedItem, mediaSourceId, context, playSessionId)
+  const previewPath = jellyfinPlaySessionId
+    ? buildPreviewPath(
+        enrichedItem,
+        mediaSourceId,
+        context,
+        jellyfinPlaySessionId,
+      )
     : undefined;
   const imagePath = itemImagePath(enrichedItem);
   const selectedAudioTrack = deriveSelectedAudioTrack(
@@ -902,7 +912,7 @@ async function normalizeCurrentPlayback(
     : undefined;
   const playbackItemId = playbackItemIdentity(
     source.id,
-    clientSessionId,
+    jellyfinClientSessionId,
     itemId,
     mediaSourceId,
   );
@@ -914,7 +924,7 @@ async function normalizeCurrentPlayback(
     sessionId: session.id,
     sourceId: source.id,
     providerAccountId: source.providerAccountId,
-    playSessionId,
+    playSessionId: jellyfinPlaySessionId,
     currentlyPlayingItem: {
       id: playbackItemId,
       title: itemTitle(enrichedItem),
@@ -976,7 +986,11 @@ async function normalizeCurrentPlayback(
   }
 
   return {
-    viewer: playbackViewer(source.id, clientSessionId ?? itemId, sessionInfo),
+    viewer: playbackViewer(
+      source.id,
+      jellyfinClientSessionId ?? itemId,
+      sessionInfo,
+    ),
     item: {
       id: playbackItemId,
       source: {

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -119,15 +119,15 @@ function fetchInputUrl(input: Parameters<typeof fetch>[0]) {
 
 function createJellyfinPlaybackFetch(options: {
   itemId: string;
-  playSessionId?: string | null | (() => string | null);
-  clientSessionId?: string;
+  jellyfinPlaySessionId?: string | null | (() => string | null);
+  jellyfinClientSessionId?: string;
   mediaSourceId?: string;
   title?: string;
 }) {
   const {
     itemId,
-    playSessionId = "playback-info-session-1",
-    clientSessionId = "client-session-1",
+    jellyfinPlaySessionId = "playback-info-session-1",
+    jellyfinClientSessionId = "client-session-1",
     mediaSourceId = "media-source-1",
     title = "Chapter 1: The Dark Revenge",
   } = options;
@@ -172,7 +172,7 @@ function createJellyfinPlaybackFetch(options: {
     if (url.pathname === "/Sessions") {
       return jsonResponse([
         {
-          Id: clientSessionId,
+          Id: jellyfinClientSessionId,
           UserId: "user-1",
           UserName: "Rick",
           DeviceName: "Chrome",
@@ -192,11 +192,13 @@ function createJellyfinPlaybackFetch(options: {
     }
 
     if (url.pathname === `/Items/${itemId}/PlaybackInfo`) {
-      const resolvedPlaySessionId =
-        typeof playSessionId === "function" ? playSessionId() : playSessionId;
+      const resolvedJellyfinPlaySessionId =
+        typeof jellyfinPlaySessionId === "function"
+          ? jellyfinPlaySessionId()
+          : jellyfinPlaySessionId;
       return jsonResponse({
-        ...(resolvedPlaySessionId
-          ? { PlaySessionId: resolvedPlaySessionId }
+        ...(resolvedJellyfinPlaySessionId
+          ? { PlaySessionId: resolvedJellyfinPlaySessionId }
           : {}),
         MediaSources: [mediaSource],
       });
@@ -275,8 +277,8 @@ void test("uses Jellyfin PlaybackInfo play session ids for currently playing str
   const originalFetch = globalThis.fetch;
   globalThis.fetch = createJellyfinPlaybackFetch({
     itemId: "item-1",
-    playSessionId: "playback-info-session-1",
-    clientSessionId: "client-session-1",
+    jellyfinPlaySessionId: "playback-info-session-1",
+    jellyfinClientSessionId: "client-session-1",
   });
 
   try {
@@ -329,11 +331,11 @@ void test("reuses Jellyfin playback info for stable currently playing handles", 
   let playbackInfoRequestCount = 0;
   globalThis.fetch = createJellyfinPlaybackFetch({
     itemId: "item-1",
-    playSessionId: () => {
+    jellyfinPlaySessionId: () => {
       playbackInfoRequestCount += 1;
       return `playback-info-session-${playbackInfoRequestCount}`;
     },
-    clientSessionId: "client-session-1",
+    jellyfinClientSessionId: "client-session-1",
   });
 
   try {
@@ -379,7 +381,7 @@ void test("keeps Jellyfin currently playing item ids stable and item-scoped", as
   try {
     globalThis.fetch = createJellyfinPlaybackFetch({
       itemId: "item-1",
-      clientSessionId: "client-session-1",
+      jellyfinClientSessionId: "client-session-1",
     });
     const firstEntries = await listCurrentlyPlaying(
       createSession(),
@@ -392,7 +394,7 @@ void test("keeps Jellyfin currently playing item ids stable and item-scoped", as
 
     globalThis.fetch = createJellyfinPlaybackFetch({
       itemId: "item-2",
-      clientSessionId: "client-session-1",
+      jellyfinClientSessionId: "client-session-1",
     });
     const differentItemEntries = await listCurrentlyPlaying(
       createSession(),
@@ -411,8 +413,8 @@ void test("omits Jellyfin stream URLs when PlaybackInfo has no play session id",
   const originalFetch = globalThis.fetch;
   globalThis.fetch = createJellyfinPlaybackFetch({
     itemId: "item-1",
-    playSessionId: null,
-    clientSessionId: "client-session-1",
+    jellyfinPlaySessionId: null,
+    jellyfinClientSessionId: "client-session-1",
   });
 
   try {

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -646,7 +646,11 @@ void test("strips Jellyfin auth headers from cross-origin media redirects", asyn
     baseUrl: "http://jellyfin.local:8096",
     path: "/Videos/item-1/stream",
     token: "provider-token",
-    deviceId: "cliparr-device-1",
+    providerMetadata: {
+      jellyfin: {
+        deviceId: "cliparr-device-1",
+      },
+    },
     lastAccessedAt: 0,
   });
 

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -193,7 +193,11 @@ void test("preserves playback session ids when rewriting HLS playlist resources"
       sourceId: "source-1",
       baseUrl: "http://plex.local:32400",
       token: "provider-token",
-      playbackSessionId: "254",
+      providerMetadata: {
+        plex: {
+          playbackSessionId: "254",
+        },
+      },
     },
     "/video/:/transcode/universal/start.m3u8?transcodeSessionId=11111111-2222-5333-8444-555555555555",
   );
@@ -220,7 +224,7 @@ void test("preserves playback session ids when rewriting HLS playlist resources"
   );
   assert.ok(childHandle);
   assert.equal(childHandle.path, "/video/:/transcode/universal/segment0.ts");
-  assert.equal(childHandle.playbackSessionId, "254");
+  assert.equal(childHandle.providerMetadata?.plex?.playbackSessionId, "254");
 });
 
 void test("uses custom media handle URLs when rewriting HLS playlists", async () => {

--- a/apps/server/src/providers/mediaProxy.test.ts
+++ b/apps/server/src/providers/mediaProxy.test.ts
@@ -7,6 +7,7 @@ import type { ProviderSessionRecord } from "@/session/store";
 import type { MediaHandle } from "@/providers/types";
 import {
   assertAllowedMediaHandleRequestUrl,
+  createProviderMediaHandle,
   fetchMediaHandleRequest,
   proxyProviderMediaResponse,
   proxyUpstreamMediaResponse,
@@ -183,6 +184,45 @@ void test("preserves absolute HLS origins when rewriting nested playlist resourc
   assert.ok(handlePaths.has("https://cdn.example.com/hls/720p/segment0.ts"));
 });
 
+void test("preserves playback session ids when rewriting HLS playlist resources", async () => {
+  const session = createSession();
+  const rootUrl = createProviderMediaHandle(
+    session,
+    {
+      providerId: "plex",
+      sourceId: "source-1",
+      baseUrl: "http://plex.local:32400",
+      token: "provider-token",
+      playbackSessionId: "254",
+    },
+    "/video/:/transcode/universal/start.m3u8?transcodeSessionId=11111111-2222-5333-8444-555555555555",
+  );
+  const rootHandleId = rootUrl.split("/").at(-1);
+  assert.ok(rootHandleId);
+  const rootHandle = session.mediaHandles.get(rootHandleId);
+  assert.ok(rootHandle);
+  const response = createResponseRecorder();
+
+  await proxyUpstreamMediaResponse(
+    session,
+    rootHandle,
+    new globalThis.Response("#EXTM3U\n#EXTINF:1,\nsegment0.ts\n", {
+      status: 200,
+      headers: {
+        "content-type": "application/vnd.apple.mpegurl",
+      },
+    }),
+    response as unknown as Response,
+  );
+
+  const childHandle = [...session.mediaHandles.values()].find(
+    (handle) => handle.id !== rootHandle.id,
+  );
+  assert.ok(childHandle);
+  assert.equal(childHandle.path, "/video/:/transcode/universal/segment0.ts");
+  assert.equal(childHandle.playbackSessionId, "254");
+});
+
 void test("uses custom media handle URLs when rewriting HLS playlists", async () => {
   const session = createSession();
   const rootHandle = createMediaHandle({
@@ -262,11 +302,21 @@ void test("strips HLS start hints so editor seeks control playback position", as
   assert.equal(session.mediaHandles.size, 1);
 });
 
-void test("does not forward range requests for HLS playlists that Cliparr rewrites", () => {
+void test("does not forward range requests for HLS resources that Cliparr rewrites", () => {
   assert.equal(
     shouldForwardMediaRange(
       createMediaHandle({
         path: "/video/:/transcode/universal/start.m3u8?session=1",
+      }),
+      "bytes=148-",
+    ),
+    undefined,
+  );
+  assert.equal(
+    shouldForwardMediaRange(
+      createMediaHandle({
+        path: "/video/:/transcode/universal/session/session-1/base/00000.ts",
+        basePath: "/video/:/transcode/universal/session/session-1/base/",
       }),
       "bytes=148-",
     ),
@@ -546,8 +596,8 @@ void test("retries not-yet-generated HLS-derived media responses", async () => {
   globalThis.fetch = (async () => {
     fetchCount += 1;
 
-    return new Response(fetchCount < 3 ? "missing" : "ok", {
-      status: fetchCount < 3 ? 404 : 200,
+    return new Response(fetchCount < 6 ? "missing" : "ok", {
+      status: fetchCount < 6 ? 404 : 200,
     });
   }) as typeof fetch;
 
@@ -564,7 +614,7 @@ void test("retries not-yet-generated HLS-derived media responses", async () => {
 
     assert.equal(response.status, 200);
     assert.equal(await response.text(), "ok");
-    assert.equal(fetchCount, 3);
+    assert.equal(fetchCount, 6);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -674,6 +724,7 @@ void test("uses buffered byte length for cached HLS-derived media responses", as
 void test("dedupes concurrent HLS-derived media requests for the same handle", async () => {
   const session = createSession();
   const handle = createMediaHandle({
+    id: "dedupe-handle",
     path: "https://cdn.example.com/hls/segment0.ts",
     basePath: "https://cdn.example.com/hls/",
   });
@@ -719,4 +770,45 @@ void test("dedupes concurrent HLS-derived media requests for the same handle", a
   assert.equal(fetchCount, 1);
   assert.deepEqual(firstResponse.body, Buffer.from([1, 2, 3, 4]));
   assert.deepEqual(secondResponse.body, Buffer.from([1, 2, 3, 4]));
+});
+
+void test("cleans failed in-flight HLS responses without unhandled rejection", async () => {
+  const session = createSession();
+  const handle = createMediaHandle({
+    id: "failed-inflight-handle",
+    path: "https://cdn.example.com/hls/segment0.ts",
+    basePath: "https://cdn.example.com/hls/",
+  });
+  const response = createBinaryResponseRecorder();
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    await assert.rejects(
+      () =>
+        proxyProviderMediaResponse(
+          session,
+          handle,
+          {
+            accept: "video/mp2t",
+          },
+          async () => {
+            throw new Error("upstream failed");
+          },
+          response as unknown as Response,
+        ),
+      /upstream failed/,
+    );
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+
+  assert.deepEqual(unhandledRejections, []);
 });

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -81,7 +81,14 @@ function createMediaHandle(
       sourceId: context.sourceId,
       baseUrl: context.baseUrl,
       token: context.token,
-      playbackSessionId: options.playbackSessionId,
+      providerMetadata:
+        options.playbackSessionId === undefined
+          ? undefined
+          : {
+              plex: {
+                playbackSessionId: options.playbackSessionId,
+              },
+            },
     },
     path,
     {
@@ -1451,7 +1458,8 @@ export async function proxyMedia(
   }
 
   const playbackSessionId = useProviderAuth
-    ? (handle.playbackSessionId ?? transcodeSessionId(handle.path))
+    ? (handle.providerMetadata?.plex?.playbackSessionId ??
+      transcodeSessionId(handle.path))
     : null;
   if (playbackSessionId) {
     headers.set("X-Plex-Session-Identifier", playbackSessionId);

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -66,14 +66,13 @@ import {
 
 const logger = getServerLogger(["provider", "plex", "playback"]);
 const HD_ARTWORK_SIZE = 1920;
-const PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH = 16;
 const PLEX_METADATA_PATH_PREFIX = "/library/metadata/";
 
 function createMediaHandle(
   session: ProviderSessionRecord,
   context: PlexSourceContext,
   path: string,
-  options: { basePath?: string } = {},
+  options: { basePath?: string; playbackSessionId?: string } = {},
 ) {
   return createProviderMediaHandle(
     session,
@@ -82,9 +81,12 @@ function createMediaHandle(
       sourceId: context.sourceId,
       baseUrl: context.baseUrl,
       token: context.token,
+      playbackSessionId: options.playbackSessionId,
     },
     path,
-    options,
+    {
+      basePath: options.basePath,
+    },
   );
 }
 
@@ -435,17 +437,22 @@ export function createCliparrPlexTranscodeSessionId(
   sourceId: string,
   playbackSessionId: string,
 ) {
-  const safeSourceId =
-    sourceId
-      .replaceAll(/[^\w-]+/gi, "-")
-      .replaceAll(/^-+|-+$/g, "")
-      .slice(0, PLEX_TRANSCODE_SOURCE_ID_MAX_LENGTH) || "source";
   const digest = createHash("sha256")
     .update(`${sourceId}:${playbackSessionId}`)
     .digest("hex")
-    .slice(0, 16);
+    .slice(0, 32);
+  const version = "5";
+  const variant = ((Number.parseInt(digest[16] ?? "0", 16) & 0x3) | 0x8)
+    .toString(16)
+    .slice(0, 1);
 
-  return `cliparr-${safeSourceId}-${digest}`;
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    `${version}${digest.slice(13, 16)}`,
+    `${variant}${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
 }
 
 function transcodeSessionId(path: string) {
@@ -947,7 +954,11 @@ function plexSubtitleTrack(
     isHearingImpaired: booleanFlag(stream?.hearingImpaired),
     isExternal: Boolean(stringValue(stream?.key)),
     contentUrl: contentPath
-      ? createMediaHandle(session, context, contentPath)
+      ? createMediaHandle(session, context, contentPath, {
+          playbackSessionId: transcodeSubtitlePath
+            ? playbackSessionId
+            : undefined,
+        })
       : undefined,
   };
 }
@@ -1251,7 +1262,7 @@ async function normalizeCurrentPlayback(
         session,
         context,
         enrichedItem,
-        transcodeSessionId,
+        sessionId,
         mediaSelection,
       ).filter((track) => subtitleTrackSupportsBurnIn(track));
       const selectedPart = resolveSelectedPart(
@@ -1285,7 +1296,9 @@ async function normalizeCurrentPlayback(
         ? createMediaHandle(session, context, mediaPath)
         : undefined;
       const hlsUrl = previewPath
-        ? createMediaHandle(session, context, previewPath)
+        ? createMediaHandle(session, context, previewPath, {
+            playbackSessionId: sessionId,
+          })
         : undefined;
       const missingPreviewPath =
         !previewPath && itemTypeValue(enrichedItem) !== "track";
@@ -1438,7 +1451,7 @@ export async function proxyMedia(
   }
 
   const playbackSessionId = useProviderAuth
-    ? transcodeSessionId(handle.path)
+    ? (handle.playbackSessionId ?? transcodeSessionId(handle.path))
     : null;
   if (playbackSessionId) {
     headers.set("X-Plex-Session-Identifier", playbackSessionId);

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -442,10 +442,10 @@ export function createPreviewPath(
 
 export function createCliparrPlexTranscodeSessionId(
   sourceId: string,
-  playbackSessionId: string,
+  plexPlaybackSessionId: string,
 ) {
   const digest = createHash("sha256")
-    .update(`${sourceId}:${playbackSessionId}`)
+    .update(`${sourceId}:${plexPlaybackSessionId}`)
     .digest("hex")
     .slice(0, 32);
   const version = "5";
@@ -1193,6 +1193,18 @@ function playbackSessionIdentity(item: PlexMetadataItem) {
   );
 }
 
+function derivePlexPlaybackIds(sourceId: string, item: PlexMetadataItem) {
+  const plexPlaybackSessionId = playbackSessionIdentity(item);
+
+  return {
+    plexPlaybackSessionId,
+    cliparrPreviewTranscodeSessionId: createCliparrPlexTranscodeSessionId(
+      sourceId,
+      plexPlaybackSessionId,
+    ),
+  };
+}
+
 export function createPlexViewerAvatarUrl(
   session: ProviderSessionRecord,
   context: PlexSourceContext,
@@ -1209,13 +1221,13 @@ function playbackViewer(
   context: PlexSourceContext,
   item: PlexMetadataItem,
   sourceId: string,
-  sessionId: string,
+  plexPlaybackSessionId: string,
 ) {
   const externalId = stringValue(item?.User?.id);
   return {
     id: externalId
       ? `plex:user:${externalId}`
-      : `plex:synthetic:${sourceId}:${sessionId}`,
+      : `plex:synthetic:${sourceId}:${plexPlaybackSessionId}`,
     providerId: "plex" as const,
     externalId,
     name: stringValue(item?.User?.title) ?? "Unknown User",
@@ -1238,11 +1250,8 @@ async function normalizeCurrentPlayback(
 
   return Promise.all(
     uniqueMetadata.map(async (item) => {
-      const sessionId = playbackSessionIdentity(item);
-      const transcodeSessionId = createCliparrPlexTranscodeSessionId(
-        source.id,
-        sessionId,
-      );
+      const { plexPlaybackSessionId, cliparrPreviewTranscodeSessionId } =
+        derivePlexPlaybackIds(source.id, item);
       const mediaSelection = deriveMediaSelection(item);
       const enrichedItem = await enrichMetadataItem(context, item);
       const mediaPath = await resolveMediaPath(
@@ -1253,7 +1262,7 @@ async function normalizeCurrentPlayback(
       );
       const previewPath = createPreviewPath(
         enrichedItem,
-        transcodeSessionId,
+        cliparrPreviewTranscodeSessionId,
         mediaSelection,
       );
       const thumbPath = metadataImagePath(enrichedItem);
@@ -1269,7 +1278,7 @@ async function normalizeCurrentPlayback(
         session,
         context,
         enrichedItem,
-        sessionId,
+        plexPlaybackSessionId,
         mediaSelection,
       ).filter((track) => subtitleTrackSupportsBurnIn(track));
       const selectedPart = resolveSelectedPart(
@@ -1304,7 +1313,7 @@ async function normalizeCurrentPlayback(
         : undefined;
       const hlsUrl = previewPath
         ? createMediaHandle(session, context, previewPath, {
-            playbackSessionId: sessionId,
+            playbackSessionId: plexPlaybackSessionId,
           })
         : undefined;
       const missingPreviewPath =
@@ -1315,10 +1324,10 @@ async function normalizeCurrentPlayback(
         sessionId: session.id,
         sourceId: source.id,
         providerAccountId: source.providerAccountId,
-        playbackSessionId: sessionId,
-        transcodeSessionId,
+        playbackSessionId: plexPlaybackSessionId,
+        transcodeSessionId: cliparrPreviewTranscodeSessionId,
         currentlyPlayingItem: {
-          id: `${source.id}:${sessionId}`,
+          id: `${source.id}:${plexPlaybackSessionId}`,
           title: itemTitleValue(enrichedItem),
           type: itemTypeValue(enrichedItem) || "video",
           duration,
@@ -1384,9 +1393,15 @@ async function normalizeCurrentPlayback(
       }
 
       return {
-        viewer: playbackViewer(session, context, item, source.id, sessionId),
+        viewer: playbackViewer(
+          session,
+          context,
+          item,
+          source.id,
+          plexPlaybackSessionId,
+        ),
         item: {
-          id: `${source.id}:${sessionId}`,
+          id: `${source.id}:${plexPlaybackSessionId}`,
           source: {
             id: source.id,
             name: source.name,

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -191,7 +191,10 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
   assert.equal(tracks[0]?.contentUrl, `/api/media/${handle.id}`);
   assert.equal(tracks[0]?.contentFormat, "srt");
   assert.equal(tracks[0]?.streamId, "101151");
-  assert.equal(handle.playbackSessionId, plexPlaybackSessionId);
+  assert.equal(
+    handle.providerMetadata?.plex?.playbackSessionId,
+    plexPlaybackSessionId,
+  );
   assert.equal(
     subtitleUrl.searchParams.get("transcodeSessionId"),
     plexPlaybackSessionId,
@@ -239,7 +242,11 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     baseUrl: context.baseUrl,
     path: previewPath,
     token: context.token,
-    playbackSessionId: plexPlaybackSessionId,
+    providerMetadata: {
+      plex: {
+        playbackSessionId: plexPlaybackSessionId,
+      },
+    },
     lastAccessedAt: 0,
   });
   const requestHeaders: Headers[] = [];

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -140,7 +140,7 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
   const session = createSession();
   const context = createContext();
   const plexPlaybackSessionId = "254";
-  const cliparrTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+  const cliparrPreviewTranscodeSessionId = createCliparrPlexTranscodeSessionId(
     context.sourceId,
     plexPlaybackSessionId,
   );
@@ -171,7 +171,7 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
     ],
   };
 
-  const previewPath = createPreviewPath(item, cliparrTranscodeSessionId);
+  const previewPath = createPreviewPath(item, cliparrPreviewTranscodeSessionId);
   const previewUrl = new URL(previewPath ?? "", "http://cliparr.local");
   const tracks = deriveSubtitleTracks(
     session,
@@ -184,7 +184,7 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
 
   assert.equal(
     previewUrl.searchParams.get("transcodeSessionId"),
-    cliparrTranscodeSessionId,
+    cliparrPreviewTranscodeSessionId,
   );
   assert.equal(previewUrl.searchParams.get("subtitles"), "none");
   assert.equal(tracks.length, 1);
@@ -201,7 +201,7 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
   );
   assert.notEqual(
     subtitleUrl.searchParams.get("transcodeSessionId"),
-    cliparrTranscodeSessionId,
+    cliparrPreviewTranscodeSessionId,
   );
   assert.equal(subtitleUrl.searchParams.get("path"), "/library/metadata/14447");
   assert.equal(subtitleUrl.searchParams.get("mediaIndex"), "0");
@@ -213,7 +213,7 @@ void test("sends the real Plex playback session header for synthetic HLS preview
   const session = createSession();
   const context = createContext();
   const plexPlaybackSessionId = "254";
-  const cliparrTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+  const cliparrPreviewTranscodeSessionId = createCliparrPlexTranscodeSessionId(
     context.sourceId,
     plexPlaybackSessionId,
   );
@@ -232,7 +232,7 @@ void test("sends the real Plex playback session header for synthetic HLS preview
       },
     ],
   };
-  const previewPath = createPreviewPath(item, cliparrTranscodeSessionId);
+  const previewPath = createPreviewPath(item, cliparrPreviewTranscodeSessionId);
   assert.ok(previewPath);
   const handleId = "hls-handle";
   session.mediaHandles.set(handleId, {
@@ -280,7 +280,7 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     const upstreamUrl = new URL(requestUrls[0] ?? "");
     assert.equal(
       upstreamUrl.searchParams.get("transcodeSessionId"),
-      cliparrTranscodeSessionId,
+      cliparrPreviewTranscodeSessionId,
     );
     assert.equal(
       requestHeaders[0]?.get("x-plex-session-identifier"),
@@ -288,7 +288,7 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     );
     assert.notEqual(
       requestHeaders[0]?.get("x-plex-session-identifier"),
-      cliparrTranscodeSessionId,
+      cliparrPreviewTranscodeSessionId,
     );
     assert.equal(requestHeaders[0]?.get("x-plex-token"), context.token);
     assert.equal(response.statusCode, 200);

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { Request, Response } from "express";
 import type { ProviderSessionRecord } from "@/session/store";
 import {
   createPlexExportEstimateMetadata,
@@ -9,6 +10,7 @@ import {
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
   playheadSecondsFromViewOffset,
+  proxyMedia,
 } from "@/providers/plex/playback";
 import type { PlexSourceContext } from "@/providers/plex/shared";
 
@@ -30,6 +32,46 @@ function createContext(): PlexSourceContext {
     baseUrl: "http://plex.local:32400",
     token: "provider-token",
   };
+}
+
+function createRequest(headers: Record<string, string> = {}) {
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]),
+  );
+
+  return {
+    header(name: string) {
+      return normalizedHeaders.get(name.toLowerCase());
+    },
+  };
+}
+
+function createResponseRecorder() {
+  const recorder = {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    body: Buffer.alloc(0),
+    ended: false,
+    status(code: number) {
+      recorder.statusCode = code;
+      return recorder;
+    },
+    setHeader(name: string, value: string | number) {
+      recorder.headers.set(name.toLowerCase(), String(value));
+      return recorder;
+    },
+    end(chunk?: string | Uint8Array) {
+      if (typeof chunk === "string") {
+        recorder.body = Buffer.from(chunk);
+      } else if (chunk) {
+        recorder.body = Buffer.from(chunk);
+      }
+      recorder.ended = true;
+      return recorder;
+    },
+  };
+
+  return recorder;
 }
 
 function onlyMediaHandle(session: ProviderSessionRecord) {
@@ -87,7 +129,165 @@ void test("creates a Cliparr-owned Plex transcode session id", () => {
   assert.equal(firstId, secondId);
   assert.notEqual(firstId, differentPlaybackId);
   assert.notEqual(firstId, differentSourceId);
-  assert.match(firstId, /^cliparr-source-1-[\da-f]{16}$/);
+  assert.notEqual(firstId, "plex-session-1");
+  assert.match(
+    firstId,
+    /^[\da-f]{8}-[\da-f]{4}-5[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/,
+  );
+});
+
+void test("keeps Plex subtitle extraction on the real playback session id", () => {
+  const session = createSession();
+  const context = createContext();
+  const plexPlaybackSessionId = "254";
+  const cliparrTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+    context.sourceId,
+    plexPlaybackSessionId,
+  );
+  const item = {
+    ratingKey: "14447",
+    Media: [
+      {
+        id: "19134",
+        selected: 1,
+        Part: [
+          {
+            id: "28744",
+            selected: 1,
+            Stream: [
+              {
+                id: "101151",
+                index: "3",
+                streamType: "3",
+                codec: "srt",
+                languageCode: "eng",
+                selected: "1",
+                title: "English SDH",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const previewPath = createPreviewPath(item, cliparrTranscodeSessionId);
+  const previewUrl = new URL(previewPath ?? "", "http://cliparr.local");
+  const tracks = deriveSubtitleTracks(
+    session,
+    context,
+    item,
+    plexPlaybackSessionId,
+  );
+  const handle = onlyMediaHandle(session);
+  const subtitleUrl = new URL(handle.path, "http://cliparr.local");
+
+  assert.equal(
+    previewUrl.searchParams.get("transcodeSessionId"),
+    cliparrTranscodeSessionId,
+  );
+  assert.equal(previewUrl.searchParams.get("subtitles"), "none");
+  assert.equal(tracks.length, 1);
+  assert.equal(tracks[0]?.contentUrl, `/api/media/${handle.id}`);
+  assert.equal(tracks[0]?.contentFormat, "srt");
+  assert.equal(tracks[0]?.streamId, "101151");
+  assert.equal(handle.playbackSessionId, plexPlaybackSessionId);
+  assert.equal(
+    subtitleUrl.searchParams.get("transcodeSessionId"),
+    plexPlaybackSessionId,
+  );
+  assert.notEqual(
+    subtitleUrl.searchParams.get("transcodeSessionId"),
+    cliparrTranscodeSessionId,
+  );
+  assert.equal(subtitleUrl.searchParams.get("path"), "/library/metadata/14447");
+  assert.equal(subtitleUrl.searchParams.get("mediaIndex"), "0");
+  assert.equal(subtitleUrl.searchParams.get("partIndex"), "0");
+  assert.equal(subtitleUrl.searchParams.get("subtitles"), "sidecar");
+});
+
+void test("sends the real Plex playback session header for synthetic HLS preview handles", async () => {
+  const session = createSession();
+  const context = createContext();
+  const plexPlaybackSessionId = "254";
+  const cliparrTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+    context.sourceId,
+    plexPlaybackSessionId,
+  );
+  const item = {
+    ratingKey: "14447",
+    Media: [
+      {
+        id: "19134",
+        selected: 1,
+        Part: [
+          {
+            id: "28744",
+            selected: 1,
+          },
+        ],
+      },
+    ],
+  };
+  const previewPath = createPreviewPath(item, cliparrTranscodeSessionId);
+  assert.ok(previewPath);
+  const handleId = "hls-handle";
+  session.mediaHandles.set(handleId, {
+    id: handleId,
+    providerId: "plex",
+    sourceId: context.sourceId,
+    baseUrl: context.baseUrl,
+    path: previewPath,
+    token: context.token,
+    playbackSessionId: plexPlaybackSessionId,
+    lastAccessedAt: 0,
+  });
+  const requestHeaders: Headers[] = [];
+  const requestUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input, init) => {
+    requestUrls.push(
+      typeof input === "string" || input instanceof URL
+        ? input.toString()
+        : input.url,
+    );
+    requestHeaders.push(new Headers(init?.headers));
+    return new globalThis.Response("#EXTM3U\n#EXT-X-ENDLIST\n", {
+      status: 200,
+      headers: {
+        "content-type": "application/vnd.apple.mpegurl",
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = createResponseRecorder();
+    await proxyMedia(
+      session,
+      handleId,
+      createRequest({ accept: "*/*" }) as Request,
+      response as unknown as Response,
+    );
+
+    const upstreamUrl = new URL(requestUrls[0] ?? "");
+    assert.equal(
+      upstreamUrl.searchParams.get("transcodeSessionId"),
+      cliparrTranscodeSessionId,
+    );
+    assert.equal(
+      requestHeaders[0]?.get("x-plex-session-identifier"),
+      plexPlaybackSessionId,
+    );
+    assert.notEqual(
+      requestHeaders[0]?.get("x-plex-session-identifier"),
+      cliparrTranscodeSessionId,
+    );
+    assert.equal(requestHeaders[0]?.get("x-plex-token"), context.token);
+    assert.equal(response.statusCode, 200);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 void test("does not create Plex HLS preview paths for audio tracks", () => {

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { Request, Response } from "express";
+import type {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+import type { MediaSource } from "@/db/mediaSourcesRepository";
 import type { ProviderSessionRecord } from "@/session/store";
 import {
   createPlexExportEstimateMetadata,
@@ -9,6 +13,7 @@ import {
   createPreviewPath,
   deriveSelectedSubtitleTrack,
   deriveSubtitleTracks,
+  listCurrentlyPlaying,
   playheadSecondsFromViewOffset,
   proxyMedia,
 } from "@/providers/plex/playback";
@@ -32,6 +37,79 @@ function createContext(): PlexSourceContext {
     baseUrl: "http://plex.local:32400",
     token: "provider-token",
   };
+}
+
+function createSource(): MediaSource {
+  return {
+    id: "source-1",
+    providerId: "plex",
+    providerAccountId: "account-1",
+    name: "Plex",
+    enabled: true,
+    baseUrl: "http://plex.local:32400",
+    connection: {
+      baseUrlMode: "manual",
+      connections: [
+        {
+          id: "plex-connection-1",
+          uri: "http://plex.local:32400",
+          local: true,
+          relay: false,
+          protocol: "http",
+          address: "plex.local",
+          port: 32_400,
+        },
+      ],
+      selectedConnectionId: "plex-connection-1",
+    },
+    credentials: {
+      accessToken: "provider-token",
+    },
+    metadata: {
+      owned: true,
+      provides: ["server"],
+    },
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+
+  return globalThis.Response.json(body, {
+    ...init,
+    headers,
+  });
+}
+
+function withMockFetch(
+  handler: (
+    request: globalThis.Request,
+  ) => globalThis.Response | Promise<globalThis.Response>,
+  callback: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    return handler(new globalThis.Request(input, init));
+  }) as typeof fetch;
+
+  return callback().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+function mediaHandleForUrl(
+  session: ProviderSessionRecord,
+  mediaUrl: string | undefined,
+) {
+  assert.ok(mediaUrl);
+  const handleId = mediaUrl.split("/").at(-1);
+  assert.ok(handleId);
+  const handle = session.mediaHandles.get(handleId);
+  assert.ok(handle);
+  return handle;
 }
 
 function createRequest(headers: Record<string, string> = {}) {
@@ -273,8 +351,8 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     await proxyMedia(
       session,
       handleId,
-      createRequest({ accept: "*/*" }) as Request,
-      response as unknown as Response,
+      createRequest({ accept: "*/*" }) as ExpressRequest,
+      response as unknown as ExpressResponse,
     );
 
     const upstreamUrl = new URL(requestUrls[0] ?? "");
@@ -295,6 +373,152 @@ void test("sends the real Plex playback session header for synthetic HLS preview
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+void test("builds Plex HLS preview and selected embedded SRT subtitles with separate session ids", async () => {
+  const session = createSession();
+  const source = createSource();
+  const plexPlaybackSessionId = "254";
+  const cliparrPreviewTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+    source.id,
+    plexPlaybackSessionId,
+  );
+  const currentItem = {
+    ratingKey: "14447",
+    key: "/library/metadata/14447",
+    sessionKey: plexPlaybackSessionId,
+    type: "episode",
+    title: "The Plex Subtitle Case",
+    duration: 1_800_000,
+    viewOffset: 120_000,
+    User: {
+      id: "user-1",
+      title: "Rick",
+    },
+    Player: {
+      title: "Chrome",
+      state: "playing",
+    },
+  };
+  const metadataItem = {
+    ratingKey: "14447",
+    key: "/library/metadata/14447",
+    type: "episode",
+    title: "The Plex Subtitle Case",
+    duration: 1_800_000,
+    Media: [
+      {
+        id: "19134",
+        selected: 1,
+        Part: [
+          {
+            id: "28744",
+            selected: 1,
+            Stream: [
+              {
+                id: "101149",
+                streamType: 1,
+                codec: "h264",
+                width: 1920,
+                height: 1080,
+                selected: 1,
+              },
+              {
+                id: "101150",
+                streamType: 2,
+                codec: "aac",
+                languageCode: "eng",
+                selected: 1,
+              },
+              {
+                id: "101151",
+                index: "3",
+                streamType: "3",
+                codec: "srt",
+                languageCode: "eng",
+                selected: "1",
+                title: "English SDH",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  await withMockFetch(
+    (request) => {
+      if (request.url === "http://plex.local:32400/status/sessions") {
+        return jsonResponse({
+          MediaContainer: {
+            Metadata: [currentItem],
+          },
+        });
+      }
+
+      if (request.url === "http://plex.local:32400/library/metadata/14447") {
+        return jsonResponse({
+          MediaContainer: {
+            Metadata: [metadataItem],
+          },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${request.url}`);
+    },
+    async () => {
+      const entries = await listCurrentlyPlaying(session, source);
+      assert.equal(entries.length, 1);
+
+      const item = entries[0]?.item;
+      assert.ok(item);
+      assert.equal(item.previewFormat, "hls");
+      assert.equal(item.selectedSubtitleTrack?.streamId, "101151");
+      assert.equal(item.selectedSubtitleTrack?.contentFormat, "srt");
+      const subtitleTracks = item.subtitleTracks ?? [];
+      assert.equal(subtitleTracks.length, 1);
+
+      const hlsHandle = mediaHandleForUrl(session, item.hlsUrl);
+      const hlsUrl = new URL(hlsHandle.path, "http://cliparr.local");
+      assert.equal(
+        hlsUrl.searchParams.get("transcodeSessionId"),
+        cliparrPreviewTranscodeSessionId,
+      );
+      assert.equal(hlsUrl.searchParams.get("subtitles"), "none");
+      assert.equal(
+        hlsHandle.providerMetadata?.plex?.playbackSessionId,
+        plexPlaybackSessionId,
+      );
+
+      const subtitleTrack = subtitleTracks[0];
+      assert.ok(subtitleTrack);
+      assert.equal(subtitleTrack.contentFormat, "srt");
+      assert.equal(subtitleTrack.streamId, "101151");
+
+      const subtitleHandle = mediaHandleForUrl(
+        session,
+        subtitleTrack.contentUrl,
+      );
+      const subtitleUrl = new URL(subtitleHandle.path, "http://cliparr.local");
+      assert.equal(
+        subtitleUrl.searchParams.get("transcodeSessionId"),
+        plexPlaybackSessionId,
+      );
+      assert.notEqual(
+        subtitleUrl.searchParams.get("transcodeSessionId"),
+        cliparrPreviewTranscodeSessionId,
+      );
+      assert.equal(subtitleUrl.searchParams.get("subtitles"), "sidecar");
+      assert.equal(
+        subtitleUrl.searchParams.get("path"),
+        "/library/metadata/14447",
+      );
+      assert.equal(
+        subtitleHandle.providerMetadata?.plex?.playbackSessionId,
+        plexPlaybackSessionId,
+      );
+    },
+  );
 });
 
 void test("does not create Plex HLS preview paths for audio tracks", () => {

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -16,6 +16,7 @@ interface MediaHandleContext {
   sourceId: string;
   baseUrl: string;
   token: string;
+  playbackSessionId?: string;
   deviceId?: string;
 }
 
@@ -69,7 +70,7 @@ const HLS_PROXY_RESPONSE_CACHE_TTL_MS = 4000;
 const HLS_PROXY_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const MEDIA_PROXY_MAX_REDIRECTS = 5;
 const MEDIA_PROXY_FETCH_ATTEMPTS = 3;
-const HLS_MEDIA_PROXY_FETCH_ATTEMPTS = 5;
+const HLS_MEDIA_PROXY_FETCH_ATTEMPTS = 8;
 const MEDIA_PROXY_FETCH_RETRY_BASE_DELAY_MS = 150;
 const MEDIA_PROXY_FETCH_RETRY_MAX_DELAY_MS = 1000;
 const DNS_VALIDATION_CACHE_TTL_MS = 60_000;
@@ -645,6 +646,7 @@ export function createProviderMediaHandle(
       existingHandle.baseUrl === context.baseUrl &&
       existingHandle.path === normalizedPath &&
       existingHandle.token === context.token &&
+      existingHandle.playbackSessionId === context.playbackSessionId &&
       existingHandle.deviceId === context.deviceId &&
       existingHandle.basePath === normalizedBasePath
     ) {
@@ -669,6 +671,7 @@ export function createProviderMediaHandle(
     baseUrl: context.baseUrl,
     path: normalizedPath,
     token: context.token,
+    playbackSessionId: context.playbackSessionId,
     deviceId: context.deviceId,
     basePath: normalizedBasePath,
     lastAccessedAt: accessedAt,
@@ -733,6 +736,7 @@ function rewritePlaylistUri(
       sourceId: handle.sourceId,
       baseUrl: handle.baseUrl,
       token: handle.token,
+      playbackSessionId: handle.playbackSessionId,
       deviceId: handle.deviceId,
     },
     nextPath,
@@ -829,7 +833,7 @@ export function shouldForwardMediaRange(
   handle: MediaHandle,
   range: string | undefined,
 ) {
-  if (!range || isHlsPlaylist(handle, "")) {
+  if (!range || isHlsDerivedHandle(handle)) {
     return;
   }
 
@@ -1122,11 +1126,16 @@ export async function proxyProviderMediaResponse(
     })();
 
     inflightProxyResponses.set(cacheKey, inflightResponse);
-    void inflightResponse.finally(() => {
-      if (inflightProxyResponses.get(cacheKey) === inflightResponse) {
-        inflightProxyResponses.delete(cacheKey);
-      }
-    });
+    void inflightResponse
+      .finally(() => {
+        if (inflightProxyResponses.get(cacheKey) === inflightResponse) {
+          inflightProxyResponses.delete(cacheKey);
+        }
+      })
+      .catch(() => {
+        // The original in-flight promise is awaited below; this prevents the
+        // cleanup promise from becoming a separate unhandled rejection.
+      });
   }
 
   sendCachedProxyResponse(await inflightResponse!, res);

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -16,8 +16,7 @@ interface MediaHandleContext {
   sourceId: string;
   baseUrl: string;
   token: string;
-  playbackSessionId?: string;
-  deviceId?: string;
+  providerMetadata?: MediaHandle["providerMetadata"];
 }
 
 interface CreateMediaHandleOptions {
@@ -96,6 +95,30 @@ const inflightProxyResponses = new Map<
 >();
 const resolvedHostnameCache = new Map<string, ResolvedHostnameCacheEntry>();
 const inflightHostnameResolutions = new Map<string, Promise<string[]>>();
+
+function normalizeProviderMetadata(
+  metadata: MediaHandle["providerMetadata"],
+): MediaHandle["providerMetadata"] {
+  const normalized: NonNullable<MediaHandle["providerMetadata"]> = {};
+
+  if (metadata?.plex?.playbackSessionId !== undefined) {
+    normalized.plex = {
+      playbackSessionId: metadata.plex.playbackSessionId,
+    };
+  }
+
+  if (metadata?.jellyfin?.deviceId !== undefined) {
+    normalized.jellyfin = {
+      deviceId: metadata.jellyfin.deviceId,
+    };
+  }
+
+  return normalized.plex || normalized.jellyfin ? normalized : undefined;
+}
+
+function providerMetadataKey(metadata: MediaHandle["providerMetadata"]) {
+  return JSON.stringify(normalizeProviderMetadata(metadata) ?? {});
+}
 
 function isAbsoluteUrl(path: string) {
   return /^[a-z][\d+.a-z-]*:/i.test(path);
@@ -637,6 +660,8 @@ export function createProviderMediaHandle(
   const normalizedBasePath = options.basePath
     ? normalizeMediaPath(options.basePath)
     : undefined;
+  const providerMetadata = normalizeProviderMetadata(context.providerMetadata);
+  const metadataKey = providerMetadataKey(providerMetadata);
   const accessedAt = Date.now();
 
   for (const existingHandle of session.mediaHandles.values()) {
@@ -646,8 +671,7 @@ export function createProviderMediaHandle(
       existingHandle.baseUrl === context.baseUrl &&
       existingHandle.path === normalizedPath &&
       existingHandle.token === context.token &&
-      existingHandle.playbackSessionId === context.playbackSessionId &&
-      existingHandle.deviceId === context.deviceId &&
+      providerMetadataKey(existingHandle.providerMetadata) === metadataKey &&
       existingHandle.basePath === normalizedBasePath
     ) {
       existingHandle.lastAccessedAt = accessedAt;
@@ -671,8 +695,7 @@ export function createProviderMediaHandle(
     baseUrl: context.baseUrl,
     path: normalizedPath,
     token: context.token,
-    playbackSessionId: context.playbackSessionId,
-    deviceId: context.deviceId,
+    providerMetadata,
     basePath: normalizedBasePath,
     lastAccessedAt: accessedAt,
   };
@@ -736,8 +759,7 @@ function rewritePlaylistUri(
       sourceId: handle.sourceId,
       baseUrl: handle.baseUrl,
       token: handle.token,
-      playbackSessionId: handle.playbackSessionId,
-      deviceId: handle.deviceId,
+      providerMetadata: handle.providerMetadata,
     },
     nextPath,
     {

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -61,6 +61,15 @@ export interface CurrentlyPlayingEntry {
   item: CurrentlyPlayingItem;
 }
 
+interface MediaHandleProviderMetadata {
+  plex?: {
+    playbackSessionId?: string;
+  };
+  jellyfin?: {
+    deviceId?: string;
+  };
+}
+
 export interface MediaHandle {
   id: string;
   providerId: ProviderId;
@@ -68,8 +77,7 @@ export interface MediaHandle {
   baseUrl: string;
   path: string;
   token: string;
-  playbackSessionId?: string;
-  deviceId?: string;
+  providerMetadata?: MediaHandleProviderMetadata;
   basePath?: string;
   lastAccessedAt: number;
 }

--- a/apps/server/src/providers/types.ts
+++ b/apps/server/src/providers/types.ts
@@ -68,6 +68,7 @@ export interface MediaHandle {
   baseUrl: string;
   path: string;
   token: string;
+  playbackSessionId?: string;
   deviceId?: string;
   basePath?: string;
   lastAccessedAt: number;


### PR DESCRIPTION
## Summary
- Use Plex's real playback session id when extracting selected subtitle content.
- Keep Cliparr's synthetic transcode session id reserved for preview HLS.
- Add regression coverage for selected embedded SRT while HLS stays subtitles=none.

## Validation
- pnpm --filter @cliparr/server exec node --import tsx --test src/providers/plexPlayback.test.ts
- pnpm --filter @cliparr/server exec node --import tsx --test src/providers/mediaProxy.test.ts
- pnpm preflight