### PR TITLE
feat(frontend): add dashboard viewer filter

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -122,6 +122,31 @@ const DASHBOARD_SKELETON_BREAKPOINT_CLASSES = [
   "hidden md:block",
   "hidden xl:block",
 ] as const;
+const DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT = 2;
+
+function viewerAvatarSizeClass(size: "xs" | "sm" | "md") {
+  if (size === "xs") {
+    return "h-6 w-6 text-[11px]";
+  }
+
+  if (size === "sm") {
+    return "h-8 w-8 text-sm";
+  }
+
+  return "h-12 w-12 text-lg";
+}
+
+function viewerAvatarImageSize(size: "xs" | "sm" | "md") {
+  if (size === "xs") {
+    return 24;
+  }
+
+  if (size === "sm") {
+    return 32;
+  }
+
+  return 48;
+}
 
 function ViewerAvatar({
   name,
@@ -130,16 +155,18 @@ function ViewerAvatar({
 }: {
   name: string;
   avatarUrl?: string;
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
 }) {
   const [imageFailed, setImageFailed] = useState(false);
   const label = name.trim().charAt(0).toUpperCase() || "?";
+  const sizeClass = viewerAvatarSizeClass(size);
+  const imageSize = viewerAvatarImageSize(size);
 
   return (
     <div
       className={cn(
         "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
-        size === "sm" ? "h-8 w-8 text-sm" : "h-12 w-12 text-lg",
+        sizeClass,
       )}
     >
       {avatarUrl && !imageFailed ? (
@@ -147,8 +174,8 @@ function ViewerAvatar({
           src={avatarUrl}
           alt={name}
           className="w-full h-full object-cover"
-          width={size === "sm" ? 32 : 48}
-          height={size === "sm" ? 32 : 48}
+          width={imageSize}
+          height={imageSize}
           decoding="async"
           onError={() => setImageFailed(true)}
         />
@@ -187,6 +214,71 @@ function dashboardViewerFilterTriggerLabel(
   return `${selectedNames.length} viewers`;
 }
 
+function selectedDashboardViewerFilterOptions(
+  viewerOptions: DashboardViewerFilterOption[],
+  selectedViewerNames: readonly string[],
+) {
+  const optionsByName = new Map(
+    viewerOptions.map((option) => [option.normalizedName, option]),
+  );
+
+  return sanitizeDashboardViewerFilterNames(selectedViewerNames).map(
+    (selectedName) =>
+      optionsByName.get(selectedName) ?? {
+        normalizedName: selectedName,
+        name: selectedName,
+        sessionCount: 0,
+      },
+  );
+}
+
+function DashboardViewerFilterTriggerSelection({
+  selectedViewerOptions,
+}: {
+  selectedViewerOptions: DashboardViewerFilterOption[];
+}) {
+  const visibleViewerOptions = selectedViewerOptions.slice(
+    0,
+    DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT,
+  );
+  const hiddenViewerCount = Math.max(
+    selectedViewerOptions.length - visibleViewerOptions.length,
+    0,
+  );
+
+  return (
+    <span
+      className="flex min-w-0 flex-1 items-center justify-center gap-1 sm:justify-end"
+      data-dashboard-viewer-filter-selected-avatars
+      aria-hidden="true"
+    >
+      <span className="flex shrink-0 -space-x-2">
+        {visibleViewerOptions.map((option, index) => (
+          <span
+            key={option.normalizedName}
+            className="relative rounded-full ring-2 ring-background"
+            style={{ zIndex: visibleViewerOptions.length - index }}
+          >
+            <ViewerAvatar
+              name={option.name}
+              avatarUrl={option.avatarUrl}
+              size="xs"
+            />
+          </span>
+        ))}
+      </span>
+      {hiddenViewerCount > 0 ? (
+        <span
+          className="inline-flex h-6 shrink-0 items-center rounded-full border border-border bg-background px-1.5 text-[11px] leading-none font-semibold text-muted-foreground"
+          data-dashboard-viewer-filter-overflow-count
+        >
+          (+{hiddenViewerCount})
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
 export function DashboardViewerFilterPicker({
   viewerOptions,
   selectedViewerNames,
@@ -222,6 +314,10 @@ export function DashboardViewerFilterPicker({
     viewerOptions,
     selectedNames,
   );
+  const selectedViewerOptions = selectedDashboardViewerFilterOptions(
+    viewerOptions,
+    selectedNames,
+  );
   const totalSessionCount = viewerOptions.reduce(
     (sum, option) => sum + option.sessionCount,
     0,
@@ -239,7 +335,7 @@ export function DashboardViewerFilterPicker({
         data-dashboard-viewer-filter-active={filterActive || undefined}
         className={(state) =>
           cn(
-            "inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-muted-foreground transition-[color,background-color,border-color,transform] duration-200 hover:-translate-y-px hover:bg-accent hover:text-foreground active:scale-[0.985] focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none motion-reduce:transform-none sm:h-9 sm:px-3 sm:font-medium",
+            "inline-flex h-11 w-full min-w-0 items-center justify-center gap-1.5 rounded-lg border border-border px-2 text-sm font-semibold text-muted-foreground transition-[color,background-color,border-color,transform] duration-200 hover:-translate-y-px hover:bg-accent hover:text-foreground active:scale-[0.985] focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none motion-reduce:transform-none sm:h-9 sm:w-52 sm:shrink-0 sm:gap-2 sm:px-3 sm:font-medium",
             state.open &&
               "[&_[data-dashboard-viewer-filter-chevron]]:rotate-180",
             filterActive &&
@@ -250,7 +346,16 @@ export function DashboardViewerFilterPicker({
       >
         <Users className="h-4 w-4 shrink-0" />
         <span className="hidden shrink-0 sm:inline">Viewers</span>
-        <span className="min-w-0 truncate">{triggerLabel}</span>
+        {filterActive ? (
+          <>
+            <DashboardViewerFilterTriggerSelection
+              selectedViewerOptions={selectedViewerOptions}
+            />
+            <span className="sr-only">{triggerLabel}</span>
+          </>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-left">All viewers</span>
+        )}
         <span
           className="shrink-0 transition-transform duration-200 motion-reduce:transition-none"
           data-dashboard-viewer-filter-chevron

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -1,12 +1,16 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Popover } from "@base-ui/react/popover";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   AlertTriangle,
+  Check,
+  ChevronDown,
   FolderOpen,
   Globe,
   LogOut,
   Play,
   RefreshCw,
+  Search,
   Settings2,
   Users,
   Video,
@@ -163,103 +167,215 @@ function formatFilterHiddenCount(count: number) {
   return `${count} ${count === 1 ? "session is" : "sessions are"} hidden by the viewer filter.`;
 }
 
-export function DashboardViewerFilterBar({
+function dashboardViewerFilterTriggerLabel(
+  viewerOptions: DashboardViewerFilterOption[],
+  selectedViewerNames: readonly string[],
+) {
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  if (selectedNames.length === 0) {
+    return "All viewers";
+  }
+
+  if (selectedNames.length === 1) {
+    const [selectedName] = selectedNames;
+    const option = viewerOptions.find(
+      (viewerOption) => viewerOption.normalizedName === selectedName,
+    );
+    return option?.name ?? "1 viewer";
+  }
+
+  return `${selectedNames.length} viewers`;
+}
+
+export function DashboardViewerFilterPicker({
   viewerOptions,
   selectedViewerNames,
   hiddenSessionCount,
   onToggleViewer,
   onClearViewerFilter,
+  className,
 }: {
   viewerOptions: DashboardViewerFilterOption[];
   selectedViewerNames: readonly string[];
   hiddenSessionCount: number;
   onToggleViewer: (viewerName: string) => void;
   onClearViewerFilter: () => void;
+  className?: string;
 }) {
+  const [query, setQuery] = useState("");
   const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
   const selectedNamesSet = new Set(selectedNames);
   const filterActive = selectedNames.length > 0;
+  const queryText = query.trim().toLowerCase();
+  const filteredViewerOptions = queryText
+    ? viewerOptions.filter((option) =>
+        option.name.toLowerCase().includes(queryText),
+      )
+    : viewerOptions;
+  const triggerLabel = dashboardViewerFilterTriggerLabel(
+    viewerOptions,
+    selectedNames,
+  );
+  const totalSessionCount = viewerOptions.reduce(
+    (sum, option) => sum + option.sessionCount,
+    0,
+  );
 
   if (viewerOptions.length <= 1 && !filterActive) {
     return null;
   }
 
   return (
-    <div
-      className="rounded-lg border border-border bg-card/70 p-1"
-      data-dashboard-viewer-filter
-      data-dashboard-viewer-filter-active={filterActive || undefined}
-    >
-      <div
-        role="toolbar"
-        aria-label="Filter sessions by viewer"
-        className="cliparr-editor-scrollbar flex items-center gap-1 overflow-x-auto"
+    <Popover.Root>
+      <Popover.Trigger
+        aria-label={`Filter sessions by viewer: ${triggerLabel}`}
+        data-dashboard-viewer-filter
+        data-dashboard-viewer-filter-active={filterActive || undefined}
+        className={cn(
+          "inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none sm:h-9 sm:px-3 sm:font-medium",
+          filterActive &&
+            "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+          className,
+        )}
       >
-        <button
-          type="button"
-          onClick={onClearViewerFilter}
-          aria-pressed={!filterActive}
-          className={cn(
-            "inline-flex h-9 shrink-0 items-center justify-center rounded-md px-3 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
-            filterActive
-              ? "text-muted-foreground hover:bg-accent hover:text-foreground"
-              : "bg-primary text-primary-foreground",
-          )}
-        >
-          All
-        </button>
+        <Users className="h-4 w-4 shrink-0" />
+        <span className="hidden shrink-0 sm:inline">Viewers</span>
+        <span className="min-w-0 truncate">{triggerLabel}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8} align="end">
+          <Popover.Popup
+            className={cn(
+              "z-50 w-[min(calc(100vw-2rem),22rem)] rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-lg outline-none",
+              "data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            )}
+            initialFocus={false}
+          >
+            <div className="px-2 py-1.5">
+              <Popover.Title className="text-sm font-semibold text-foreground">
+                Filter by viewer
+              </Popover.Title>
+              <Popover.Description className="mt-0.5 text-xs text-muted-foreground">
+                Selected viewers are shown as a whitelist.
+              </Popover.Description>
+            </div>
 
-        {viewerOptions.map((option) => {
-          const selected = selectedNamesSet.has(option.normalizedName);
-          const actionLabel = selected
-            ? `Hide ${option.name} sessions`
-            : `Show ${option.name} sessions`;
+            <label className="relative mt-2 block">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search viewers"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+                data-dashboard-viewer-filter-search
+              />
+            </label>
 
-          return (
-            <Tooltip key={option.normalizedName}>
-              <TooltipTrigger asChild>
+            <div
+              className="cliparr-editor-scrollbar mt-2 max-h-72 overflow-y-auto"
+              data-dashboard-viewer-filter-options
+            >
+              <button
+                type="button"
+                onClick={onClearViewerFilter}
+                aria-pressed={!filterActive}
+                className={cn(
+                  "flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                  !filterActive && "bg-primary/10 text-primary",
+                )}
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background text-primary">
+                  <Users className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-semibold">
+                    All viewers
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {formatFilterSessionCount(totalSessionCount)}
+                  </span>
+                </span>
+                <Check
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    filterActive ? "invisible" : "text-primary",
+                  )}
+                />
+              </button>
+
+              {filteredViewerOptions.length === 0 ? (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  No viewers found.
+                </div>
+              ) : (
+                filteredViewerOptions.map((option) => {
+                  const selected = selectedNamesSet.has(option.normalizedName);
+                  const actionLabel = selected
+                    ? `Hide ${option.name} sessions`
+                    : `Show ${option.name} sessions`;
+
+                  return (
+                    <button
+                      key={option.normalizedName}
+                      type="button"
+                      onClick={() => onToggleViewer(option.normalizedName)}
+                      aria-pressed={selected}
+                      aria-label={actionLabel}
+                      className={cn(
+                        "mt-1 flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                        selected && "bg-primary/10 text-primary",
+                      )}
+                    >
+                      <ViewerAvatar
+                        name={option.name}
+                        avatarUrl={option.avatarUrl}
+                        size="sm"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-semibold">
+                          {option.name}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {formatFilterSessionCount(option.sessionCount)}
+                        </span>
+                      </span>
+                      <Check
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          selected ? "text-primary" : "invisible",
+                        )}
+                      />
+                    </button>
+                  );
+                })
+              )}
+            </div>
+
+            {filterActive && (
+              <div
+                className="mt-2 flex items-center justify-between gap-3 border-t border-border px-2 pt-2"
+                data-dashboard-viewer-filter-summary
+              >
+                <span className="min-w-0 truncate text-xs text-muted-foreground">
+                  {hiddenSessionCount > 0
+                    ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
+                    : "Filtered"}
+                </span>
                 <button
                   type="button"
-                  onClick={() => onToggleViewer(option.normalizedName)}
-                  aria-pressed={selected}
-                  aria-label={actionLabel}
-                  className={cn(
-                    "inline-flex h-9 max-w-52 shrink-0 items-center gap-2 rounded-full border py-0.5 pr-3 pl-0.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
-                    selected
-                      ? "border-primary/50 bg-primary/15 text-primary"
-                      : "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground",
-                  )}
+                  onClick={onClearViewerFilter}
+                  className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
                 >
-                  <ViewerAvatar
-                    name={option.name}
-                    avatarUrl={option.avatarUrl}
-                    size="sm"
-                  />
-                  <span className="truncate">{option.name}</span>
-                  <span className="min-w-[2ch] rounded-full bg-background/80 px-1.5 text-center font-mono text-ui-micro tabular-nums text-muted-foreground">
-                    {option.sessionCount}
-                  </span>
+                  <X className="h-3.5 w-3.5" />
+                  Clear
                 </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {option.name}: {formatFilterSessionCount(option.sessionCount)}
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
-
-        {filterActive && (
-          <span
-            className="ml-auto hidden shrink-0 px-2 text-xs text-muted-foreground sm:inline-flex"
-            data-dashboard-viewer-filter-summary
-          >
-            {hiddenSessionCount > 0
-              ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
-              : "Filtered"}
-          </span>
-        )}
-      </div>
-    </div>
+              </div>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 
@@ -862,6 +978,18 @@ export default function DashboardScreen({
     setSelectedViewerNames([]);
     writeDashboardViewerFilter([]);
   }, []);
+  const showViewerFilterControl =
+    viewerFilterOptions.length > 1 || selectedViewerFilterNames.length > 0;
+  const renderViewerFilterPicker = () =>
+    showViewerFilterControl ? (
+      <DashboardViewerFilterPicker
+        viewerOptions={viewerFilterOptions}
+        selectedViewerNames={selectedViewerFilterNames}
+        hiddenSessionCount={hiddenViewerFilterCardCount}
+        onToggleViewer={toggleViewerFilter}
+        onClearViewerFilter={clearViewerFilter}
+      />
+    ) : null;
 
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
@@ -897,7 +1025,14 @@ export default function DashboardScreen({
               onDisconnect={onDisconnect}
             />
           </div>
-          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.75rem] gap-2 sm:hidden">
+          <div
+            className={cn(
+              "grid gap-2 sm:hidden",
+              showViewerFilterControl
+                ? "grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_2.75rem]"
+                : "grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.75rem]",
+            )}
+          >
             <button
               type="button"
               onClick={onOpenLocalVideo}
@@ -914,6 +1049,7 @@ export default function DashboardScreen({
               <Settings2 className="h-4 w-4 shrink-0" />
               <span className="truncate">Sources</span>
             </button>
+            {renderViewerFilterPicker()}
             <button
               type="button"
               onClick={fetchSessions}
@@ -944,6 +1080,7 @@ export default function DashboardScreen({
               <Settings2 className="w-4 h-4" />
               Sources
             </button>
+            {renderViewerFilterPicker()}
             <button
               type="button"
               onClick={fetchSessions}
@@ -1003,16 +1140,6 @@ export default function DashboardScreen({
           )}
 
           {!error && <WarningBanner sourceErrors={sourceErrors} />}
-
-          {!error && (
-            <DashboardViewerFilterBar
-              viewerOptions={viewerFilterOptions}
-              selectedViewerNames={selectedViewerFilterNames}
-              hiddenSessionCount={hiddenViewerFilterCardCount}
-              onToggleViewer={toggleViewerFilter}
-              onClearViewerFilter={clearViewerFilter}
-            />
-          )}
 
           <DashboardPlaybackMotionRegion
             loading={loading}

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -30,6 +30,7 @@ import {
   GithubIcon,
 } from "@/components/DashboardMobileMenu";
 import { MobilePwaInstallNudge } from "@/components/MobilePwaInstallNudge";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tooltip,
   TooltipContent,
@@ -393,9 +394,11 @@ export function DashboardViewerFilterPicker({
               />
             </label>
 
-            <div
-              className="cliparr-editor-scrollbar mt-2 max-h-72 overflow-y-auto"
+            <ScrollArea
+              className="mt-2 max-h-72"
+              contentClassName="pr-3"
               data-dashboard-viewer-filter-options
+              viewportClassName="max-h-72"
             >
               <motion.button
                 type="button"
@@ -493,7 +496,7 @@ export function DashboardViewerFilterPicker({
                   );
                 })
               )}
-            </div>
+            </ScrollArea>
 
             {filterActive && (
               <div

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -257,7 +257,7 @@ function DashboardViewerFilterTriggerSelection({
           <span
             key={option.normalizedName}
             className="relative rounded-full ring-2 ring-background"
-            style={{ zIndex: visibleViewerOptions.length - index }}
+            style={{ zIndex: index + 1 }}
           >
             <ViewerAvatar
               name={option.name}

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -206,6 +206,12 @@ export function DashboardViewerFilterPicker({
   const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
   const selectedNamesSet = new Set(selectedNames);
   const filterActive = selectedNames.length > 0;
+  const reduceMotion = useReducedMotion();
+  const microHover = reduceMotion ? undefined : { y: -1 };
+  const microTap = reduceMotion ? undefined : { scale: 0.985 };
+  const microTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
   const queryText = query.trim().toLowerCase();
   const filteredViewerOptions = queryText
     ? viewerOptions.filter((option) =>
@@ -231,17 +237,27 @@ export function DashboardViewerFilterPicker({
         aria-label={`Filter sessions by viewer: ${triggerLabel}`}
         data-dashboard-viewer-filter
         data-dashboard-viewer-filter-active={filterActive || undefined}
-        className={cn(
-          "inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none sm:h-9 sm:px-3 sm:font-medium",
-          filterActive &&
-            "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
-          className,
-        )}
+        className={(state) =>
+          cn(
+            "inline-flex h-11 min-w-0 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-semibold text-muted-foreground transition-[color,background-color,border-color,transform] duration-200 hover:-translate-y-px hover:bg-accent hover:text-foreground active:scale-[0.985] focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none motion-reduce:transform-none sm:h-9 sm:px-3 sm:font-medium",
+            state.open &&
+              "[&_[data-dashboard-viewer-filter-chevron]]:rotate-180",
+            filterActive &&
+              "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+            className,
+          )
+        }
       >
         <Users className="h-4 w-4 shrink-0" />
         <span className="hidden shrink-0 sm:inline">Viewers</span>
         <span className="min-w-0 truncate">{triggerLabel}</span>
-        <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
+        <span
+          className="shrink-0 transition-transform duration-200 motion-reduce:transition-none"
+          data-dashboard-viewer-filter-chevron
+          aria-hidden="true"
+        >
+          <ChevronDown className="h-4 w-4 opacity-70" />
+        </span>
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner sideOffset={8} align="end">
@@ -276,7 +292,7 @@ export function DashboardViewerFilterPicker({
               className="cliparr-editor-scrollbar mt-2 max-h-72 overflow-y-auto"
               data-dashboard-viewer-filter-options
             >
-              <button
+              <motion.button
                 type="button"
                 onClick={onClearViewerFilter}
                 aria-pressed={!filterActive}
@@ -284,6 +300,9 @@ export function DashboardViewerFilterPicker({
                   "flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
                   !filterActive && "bg-primary/10 text-primary",
                 )}
+                whileHover={microHover}
+                whileTap={microTap}
+                transition={microTransition}
               >
                 <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background text-primary">
                   <Users className="h-4 w-4" />
@@ -296,13 +315,21 @@ export function DashboardViewerFilterPicker({
                     {formatFilterSessionCount(totalSessionCount)}
                   </span>
                 </span>
-                <Check
+                <motion.span
                   className={cn(
-                    "h-4 w-4 shrink-0",
-                    filterActive ? "invisible" : "text-primary",
+                    "shrink-0 text-primary",
+                    filterActive && "pointer-events-none",
                   )}
-                />
-              </button>
+                  animate={{
+                    opacity: filterActive ? 0 : 1,
+                    scale: filterActive ? 0.8 : 1,
+                  }}
+                  transition={microTransition}
+                  aria-hidden="true"
+                >
+                  <Check className="h-4 w-4" />
+                </motion.span>
+              </motion.button>
 
               {filteredViewerOptions.length === 0 ? (
                 <div className="px-3 py-6 text-center text-sm text-muted-foreground">
@@ -316,7 +343,7 @@ export function DashboardViewerFilterPicker({
                     : `Show ${option.name} sessions`;
 
                   return (
-                    <button
+                    <motion.button
                       key={option.normalizedName}
                       type="button"
                       onClick={() => onToggleViewer(option.normalizedName)}
@@ -326,6 +353,9 @@ export function DashboardViewerFilterPicker({
                         "mt-1 flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
                         selected && "bg-primary/10 text-primary",
                       )}
+                      whileHover={microHover}
+                      whileTap={microTap}
+                      transition={microTransition}
                     >
                       <ViewerAvatar
                         name={option.name}
@@ -340,13 +370,21 @@ export function DashboardViewerFilterPicker({
                           {formatFilterSessionCount(option.sessionCount)}
                         </span>
                       </span>
-                      <Check
+                      <motion.span
                         className={cn(
-                          "h-4 w-4 shrink-0",
-                          selected ? "text-primary" : "invisible",
+                          "shrink-0 text-primary",
+                          !selected && "pointer-events-none",
                         )}
-                      />
-                    </button>
+                        animate={{
+                          opacity: selected ? 1 : 0,
+                          scale: selected ? 1 : 0.8,
+                        }}
+                        transition={microTransition}
+                        aria-hidden="true"
+                      >
+                        <Check className="h-4 w-4" />
+                      </motion.span>
+                    </motion.button>
                   );
                 })
               )}
@@ -362,14 +400,17 @@ export function DashboardViewerFilterPicker({
                     ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
                     : "Filtered"}
                 </span>
-                <button
+                <motion.button
                   type="button"
                   onClick={onClearViewerFilter}
                   className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
+                  whileHover={microHover}
+                  whileTap={microTap}
+                  transition={microTransition}
                 >
                   <X className="h-3.5 w-3.5" />
                   Clear
-                </button>
+                </motion.button>
               </div>
             )}
           </Popover.Popup>
@@ -861,6 +902,7 @@ export default function DashboardScreen({
     readDashboardViewerFilter(),
   );
   const hasFetchedSessionsReference = useRef(false);
+  const reduceDashboardMotion = useReducedMotion();
 
   const fetchSessions = useCallback(async () => {
     const isInitialFetch = !hasFetchedSessionsReference.current;
@@ -1112,14 +1154,36 @@ export default function DashboardScreen({
             >
               <GithubIcon className="h-5 w-5" />
             </a>
-            <button
+            <motion.button
               type="button"
               onClick={onDisconnect}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+              className={cn(
+                "flex items-center gap-2 rounded-lg text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                showViewerFilterControl
+                  ? "h-9 w-9 justify-center p-2"
+                  : "px-4 py-2",
+              )}
+              aria-label="Disconnect"
+              title="Disconnect"
+              whileHover={
+                showViewerFilterControl && !reduceDashboardMotion
+                  ? { y: -1 }
+                  : undefined
+              }
+              whileTap={
+                showViewerFilterControl && !reduceDashboardMotion
+                  ? { scale: 0.985 }
+                  : undefined
+              }
+              transition={
+                reduceDashboardMotion
+                  ? { duration: 0 }
+                  : cliparrMotionTransitions.fast
+              }
             >
               <LogOut className="w-4 h-4" />
-              Disconnect
-            </button>
+              {!showViewerFilterControl && "Disconnect"}
+            </motion.button>
           </div>
         </header>
 

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -8,7 +8,9 @@ import {
   Play,
   RefreshCw,
   Settings2,
+  Users,
   Video,
+  X,
 } from "lucide-react";
 import { cliparrClient, type CliparrVersionInfo } from "@/api/cliparrClient";
 import { cn } from "@/lib/utilities";
@@ -30,11 +32,20 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  buildDashboardViewerFilterOptions,
+  countDashboardViewerFilterHiddenCards,
+  filterDashboardPlaybackCardsByViewer,
   flattenDashboardPlaybackItems,
   formatViewerSessionCount,
+  readDashboardViewerFilter,
+  sanitizeDashboardViewerFilterNames,
+  writeDashboardViewerFilter,
 } from "@/components/dashboardPlaybackItems";
 import { cliparrMotionTransitions } from "@/lib/motionPresets";
-import type { DashboardPlaybackCardItem } from "@/components/dashboardPlaybackItems";
+import type {
+  DashboardPlaybackCardItem,
+  DashboardViewerFilterOption,
+} from "@/components/dashboardPlaybackItems";
 import type {
   CurrentlyPlayingItem,
   SourcePlaybackError,
@@ -123,7 +134,7 @@ function ViewerAvatar({
   return (
     <div
       className={cn(
-        "flex items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
         size === "sm" ? "h-8 w-8 text-sm" : "h-12 w-12 text-lg",
       )}
     >
@@ -140,6 +151,114 @@ function ViewerAvatar({
       ) : (
         label
       )}
+    </div>
+  );
+}
+
+function formatFilterSessionCount(count: number) {
+  return `${count} ${count === 1 ? "session" : "sessions"}`;
+}
+
+function formatFilterHiddenCount(count: number) {
+  return `${count} ${count === 1 ? "session is" : "sessions are"} hidden by the viewer filter.`;
+}
+
+export function DashboardViewerFilterBar({
+  viewerOptions,
+  selectedViewerNames,
+  hiddenSessionCount,
+  onToggleViewer,
+  onClearViewerFilter,
+}: {
+  viewerOptions: DashboardViewerFilterOption[];
+  selectedViewerNames: readonly string[];
+  hiddenSessionCount: number;
+  onToggleViewer: (viewerName: string) => void;
+  onClearViewerFilter: () => void;
+}) {
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  const selectedNamesSet = new Set(selectedNames);
+  const filterActive = selectedNames.length > 0;
+
+  if (viewerOptions.length <= 1 && !filterActive) {
+    return null;
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-card/70 p-1"
+      data-dashboard-viewer-filter
+      data-dashboard-viewer-filter-active={filterActive || undefined}
+    >
+      <div
+        role="toolbar"
+        aria-label="Filter sessions by viewer"
+        className="cliparr-editor-scrollbar flex items-center gap-1 overflow-x-auto"
+      >
+        <button
+          type="button"
+          onClick={onClearViewerFilter}
+          aria-pressed={!filterActive}
+          className={cn(
+            "inline-flex h-9 shrink-0 items-center justify-center rounded-md px-3 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+            filterActive
+              ? "text-muted-foreground hover:bg-accent hover:text-foreground"
+              : "bg-primary text-primary-foreground",
+          )}
+        >
+          All
+        </button>
+
+        {viewerOptions.map((option) => {
+          const selected = selectedNamesSet.has(option.normalizedName);
+          const actionLabel = selected
+            ? `Hide ${option.name} sessions`
+            : `Show ${option.name} sessions`;
+
+          return (
+            <Tooltip key={option.normalizedName}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onToggleViewer(option.normalizedName)}
+                  aria-pressed={selected}
+                  aria-label={actionLabel}
+                  className={cn(
+                    "inline-flex h-9 max-w-52 shrink-0 items-center gap-2 rounded-full border py-0.5 pr-3 pl-0.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                    selected
+                      ? "border-primary/50 bg-primary/15 text-primary"
+                      : "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground",
+                  )}
+                >
+                  <ViewerAvatar
+                    name={option.name}
+                    avatarUrl={option.avatarUrl}
+                    size="sm"
+                  />
+                  <span className="truncate">{option.name}</span>
+                  <span className="min-w-[2ch] rounded-full bg-background/80 px-1.5 text-center font-mono text-ui-micro tabular-nums text-muted-foreground">
+                    {option.sessionCount}
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {option.name}: {formatFilterSessionCount(option.sessionCount)}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+
+        {filterActive && (
+          <span
+            className="ml-auto hidden shrink-0 px-2 text-xs text-muted-foreground sm:inline-flex"
+            data-dashboard-viewer-filter-summary
+          >
+            {hiddenSessionCount > 0
+              ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
+              : "Filtered"}
+          </span>
+        )}
+      </div>
     </div>
   );
 }
@@ -307,20 +426,56 @@ function dashboardSkeletonExit(index: number, loadedCardCount: number) {
   };
 }
 
+export function DashboardPlaybackFilterEmptyState({
+  hiddenSessionCount,
+  onClearViewerFilter,
+}: {
+  hiddenSessionCount: number;
+  onClearViewerFilter: () => void;
+}) {
+  return (
+    <>
+      <div className="bg-background mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+        <Users className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <h3 className="mb-2 text-lg font-medium">
+        No sessions match this viewer filter
+      </h3>
+      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+        {formatFilterHiddenCount(hiddenSessionCount)}
+      </p>
+      <button
+        type="button"
+        onClick={onClearViewerFilter}
+        className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-border px-4 text-sm font-semibold text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
+      >
+        <X className="h-4 w-4" />
+        Clear filter
+      </button>
+    </>
+  );
+}
+
 function DashboardPlaybackMotionRegion({
   loading,
   error,
   playbackCards,
+  filteredByViewer,
+  hiddenSessionCount,
   emptyMessage,
   activeViewTransitionSessionId,
   onSelectSession,
+  onClearViewerFilter,
 }: {
   loading: boolean;
   error: string;
   playbackCards: DashboardPlaybackCardItem[];
+  filteredByViewer: boolean;
+  hiddenSessionCount: number;
   emptyMessage: string;
   activeViewTransitionSessionId?: string | null;
   onSelectSession: (session: CurrentlyPlayingItem) => void;
+  onClearViewerFilter: () => void;
 }) {
   const reduceMotion = useReducedMotion();
   const hasPlaybackCards = playbackCards.length > 0;
@@ -435,15 +590,24 @@ function DashboardPlaybackMotionRegion({
             exit={DASHBOARD_PLAYBACK_STATE_EXIT}
             transition={stateTransition}
           >
-            <div className="bg-background w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Play className="w-6 h-6 text-muted-foreground" />
-            </div>
-            <h3 className="text-lg font-medium mb-2">
-              Nothing is playing right now
-            </h3>
-            <p className="text-muted-foreground text-sm max-w-sm mx-auto">
-              {emptyMessage}
-            </p>
+            {filteredByViewer && hiddenSessionCount > 0 ? (
+              <DashboardPlaybackFilterEmptyState
+                hiddenSessionCount={hiddenSessionCount}
+                onClearViewerFilter={onClearViewerFilter}
+              />
+            ) : (
+              <>
+                <div className="bg-background mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                  <Play className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <h3 className="mb-2 text-lg font-medium">
+                  Nothing is playing right now
+                </h3>
+                <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+                  {emptyMessage}
+                </p>
+              </>
+            )}
           </motion.div>
         )}
       </AnimatePresence>
@@ -577,6 +741,9 @@ export default function DashboardScreen({
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState("");
+  const [selectedViewerNames, setSelectedViewerNames] = useState(() =>
+    readDashboardViewerFilter(),
+  );
   const hasFetchedSessionsReference = useRef(false);
 
   const fetchSessions = useCallback(async () => {
@@ -632,8 +799,32 @@ export default function DashboardScreen({
     () => flattenDashboardPlaybackItems(viewers),
     [viewers],
   );
-  const hasPlaybackCards = playbackCards.length > 0;
-  const showPlaybackGrid = loading || hasPlaybackCards;
+  const selectedViewerFilterNames = useMemo(
+    () => sanitizeDashboardViewerFilterNames(selectedViewerNames),
+    [selectedViewerNames],
+  );
+  const viewerFilterOptions = useMemo(
+    () => buildDashboardViewerFilterOptions(playbackCards),
+    [playbackCards],
+  );
+  const filteredPlaybackCards = useMemo(
+    () =>
+      filterDashboardPlaybackCardsByViewer(
+        playbackCards,
+        selectedViewerFilterNames,
+      ),
+    [playbackCards, selectedViewerFilterNames],
+  );
+  const hiddenViewerFilterCardCount = useMemo(
+    () =>
+      countDashboardViewerFilterHiddenCards(
+        playbackCards,
+        selectedViewerFilterNames,
+      ),
+    [playbackCards, selectedViewerFilterNames],
+  );
+  const hasAnyPlaybackCards = playbackCards.length > 0;
+  const showPlaybackGrid = loading || hasAnyPlaybackCards;
   const emptyMessage =
     sourceErrors.length > 0
       ? "No active playback on the available sources."
@@ -650,6 +841,27 @@ export default function DashboardScreen({
         ? "Local development build; release update checks are disabled"
         : "Non-release build; release update checks are disabled";
   }
+
+  const toggleViewerFilter = useCallback((viewerName: string) => {
+    const [normalizedName] = sanitizeDashboardViewerFilterNames([viewerName]);
+    if (!normalizedName) {
+      return;
+    }
+
+    setSelectedViewerNames((current) => {
+      const currentNames = sanitizeDashboardViewerFilterNames(current);
+      const nextNames = currentNames.includes(normalizedName)
+        ? currentNames.filter((name) => name !== normalizedName)
+        : [...currentNames, normalizedName];
+      writeDashboardViewerFilter(nextNames);
+      return nextNames;
+    });
+  }, []);
+
+  const clearViewerFilter = useCallback(() => {
+    setSelectedViewerNames([]);
+    writeDashboardViewerFilter([]);
+  }, []);
 
   return (
     <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
@@ -792,13 +1004,26 @@ export default function DashboardScreen({
 
           {!error && <WarningBanner sourceErrors={sourceErrors} />}
 
+          {!error && (
+            <DashboardViewerFilterBar
+              viewerOptions={viewerFilterOptions}
+              selectedViewerNames={selectedViewerFilterNames}
+              hiddenSessionCount={hiddenViewerFilterCardCount}
+              onToggleViewer={toggleViewerFilter}
+              onClearViewerFilter={clearViewerFilter}
+            />
+          )}
+
           <DashboardPlaybackMotionRegion
             loading={loading}
             error={error}
-            playbackCards={playbackCards}
+            playbackCards={filteredPlaybackCards}
+            filteredByViewer={selectedViewerFilterNames.length > 0}
+            hiddenSessionCount={hiddenViewerFilterCardCount}
             emptyMessage={emptyMessage}
             activeViewTransitionSessionId={activeViewTransitionSessionId}
             onSelectSession={onSelectSession}
+            onClearViewerFilter={clearViewerFilter}
           />
         </div>
       </div>

--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -1,20 +1,14 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Popover } from "@base-ui/react/popover";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   AlertTriangle,
-  Check,
-  ChevronDown,
   FolderOpen,
   Globe,
   LogOut,
   Play,
   RefreshCw,
-  Search,
   Settings2,
-  Users,
   Video,
-  X,
 } from "lucide-react";
 import { cliparrClient, type CliparrVersionInfo } from "@/api/cliparrClient";
 import { cn } from "@/lib/utilities";
@@ -30,7 +24,11 @@ import {
   GithubIcon,
 } from "@/components/DashboardMobileMenu";
 import { MobilePwaInstallNudge } from "@/components/MobilePwaInstallNudge";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { DashboardViewerAvatar } from "@/components/DashboardViewerAvatar";
+import {
+  DashboardPlaybackFilterEmptyState,
+  DashboardViewerFilterPicker,
+} from "@/components/DashboardViewerFilter";
 import {
   Tooltip,
   TooltipContent,
@@ -47,10 +45,7 @@ import {
   writeDashboardViewerFilter,
 } from "@/components/dashboardPlaybackItems";
 import { cliparrMotionTransitions } from "@/lib/motionPresets";
-import type {
-  DashboardPlaybackCardItem,
-  DashboardViewerFilterOption,
-} from "@/components/dashboardPlaybackItems";
+import type { DashboardPlaybackCardItem } from "@/components/dashboardPlaybackItems";
 import type {
   CurrentlyPlayingItem,
   SourcePlaybackError,
@@ -123,410 +118,6 @@ const DASHBOARD_SKELETON_BREAKPOINT_CLASSES = [
   "hidden md:block",
   "hidden xl:block",
 ] as const;
-const DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT = 2;
-
-function viewerAvatarSizeClass(size: "xs" | "sm" | "md") {
-  if (size === "xs") {
-    return "h-6 w-6 text-[11px]";
-  }
-
-  if (size === "sm") {
-    return "h-8 w-8 text-sm";
-  }
-
-  return "h-12 w-12 text-lg";
-}
-
-function viewerAvatarImageSize(size: "xs" | "sm" | "md") {
-  if (size === "xs") {
-    return 24;
-  }
-
-  if (size === "sm") {
-    return 32;
-  }
-
-  return 48;
-}
-
-function ViewerAvatar({
-  name,
-  avatarUrl,
-  size = "md",
-}: {
-  name: string;
-  avatarUrl?: string;
-  size?: "xs" | "sm" | "md";
-}) {
-  const [imageFailed, setImageFailed] = useState(false);
-  const label = name.trim().charAt(0).toUpperCase() || "?";
-  const sizeClass = viewerAvatarSizeClass(size);
-  const imageSize = viewerAvatarImageSize(size);
-
-  return (
-    <div
-      className={cn(
-        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
-        sizeClass,
-      )}
-    >
-      {avatarUrl && !imageFailed ? (
-        <img
-          src={avatarUrl}
-          alt={name}
-          className="w-full h-full object-cover"
-          width={imageSize}
-          height={imageSize}
-          decoding="async"
-          onError={() => setImageFailed(true)}
-        />
-      ) : (
-        label
-      )}
-    </div>
-  );
-}
-
-function formatFilterSessionCount(count: number) {
-  return `${count} ${count === 1 ? "session" : "sessions"}`;
-}
-
-function formatFilterHiddenCount(count: number) {
-  return `${count} ${count === 1 ? "session is" : "sessions are"} hidden by the viewer filter.`;
-}
-
-function dashboardViewerFilterTriggerLabel(
-  viewerOptions: DashboardViewerFilterOption[],
-  selectedViewerNames: readonly string[],
-) {
-  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
-  if (selectedNames.length === 0) {
-    return "All viewers";
-  }
-
-  if (selectedNames.length === 1) {
-    const [selectedName] = selectedNames;
-    const option = viewerOptions.find(
-      (viewerOption) => viewerOption.normalizedName === selectedName,
-    );
-    return option?.name ?? "1 viewer";
-  }
-
-  return `${selectedNames.length} viewers`;
-}
-
-function selectedDashboardViewerFilterOptions(
-  viewerOptions: DashboardViewerFilterOption[],
-  selectedViewerNames: readonly string[],
-) {
-  const optionsByName = new Map(
-    viewerOptions.map((option) => [option.normalizedName, option]),
-  );
-
-  return sanitizeDashboardViewerFilterNames(selectedViewerNames).map(
-    (selectedName) =>
-      optionsByName.get(selectedName) ?? {
-        normalizedName: selectedName,
-        name: selectedName,
-        sessionCount: 0,
-      },
-  );
-}
-
-function DashboardViewerFilterTriggerSelection({
-  selectedViewerOptions,
-}: {
-  selectedViewerOptions: DashboardViewerFilterOption[];
-}) {
-  const visibleViewerOptions = selectedViewerOptions.slice(
-    0,
-    DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT,
-  );
-  const hiddenViewerCount = Math.max(
-    selectedViewerOptions.length - visibleViewerOptions.length,
-    0,
-  );
-
-  return (
-    <span
-      className="flex min-w-0 flex-1 items-center justify-center gap-1 sm:justify-end"
-      data-dashboard-viewer-filter-selected-avatars
-      aria-hidden="true"
-    >
-      <span className="flex shrink-0 -space-x-2">
-        {visibleViewerOptions.map((option, index) => (
-          <span
-            key={option.normalizedName}
-            className="relative rounded-full ring-2 ring-background"
-            style={{ zIndex: index + 1 }}
-          >
-            <ViewerAvatar
-              name={option.name}
-              avatarUrl={option.avatarUrl}
-              size="xs"
-            />
-          </span>
-        ))}
-      </span>
-      {hiddenViewerCount > 0 ? (
-        <span
-          className="inline-flex h-6 shrink-0 items-center rounded-full border border-border bg-background px-1.5 text-[11px] leading-none font-semibold text-muted-foreground"
-          data-dashboard-viewer-filter-overflow-count
-        >
-          (+{hiddenViewerCount})
-        </span>
-      ) : null}
-    </span>
-  );
-}
-
-export function DashboardViewerFilterPicker({
-  viewerOptions,
-  selectedViewerNames,
-  hiddenSessionCount,
-  onToggleViewer,
-  onClearViewerFilter,
-  className,
-}: {
-  viewerOptions: DashboardViewerFilterOption[];
-  selectedViewerNames: readonly string[];
-  hiddenSessionCount: number;
-  onToggleViewer: (viewerName: string) => void;
-  onClearViewerFilter: () => void;
-  className?: string;
-}) {
-  const [query, setQuery] = useState("");
-  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
-  const selectedNamesSet = new Set(selectedNames);
-  const filterActive = selectedNames.length > 0;
-  const reduceMotion = useReducedMotion();
-  const microHover = reduceMotion ? undefined : { y: -1 };
-  const microTap = reduceMotion ? undefined : { scale: 0.985 };
-  const microTransition = reduceMotion
-    ? { duration: 0 }
-    : cliparrMotionTransitions.fast;
-  const queryText = query.trim().toLowerCase();
-  const filteredViewerOptions = queryText
-    ? viewerOptions.filter((option) =>
-        option.name.toLowerCase().includes(queryText),
-      )
-    : viewerOptions;
-  const triggerLabel = dashboardViewerFilterTriggerLabel(
-    viewerOptions,
-    selectedNames,
-  );
-  const selectedViewerOptions = selectedDashboardViewerFilterOptions(
-    viewerOptions,
-    selectedNames,
-  );
-  const totalSessionCount = viewerOptions.reduce(
-    (sum, option) => sum + option.sessionCount,
-    0,
-  );
-
-  if (viewerOptions.length <= 1 && !filterActive) {
-    return null;
-  }
-
-  return (
-    <Popover.Root>
-      <Popover.Trigger
-        aria-label={`Filter sessions by viewer: ${triggerLabel}`}
-        data-dashboard-viewer-filter
-        data-dashboard-viewer-filter-active={filterActive || undefined}
-        className={(state) =>
-          cn(
-            "inline-flex h-11 w-full min-w-0 items-center justify-center gap-1.5 rounded-lg border border-border px-2 text-sm font-semibold text-muted-foreground transition-[color,background-color,border-color,transform] duration-200 hover:-translate-y-px hover:bg-accent hover:text-foreground active:scale-[0.985] focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none motion-reduce:transform-none sm:h-9 sm:w-52 sm:shrink-0 sm:gap-2 sm:px-3 sm:font-medium",
-            state.open &&
-              "[&_[data-dashboard-viewer-filter-chevron]]:rotate-180",
-            filterActive &&
-              "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
-            className,
-          )
-        }
-      >
-        <Users className="h-4 w-4 shrink-0" />
-        <span className="hidden shrink-0 sm:inline">Viewers</span>
-        {filterActive ? (
-          <>
-            <DashboardViewerFilterTriggerSelection
-              selectedViewerOptions={selectedViewerOptions}
-            />
-            <span className="sr-only">{triggerLabel}</span>
-          </>
-        ) : (
-          <span className="min-w-0 flex-1 truncate text-left">All viewers</span>
-        )}
-        <span
-          className="shrink-0 transition-transform duration-200 motion-reduce:transition-none"
-          data-dashboard-viewer-filter-chevron
-          aria-hidden="true"
-        >
-          <ChevronDown className="h-4 w-4 opacity-70" />
-        </span>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Positioner sideOffset={8} align="end">
-          <Popover.Popup
-            className={cn(
-              "z-50 w-[min(calc(100vw-2rem),22rem)] rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-lg outline-none",
-              "data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
-            )}
-            initialFocus={false}
-          >
-            <div className="px-2 py-1.5">
-              <Popover.Title className="text-sm font-semibold text-foreground">
-                Filter by viewer
-              </Popover.Title>
-              <Popover.Description className="mt-0.5 text-xs text-muted-foreground">
-                Selected viewers are shown as a whitelist.
-              </Popover.Description>
-            </div>
-
-            <label className="relative mt-2 block">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search viewers"
-                className="h-9 w-full rounded-md border border-input bg-background px-3 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
-                data-dashboard-viewer-filter-search
-              />
-            </label>
-
-            <ScrollArea
-              className="mt-2 max-h-72"
-              contentClassName="pr-3"
-              data-dashboard-viewer-filter-options
-              viewportClassName="max-h-72"
-            >
-              <motion.button
-                type="button"
-                onClick={onClearViewerFilter}
-                aria-pressed={!filterActive}
-                className={cn(
-                  "flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
-                  !filterActive && "bg-primary/10 text-primary",
-                )}
-                whileHover={microHover}
-                whileTap={microTap}
-                transition={microTransition}
-              >
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background text-primary">
-                  <Users className="h-4 w-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate font-semibold">
-                    All viewers
-                  </span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {formatFilterSessionCount(totalSessionCount)}
-                  </span>
-                </span>
-                <motion.span
-                  className={cn(
-                    "shrink-0 text-primary",
-                    filterActive && "pointer-events-none",
-                  )}
-                  animate={{
-                    opacity: filterActive ? 0 : 1,
-                    scale: filterActive ? 0.8 : 1,
-                  }}
-                  transition={microTransition}
-                  aria-hidden="true"
-                >
-                  <Check className="h-4 w-4" />
-                </motion.span>
-              </motion.button>
-
-              {filteredViewerOptions.length === 0 ? (
-                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-                  No viewers found.
-                </div>
-              ) : (
-                filteredViewerOptions.map((option) => {
-                  const selected = selectedNamesSet.has(option.normalizedName);
-                  const actionLabel = selected
-                    ? `Hide ${option.name} sessions`
-                    : `Show ${option.name} sessions`;
-
-                  return (
-                    <motion.button
-                      key={option.normalizedName}
-                      type="button"
-                      onClick={() => onToggleViewer(option.normalizedName)}
-                      aria-pressed={selected}
-                      aria-label={actionLabel}
-                      className={cn(
-                        "mt-1 flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
-                        selected && "bg-primary/10 text-primary",
-                      )}
-                      whileHover={microHover}
-                      whileTap={microTap}
-                      transition={microTransition}
-                    >
-                      <ViewerAvatar
-                        name={option.name}
-                        avatarUrl={option.avatarUrl}
-                        size="sm"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-semibold">
-                          {option.name}
-                        </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {formatFilterSessionCount(option.sessionCount)}
-                        </span>
-                      </span>
-                      <motion.span
-                        className={cn(
-                          "shrink-0 text-primary",
-                          !selected && "pointer-events-none",
-                        )}
-                        animate={{
-                          opacity: selected ? 1 : 0,
-                          scale: selected ? 1 : 0.8,
-                        }}
-                        transition={microTransition}
-                        aria-hidden="true"
-                      >
-                        <Check className="h-4 w-4" />
-                      </motion.span>
-                    </motion.button>
-                  );
-                })
-              )}
-            </ScrollArea>
-
-            {filterActive && (
-              <div
-                className="mt-2 flex items-center justify-between gap-3 border-t border-border px-2 pt-2"
-                data-dashboard-viewer-filter-summary
-              >
-                <span className="min-w-0 truncate text-xs text-muted-foreground">
-                  {hiddenSessionCount > 0
-                    ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
-                    : "Filtered"}
-                </span>
-                <motion.button
-                  type="button"
-                  onClick={onClearViewerFilter}
-                  className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
-                  whileHover={microHover}
-                  whileTap={microTap}
-                  transition={microTransition}
-                >
-                  <X className="h-3.5 w-3.5" />
-                  Clear
-                </motion.button>
-              </div>
-            )}
-          </Popover.Popup>
-        </Popover.Positioner>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}
 
 function ViewerChip({
   viewer,
@@ -539,7 +130,11 @@ function ViewerChip({
 }) {
   return (
     <div className="flex min-w-0 items-center gap-2.5">
-      <ViewerAvatar name={viewer.name} avatarUrl={viewer.avatarUrl} size="sm" />
+      <DashboardViewerAvatar
+        name={viewer.name}
+        avatarUrl={viewer.avatarUrl}
+        size="sm"
+      />
       <div className="min-w-0">
         <div className="truncate text-sm font-semibold text-foreground">
           {viewer.name}
@@ -689,36 +284,6 @@ function dashboardSkeletonExit(index: number, loadedCardCount: number) {
     scale: 0.98,
     filter: "blur(8px)",
   };
-}
-
-export function DashboardPlaybackFilterEmptyState({
-  hiddenSessionCount,
-  onClearViewerFilter,
-}: {
-  hiddenSessionCount: number;
-  onClearViewerFilter: () => void;
-}) {
-  return (
-    <>
-      <div className="bg-background mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
-        <Users className="h-6 w-6 text-muted-foreground" />
-      </div>
-      <h3 className="mb-2 text-lg font-medium">
-        No sessions match this viewer filter
-      </h3>
-      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-        {formatFilterHiddenCount(hiddenSessionCount)}
-      </p>
-      <button
-        type="button"
-        onClick={onClearViewerFilter}
-        className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-border px-4 text-sm font-semibold text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
-      >
-        <X className="h-4 w-4" />
-        Clear filter
-      </button>
-    </>
-  );
 }
 
 function DashboardPlaybackMotionRegion({

--- a/apps/frontend/src/components/DashboardViewerAvatar.tsx
+++ b/apps/frontend/src/components/DashboardViewerAvatar.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { cn } from "@/lib/utilities";
+
+type DashboardViewerAvatarSize = "xs" | "sm" | "md";
+
+function dashboardViewerAvatarSizeClass(size: DashboardViewerAvatarSize) {
+  if (size === "xs") {
+    return "h-6 w-6 text-[11px]";
+  }
+
+  if (size === "sm") {
+    return "h-8 w-8 text-sm";
+  }
+
+  return "h-12 w-12 text-lg";
+}
+
+function dashboardViewerAvatarImageSize(size: DashboardViewerAvatarSize) {
+  if (size === "xs") {
+    return 24;
+  }
+
+  if (size === "sm") {
+    return 32;
+  }
+
+  return 48;
+}
+
+export function DashboardViewerAvatar({
+  avatarUrl,
+  name,
+  size = "md",
+}: {
+  avatarUrl?: string;
+  name: string;
+  size?: DashboardViewerAvatarSize;
+}) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const label = name.trim().charAt(0).toUpperCase() || "?";
+  const sizeClass = dashboardViewerAvatarSizeClass(size);
+  const imageSize = dashboardViewerAvatarImageSize(size);
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-semibold text-primary",
+        sizeClass,
+      )}
+    >
+      {avatarUrl && !imageFailed ? (
+        <img
+          src={avatarUrl}
+          alt={name}
+          className="h-full w-full object-cover"
+          width={imageSize}
+          height={imageSize}
+          decoding="async"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        label
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/DashboardViewerAvatar.tsx
+++ b/apps/frontend/src/components/DashboardViewerAvatar.tsx
@@ -36,10 +36,12 @@ export function DashboardViewerAvatar({
   name: string;
   size?: DashboardViewerAvatarSize;
 }) {
-  const [imageFailed, setImageFailed] = useState(false);
+  const [failedAvatarUrl, setFailedAvatarUrl] = useState<string | null>(null);
   const label = name.trim().charAt(0).toUpperCase() || "?";
   const sizeClass = dashboardViewerAvatarSizeClass(size);
   const imageSize = dashboardViewerAvatarImageSize(size);
+  const avatarImageUrl =
+    avatarUrl && avatarUrl !== failedAvatarUrl ? avatarUrl : null;
 
   return (
     <div
@@ -48,15 +50,15 @@ export function DashboardViewerAvatar({
         sizeClass,
       )}
     >
-      {avatarUrl && !imageFailed ? (
+      {avatarImageUrl ? (
         <img
-          src={avatarUrl}
+          src={avatarImageUrl}
           alt={name}
           className="h-full w-full object-cover"
           width={imageSize}
           height={imageSize}
           decoding="async"
-          onError={() => setImageFailed(true)}
+          onError={() => setFailedAvatarUrl(avatarImageUrl)}
         />
       ) : (
         label

--- a/apps/frontend/src/components/DashboardViewerFilter.tsx
+++ b/apps/frontend/src/components/DashboardViewerFilter.tsx
@@ -35,7 +35,7 @@ function dashboardViewerFilterTriggerLabel(
     const option = viewerOptions.find(
       (viewerOption) => viewerOption.normalizedName === selectedName,
     );
-    return option?.name ?? "1 viewer";
+    return option?.name ?? selectedName;
   }
 
   return `${selectedNames.length} viewers`;

--- a/apps/frontend/src/components/DashboardViewerFilter.tsx
+++ b/apps/frontend/src/components/DashboardViewerFilter.tsx
@@ -1,0 +1,385 @@
+import { Popover } from "@base-ui/react/popover";
+import { Check, ChevronDown, Search, Users, X } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useState } from "react";
+import {
+  sanitizeDashboardViewerFilterNames,
+  type DashboardViewerFilterOption,
+} from "@/components/dashboardPlaybackItems";
+import { DashboardViewerAvatar } from "@/components/DashboardViewerAvatar";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
+import { cn } from "@/lib/utilities";
+
+const DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT = 2;
+
+function formatFilterSessionCount(count: number) {
+  return `${count} ${count === 1 ? "session" : "sessions"}`;
+}
+
+function formatFilterHiddenCount(count: number) {
+  return `${count} ${count === 1 ? "session is" : "sessions are"} hidden by the viewer filter.`;
+}
+
+function dashboardViewerFilterTriggerLabel(
+  viewerOptions: DashboardViewerFilterOption[],
+  selectedViewerNames: readonly string[],
+) {
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  if (selectedNames.length === 0) {
+    return "All viewers";
+  }
+
+  if (selectedNames.length === 1) {
+    const [selectedName] = selectedNames;
+    const option = viewerOptions.find(
+      (viewerOption) => viewerOption.normalizedName === selectedName,
+    );
+    return option?.name ?? "1 viewer";
+  }
+
+  return `${selectedNames.length} viewers`;
+}
+
+function selectedDashboardViewerFilterOptions(
+  viewerOptions: DashboardViewerFilterOption[],
+  selectedViewerNames: readonly string[],
+): DashboardViewerFilterOption[] {
+  const optionsByName = new Map(
+    viewerOptions.map((option) => [option.normalizedName, option]),
+  );
+
+  return sanitizeDashboardViewerFilterNames(selectedViewerNames).map(
+    (selectedName) =>
+      optionsByName.get(selectedName) ?? {
+        normalizedName: selectedName,
+        name: selectedName,
+        sessionCount: 0,
+      },
+  );
+}
+
+function DashboardViewerFilterTriggerSelection({
+  selectedViewerOptions,
+}: {
+  selectedViewerOptions: DashboardViewerFilterOption[];
+}) {
+  const visibleViewerOptions = selectedViewerOptions.slice(
+    0,
+    DASHBOARD_VIEWER_FILTER_TRIGGER_VISIBLE_AVATAR_COUNT,
+  );
+  const hiddenViewerCount = Math.max(
+    selectedViewerOptions.length - visibleViewerOptions.length,
+    0,
+  );
+
+  return (
+    <span
+      className="flex min-w-0 flex-1 items-center justify-center gap-1 sm:justify-end"
+      data-dashboard-viewer-filter-selected-avatars
+      aria-hidden="true"
+    >
+      <span className="flex shrink-0 -space-x-2">
+        {visibleViewerOptions.map((option, index) => (
+          <span
+            key={option.normalizedName}
+            className="relative rounded-full ring-2 ring-background"
+            style={{ zIndex: index + 1 }}
+          >
+            <DashboardViewerAvatar
+              name={option.name}
+              avatarUrl={option.avatarUrl}
+              size="xs"
+            />
+          </span>
+        ))}
+      </span>
+      {hiddenViewerCount > 0 ? (
+        <span
+          className="inline-flex h-6 shrink-0 items-center rounded-full border border-border bg-background px-1.5 text-[11px] leading-none font-semibold text-muted-foreground"
+          data-dashboard-viewer-filter-overflow-count
+        >
+          (+{hiddenViewerCount})
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export function DashboardViewerFilterPicker({
+  viewerOptions,
+  selectedViewerNames,
+  hiddenSessionCount,
+  onToggleViewer,
+  onClearViewerFilter,
+  className,
+}: {
+  viewerOptions: DashboardViewerFilterOption[];
+  selectedViewerNames: readonly string[];
+  hiddenSessionCount: number;
+  onToggleViewer: (viewerName: string) => void;
+  onClearViewerFilter: () => void;
+  className?: string;
+}) {
+  const [query, setQuery] = useState("");
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  const selectedNamesSet = new Set(selectedNames);
+  const filterActive = selectedNames.length > 0;
+  const reduceMotion = useReducedMotion();
+  const microHover = reduceMotion ? undefined : { y: -1 };
+  const microTap = reduceMotion ? undefined : { scale: 0.985 };
+  const microTransition = reduceMotion
+    ? { duration: 0 }
+    : cliparrMotionTransitions.fast;
+  const queryText = query.trim().toLowerCase();
+  const filteredViewerOptions = queryText
+    ? viewerOptions.filter((option) =>
+        option.name.toLowerCase().includes(queryText),
+      )
+    : viewerOptions;
+  const triggerLabel = dashboardViewerFilterTriggerLabel(
+    viewerOptions,
+    selectedNames,
+  );
+  const selectedViewerOptions = selectedDashboardViewerFilterOptions(
+    viewerOptions,
+    selectedNames,
+  );
+  const totalSessionCount = viewerOptions.reduce(
+    (sum, option) => sum + option.sessionCount,
+    0,
+  );
+
+  if (viewerOptions.length <= 1 && !filterActive) {
+    return null;
+  }
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        aria-label={`Filter sessions by viewer: ${triggerLabel}`}
+        data-dashboard-viewer-filter
+        data-dashboard-viewer-filter-active={filterActive || undefined}
+        className={(state) =>
+          cn(
+            "inline-flex h-11 w-full min-w-0 items-center justify-center gap-1.5 rounded-lg border border-border px-2 text-sm font-semibold text-muted-foreground transition-[color,background-color,border-color,transform] duration-200 hover:-translate-y-px hover:bg-accent hover:text-foreground active:scale-[0.985] focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none motion-reduce:transform-none sm:h-9 sm:w-52 sm:shrink-0 sm:gap-2 sm:px-3 sm:font-medium",
+            state.open &&
+              "[&_[data-dashboard-viewer-filter-chevron]]:rotate-180",
+            filterActive &&
+              "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+            className,
+          )
+        }
+      >
+        <Users className="h-4 w-4 shrink-0" />
+        <span className="hidden shrink-0 sm:inline">Viewers</span>
+        {filterActive ? (
+          <>
+            <DashboardViewerFilterTriggerSelection
+              selectedViewerOptions={selectedViewerOptions}
+            />
+            <span className="sr-only">{triggerLabel}</span>
+          </>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-left">All viewers</span>
+        )}
+        <span
+          className="shrink-0 transition-transform duration-200 motion-reduce:transition-none"
+          data-dashboard-viewer-filter-chevron
+          aria-hidden="true"
+        >
+          <ChevronDown className="h-4 w-4 opacity-70" />
+        </span>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8} align="end">
+          <Popover.Popup
+            className={cn(
+              "z-50 w-[min(calc(100vw-2rem),22rem)] rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-lg outline-none",
+              "data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            )}
+            initialFocus={false}
+          >
+            <div className="px-2 py-1.5">
+              <Popover.Title className="text-sm font-semibold text-foreground">
+                Filter by viewer
+              </Popover.Title>
+              <Popover.Description className="mt-0.5 text-xs text-muted-foreground">
+                Selected viewers are shown as a whitelist.
+              </Popover.Description>
+            </div>
+
+            <label className="relative mt-2 block">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search viewers"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+                data-dashboard-viewer-filter-search
+              />
+            </label>
+
+            <ScrollArea
+              className="mt-2 max-h-72"
+              contentClassName="pr-3"
+              data-dashboard-viewer-filter-options
+              viewportClassName="max-h-72"
+            >
+              <motion.button
+                type="button"
+                onClick={onClearViewerFilter}
+                aria-pressed={!filterActive}
+                className={cn(
+                  "flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                  !filterActive && "bg-primary/10 text-primary",
+                )}
+                whileHover={microHover}
+                whileTap={microTap}
+                transition={microTransition}
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background text-primary">
+                  <Users className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-semibold">
+                    All viewers
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {formatFilterSessionCount(totalSessionCount)}
+                  </span>
+                </span>
+                <motion.span
+                  className={cn(
+                    "shrink-0 text-primary",
+                    filterActive && "pointer-events-none",
+                  )}
+                  animate={{
+                    opacity: filterActive ? 0 : 1,
+                    scale: filterActive ? 0.8 : 1,
+                  }}
+                  transition={microTransition}
+                  aria-hidden="true"
+                >
+                  <Check className="h-4 w-4" />
+                </motion.span>
+              </motion.button>
+
+              {filteredViewerOptions.length === 0 ? (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  No viewers found.
+                </div>
+              ) : (
+                filteredViewerOptions.map((option) => {
+                  const selected = selectedNamesSet.has(option.normalizedName);
+                  const actionLabel = selected
+                    ? `Hide ${option.name} sessions`
+                    : `Show ${option.name} sessions`;
+
+                  return (
+                    <motion.button
+                      key={option.normalizedName}
+                      type="button"
+                      onClick={() => onToggleViewer(option.normalizedName)}
+                      aria-pressed={selected}
+                      aria-label={actionLabel}
+                      className={cn(
+                        "mt-1 flex min-h-11 w-full items-center gap-3 rounded-md px-2 text-left text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                        selected && "bg-primary/10 text-primary",
+                      )}
+                      whileHover={microHover}
+                      whileTap={microTap}
+                      transition={microTransition}
+                    >
+                      <DashboardViewerAvatar
+                        name={option.name}
+                        avatarUrl={option.avatarUrl}
+                        size="sm"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-semibold">
+                          {option.name}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {formatFilterSessionCount(option.sessionCount)}
+                        </span>
+                      </span>
+                      <motion.span
+                        className={cn(
+                          "shrink-0 text-primary",
+                          !selected && "pointer-events-none",
+                        )}
+                        animate={{
+                          opacity: selected ? 1 : 0,
+                          scale: selected ? 1 : 0.8,
+                        }}
+                        transition={microTransition}
+                        aria-hidden="true"
+                      >
+                        <Check className="h-4 w-4" />
+                      </motion.span>
+                    </motion.button>
+                  );
+                })
+              )}
+            </ScrollArea>
+
+            {filterActive && (
+              <div
+                className="mt-2 flex items-center justify-between gap-3 border-t border-border px-2 pt-2"
+                data-dashboard-viewer-filter-summary
+              >
+                <span className="min-w-0 truncate text-xs text-muted-foreground">
+                  {hiddenSessionCount > 0
+                    ? `${formatFilterSessionCount(hiddenSessionCount)} hidden`
+                    : "Filtered"}
+                </span>
+                <motion.button
+                  type="button"
+                  onClick={onClearViewerFilter}
+                  className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
+                  whileHover={microHover}
+                  whileTap={microTap}
+                  transition={microTransition}
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Clear
+                </motion.button>
+              </div>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+export function DashboardPlaybackFilterEmptyState({
+  hiddenSessionCount,
+  onClearViewerFilter,
+}: {
+  hiddenSessionCount: number;
+  onClearViewerFilter: () => void;
+}) {
+  return (
+    <>
+      <div className="bg-background mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+        <Users className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <h3 className="mb-2 text-lg font-medium">
+        No sessions match this viewer filter
+      </h3>
+      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+        {formatFilterHiddenCount(hiddenSessionCount)}
+      </p>
+      <button
+        type="button"
+        onClick={onClearViewerFilter}
+        className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-border px-4 text-sm font-semibold text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none"
+      >
+        <X className="h-4 w-4" />
+        Clear filter
+      </button>
+    </>
+  );
+}

--- a/apps/frontend/src/components/dashboardPlaybackItems.ts
+++ b/apps/frontend/src/components/dashboardPlaybackItems.ts
@@ -11,6 +11,21 @@ export interface DashboardPlaybackCardItem {
   viewerSessionCount: number;
 }
 
+export interface DashboardViewerFilterOption {
+  normalizedName: string;
+  name: string;
+  avatarUrl?: string;
+  sessionCount: number;
+}
+
+type DashboardViewerFilterStorage = Pick<
+  Storage,
+  "getItem" | "removeItem" | "setItem"
+>;
+
+export const DASHBOARD_VIEWER_FILTER_STORAGE_KEY =
+  "cliparr.dashboard.viewer-filter.v1";
+
 export function flattenDashboardPlaybackItems(
   viewers: ViewerPlaybackGroup[],
 ): DashboardPlaybackCardItem[] {
@@ -25,4 +40,157 @@ export function flattenDashboardPlaybackItems(
 
 export function formatViewerSessionCount(count: number) {
   return `${count} active ${count === 1 ? "session" : "sessions"}`;
+}
+
+function normalizeDashboardViewerName(value: string) {
+  return value.trim().replaceAll(/\s+/g, " ").toLowerCase();
+}
+
+export function sanitizeDashboardViewerFilterNames(values: readonly unknown[]) {
+  const names = new Set<string>();
+
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const normalizedName = normalizeDashboardViewerName(value);
+    if (normalizedName) {
+      names.add(normalizedName);
+    }
+  }
+
+  return [...names];
+}
+
+export function buildDashboardViewerFilterOptions(
+  cards: DashboardPlaybackCardItem[],
+): DashboardViewerFilterOption[] {
+  const options = new Map<string, DashboardViewerFilterOption>();
+
+  for (const card of cards) {
+    const normalizedName = normalizeDashboardViewerName(card.viewer.name);
+    if (!normalizedName) {
+      continue;
+    }
+
+    const existing = options.get(normalizedName);
+    if (existing) {
+      existing.sessionCount += 1;
+      existing.avatarUrl ||= card.viewer.avatarUrl;
+      continue;
+    }
+
+    options.set(normalizedName, {
+      normalizedName,
+      name: card.viewer.name.trim(),
+      avatarUrl: card.viewer.avatarUrl,
+      sessionCount: 1,
+    });
+  }
+
+  return [...options.values()];
+}
+
+export function filterDashboardPlaybackCardsByViewer(
+  cards: DashboardPlaybackCardItem[],
+  selectedViewerNames: readonly string[],
+) {
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  if (selectedNames.length === 0) {
+    return cards;
+  }
+
+  const selectedNamesSet = new Set(selectedNames);
+
+  return cards.filter((card) =>
+    selectedNamesSet.has(normalizeDashboardViewerName(card.viewer.name)),
+  );
+}
+
+export function countDashboardViewerFilterHiddenCards(
+  cards: DashboardPlaybackCardItem[],
+  selectedViewerNames: readonly string[],
+) {
+  const selectedNames = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+  if (selectedNames.length === 0) {
+    return 0;
+  }
+
+  return (
+    cards.length -
+    filterDashboardPlaybackCardsByViewer(cards, selectedNames).length
+  );
+}
+
+function safeDashboardViewerFilterStorage():
+  | DashboardViewerFilterStorage
+  | undefined {
+  try {
+    if (globalThis.window === undefined) {
+      return undefined;
+    }
+
+    const storage = globalThis.window.localStorage;
+    return typeof storage?.getItem === "function" &&
+      typeof storage.setItem === "function" &&
+      typeof storage.removeItem === "function"
+      ? storage
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseDashboardViewerFilterStorageValue(raw: string | null) {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? sanitizeDashboardViewerFilterNames(parsed)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function readDashboardViewerFilter(
+  storage = safeDashboardViewerFilterStorage(),
+) {
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    return parseDashboardViewerFilterStorageValue(
+      storage.getItem(DASHBOARD_VIEWER_FILTER_STORAGE_KEY),
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function writeDashboardViewerFilter(
+  selectedViewerNames: readonly string[],
+  storage = safeDashboardViewerFilterStorage(),
+) {
+  if (!storage) {
+    return;
+  }
+
+  const names = sanitizeDashboardViewerFilterNames(selectedViewerNames);
+
+  try {
+    if (names.length === 0) {
+      storage.removeItem(DASHBOARD_VIEWER_FILTER_STORAGE_KEY);
+      return;
+    }
+
+    storage.setItem(DASHBOARD_VIEWER_FILTER_STORAGE_KEY, JSON.stringify(names));
+  } catch {
+    // Best-effort persistence only.
+  }
 }

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -37,6 +37,7 @@ import {
   MobilePwaInstallNudge,
   MobilePwaInstallNudgeCard,
 } from "@/components/MobilePwaInstallNudge";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { gifExportSettingsForPreset } from "@/lib/exportTypes";
 import {
@@ -631,6 +632,26 @@ void test("renders dashboard viewer filter options for multiple viewers", () => 
   assert.match(markup, /sm:w-52/);
   assert.match(markup, /Filter sessions by viewer: All viewers/);
   assert.match(markup, /All viewers/);
+});
+
+void test("renders scroll area structure for constrained dropdown content", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      ScrollArea,
+      {
+        className: "max-h-72",
+        contentClassName: "pr-3",
+        viewportClassName: "max-h-72",
+      },
+      createElement("div", null, "Scrollable content"),
+    ),
+  );
+
+  assert.match(markup, /data-slot="scroll-area"/);
+  assert.match(markup, /data-slot="scroll-area-viewport"/);
+  assert.match(markup, /data-slot="scroll-area-content"/);
+  assert.match(markup, /style="overflow:scroll"/);
+  assert.match(markup, /max-h-72/);
 });
 
 void test("renders dashboard viewer filter as active from saved choices", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -18,12 +18,14 @@ import {
 } from "@/components/dashboardPlaybackItems";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
 import {
-  DashboardPlaybackFilterEmptyState,
   DashboardPlaybackCard,
-  DashboardViewerFilterPicker,
   DashboardVersionBadge,
 } from "@/components/DashboardScreen";
 import DashboardScreen from "@/components/DashboardScreen";
+import {
+  DashboardPlaybackFilterEmptyState,
+  DashboardViewerFilterPicker,
+} from "@/components/DashboardViewerFilter";
 import { DashboardMobileMenu } from "@/components/DashboardMobileMenu";
 import { EditorControls } from "@/components/editor/EditorControls";
 import { EditorExportDialog } from "@/components/editor/EditorExportDialog";

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -712,6 +712,7 @@ void test("renders dashboard viewer filter selected avatars with overflow count"
   assert.match(markup, /Filter sessions by viewer: 5 viewers/);
   assert.match(markup, /data-dashboard-viewer-filter-selected-avatars/);
   assert.match(markup, /data-dashboard-viewer-filter-overflow-count/);
+  assert.match(markup, /style="z-index:1".*style="z-index:2"/);
   assert.match(markup, /\(\+3\)/);
 });
 

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -20,7 +20,7 @@ import AuthCompleteScreen from "@/components/AuthCompleteScreen";
 import {
   DashboardPlaybackFilterEmptyState,
   DashboardPlaybackCard,
-  DashboardViewerFilterBar,
+  DashboardViewerFilterPicker,
   DashboardVersionBadge,
 } from "@/components/DashboardScreen";
 import DashboardScreen from "@/components/DashboardScreen";
@@ -595,7 +595,7 @@ void test("hides dashboard viewer filter with one viewer and no active filter", 
     createElement(
       TooltipProvider,
       null,
-      createElement(DashboardViewerFilterBar, {
+      createElement(DashboardViewerFilterPicker, {
         viewerOptions: options,
         selectedViewerNames: [],
         hiddenSessionCount: 0,
@@ -617,7 +617,7 @@ void test("renders dashboard viewer filter options for multiple viewers", () => 
     createElement(
       TooltipProvider,
       null,
-      createElement(DashboardViewerFilterBar, {
+      createElement(DashboardViewerFilterPicker, {
         viewerOptions: options,
         selectedViewerNames: [],
         hiddenSessionCount: 0,
@@ -628,10 +628,8 @@ void test("renders dashboard viewer filter options for multiple viewers", () => 
   );
 
   assert.match(markup, /data-dashboard-viewer-filter/);
-  assert.match(markup, /Filter sessions by viewer/);
-  assert.match(markup, />All</);
-  assert.match(markup, /TechSquidTV/);
-  assert.match(markup, /Guest/);
+  assert.match(markup, /Filter sessions by viewer: All viewers/);
+  assert.match(markup, /All viewers/);
 });
 
 void test("renders dashboard viewer filter as active from saved choices", () => {
@@ -643,7 +641,7 @@ void test("renders dashboard viewer filter as active from saved choices", () => 
     createElement(
       TooltipProvider,
       null,
-      createElement(DashboardViewerFilterBar, {
+      createElement(DashboardViewerFilterPicker, {
         viewerOptions: options,
         selectedViewerNames: ["techsquidtv"],
         hiddenSessionCount: 0,
@@ -654,8 +652,31 @@ void test("renders dashboard viewer filter as active from saved choices", () => 
   );
 
   assert.match(markup, /data-dashboard-viewer-filter-active="true"/);
-  assert.match(markup, /aria-pressed="true"/);
-  assert.match(markup, /Filtered/);
+  assert.match(markup, /Filter sessions by viewer: TechSquidTV/);
+  assert.match(markup, /TechSquidTV/);
+});
+
+void test("summarizes multiple selected dashboard viewers in the picker trigger", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems(dashboardPlaybackGroups),
+  );
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterPicker, {
+        viewerOptions: options,
+        selectedViewerNames: ["techsquidtv", "guest"],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /Filter sessions by viewer: 2 viewers/);
+  assert.match(markup, /2 viewers/);
 });
 
 void test("renders dashboard filtered empty state with a clear action", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -5,12 +5,22 @@ import test from "node:test";
 import { createElement, createRef, type ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
+  DASHBOARD_VIEWER_FILTER_STORAGE_KEY,
+  buildDashboardViewerFilterOptions,
+  countDashboardViewerFilterHiddenCards,
+  filterDashboardPlaybackCardsByViewer,
   flattenDashboardPlaybackItems,
   formatViewerSessionCount,
+  parseDashboardViewerFilterStorageValue,
+  readDashboardViewerFilter,
+  sanitizeDashboardViewerFilterNames,
+  writeDashboardViewerFilter,
 } from "@/components/dashboardPlaybackItems";
 import AuthCompleteScreen from "@/components/AuthCompleteScreen";
 import {
+  DashboardPlaybackFilterEmptyState,
   DashboardPlaybackCard,
+  DashboardViewerFilterBar,
   DashboardVersionBadge,
 } from "@/components/DashboardScreen";
 import DashboardScreen from "@/components/DashboardScreen";
@@ -78,6 +88,33 @@ const dashboardPlaybackGroups: ViewerPlaybackGroup[] = [
         duration: 5400,
         playerTitle: "Phone",
         playerState: "paused",
+      },
+    ],
+  },
+];
+
+const dashboardDuplicateViewerPlaybackGroups: ViewerPlaybackGroup[] = [
+  ...dashboardPlaybackGroups,
+  {
+    viewer: {
+      id: "viewer-c",
+      providerId: "jellyfin",
+      name: " techsquidtv ",
+      avatarUrl: "/api/media/avatar.jpg",
+    },
+    items: [
+      {
+        id: "session-c",
+        source: {
+          id: "source-c",
+          name: "Jellyfin",
+          providerId: "jellyfin",
+        },
+        title: "Same Viewer Across Providers",
+        type: "episode",
+        duration: 1800,
+        playerTitle: "Bedroom",
+        playerState: "playing",
       },
     ],
   },
@@ -468,6 +505,170 @@ void test("flattens dashboard playback cards with viewer context", () => {
   );
   assert.equal(formatViewerSessionCount(1), "1 active session");
   assert.equal(formatViewerSessionCount(2), "2 active sessions");
+});
+
+void test("groups dashboard viewer filter options by normalized viewer name", () => {
+  const cards = flattenDashboardPlaybackItems(
+    dashboardDuplicateViewerPlaybackGroups,
+  );
+  const options = buildDashboardViewerFilterOptions(cards);
+
+  assert.deepEqual(
+    options.map((option) => [
+      option.normalizedName,
+      option.name,
+      option.sessionCount,
+      option.avatarUrl,
+    ]),
+    [
+      ["techsquidtv", "TechSquidTV", 2, "/api/media/avatar.jpg"],
+      ["guest", "Guest", 1, undefined],
+    ],
+  );
+});
+
+void test("filters dashboard playback cards by multiple viewer names", () => {
+  const cards = flattenDashboardPlaybackItems(
+    dashboardDuplicateViewerPlaybackGroups,
+  );
+
+  assert.deepEqual(
+    sanitizeDashboardViewerFilterNames([
+      " TechSquidTV ",
+      "techsquidtv",
+      "GUEST",
+    ]),
+    ["techsquidtv", "guest"],
+  );
+
+  const techSquidCards = filterDashboardPlaybackCardsByViewer(cards, [
+    "TechSquidTV",
+  ]);
+  assert.deepEqual(
+    techSquidCards.map((card) => card.session.title),
+    ["The Recordist", "Same Viewer Across Providers"],
+  );
+
+  const multiViewerCards = filterDashboardPlaybackCardsByViewer(cards, [
+    "techsquidtv",
+    "guest",
+  ]);
+  assert.equal(multiViewerCards.length, cards.length);
+  assert.equal(countDashboardViewerFilterHiddenCards(cards, ["missing"]), 3);
+});
+
+void test("persists dashboard viewer filters in local storage", () => {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  } satisfies Pick<Storage, "getItem" | "removeItem" | "setItem">;
+
+  assert.deepEqual(parseDashboardViewerFilterStorageValue("not-json"), []);
+  writeDashboardViewerFilter([" TechSquidTV ", "Guest", "guest"], storage);
+  assert.equal(
+    values.get(DASHBOARD_VIEWER_FILTER_STORAGE_KEY),
+    '["techsquidtv","guest"]',
+  );
+  assert.deepEqual(readDashboardViewerFilter(storage), [
+    "techsquidtv",
+    "guest",
+  ]);
+
+  writeDashboardViewerFilter([], storage);
+  assert.equal(values.has(DASHBOARD_VIEWER_FILTER_STORAGE_KEY), false);
+});
+
+void test("hides dashboard viewer filter with one viewer and no active filter", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems([dashboardPlaybackGroups[0]!]),
+  );
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterBar, {
+        viewerOptions: options,
+        selectedViewerNames: [],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.equal(markup, "");
+});
+
+void test("renders dashboard viewer filter options for multiple viewers", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems(dashboardPlaybackGroups),
+  );
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterBar, {
+        viewerOptions: options,
+        selectedViewerNames: [],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /data-dashboard-viewer-filter/);
+  assert.match(markup, /Filter sessions by viewer/);
+  assert.match(markup, />All</);
+  assert.match(markup, /TechSquidTV/);
+  assert.match(markup, /Guest/);
+});
+
+void test("renders dashboard viewer filter as active from saved choices", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems([dashboardPlaybackGroups[0]!]),
+  );
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterBar, {
+        viewerOptions: options,
+        selectedViewerNames: ["techsquidtv"],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /data-dashboard-viewer-filter-active="true"/);
+  assert.match(markup, /aria-pressed="true"/);
+  assert.match(markup, /Filtered/);
+});
+
+void test("renders dashboard filtered empty state with a clear action", () => {
+  const markup = renderToStaticMarkup(
+    createElement(DashboardPlaybackFilterEmptyState, {
+      hiddenSessionCount: 2,
+      onClearViewerFilter: () => {},
+    }),
+  );
+
+  assert.match(markup, /No sessions match this viewer filter/);
+  assert.match(markup, /2 sessions are hidden by the viewer filter/);
+  assert.match(markup, /Clear filter/);
 });
 
 void test("renders dashboard playback cards with viewer context", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -628,6 +628,7 @@ void test("renders dashboard viewer filter options for multiple viewers", () => 
   );
 
   assert.match(markup, /data-dashboard-viewer-filter/);
+  assert.match(markup, /sm:w-52/);
   assert.match(markup, /Filter sessions by viewer: All viewers/);
   assert.match(markup, /All viewers/);
 });
@@ -652,6 +653,7 @@ void test("renders dashboard viewer filter as active from saved choices", () => 
   );
 
   assert.match(markup, /data-dashboard-viewer-filter-active="true"/);
+  assert.match(markup, /data-dashboard-viewer-filter-selected-avatars/);
   assert.match(markup, /Filter sessions by viewer: TechSquidTV/);
   assert.match(markup, /TechSquidTV/);
 });
@@ -676,7 +678,41 @@ void test("summarizes multiple selected dashboard viewers in the picker trigger"
   );
 
   assert.match(markup, /Filter sessions by viewer: 2 viewers/);
-  assert.match(markup, /2 viewers/);
+  assert.match(markup, /data-dashboard-viewer-filter-selected-avatars/);
+});
+
+void test("renders dashboard viewer filter selected avatars with overflow count", () => {
+  const viewerOptions = Array.from({ length: 5 }, (_, index) => {
+    const viewerNumber = index + 1;
+
+    return {
+      normalizedName: `viewer-${viewerNumber}`,
+      name: `Viewer ${viewerNumber}`,
+      avatarUrl: `/api/media/avatar-${viewerNumber}.jpg`,
+      sessionCount: 1,
+    };
+  });
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterPicker, {
+        viewerOptions,
+        selectedViewerNames: viewerOptions.map(
+          (option) => option.normalizedName,
+        ),
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /Filter sessions by viewer: 5 viewers/);
+  assert.match(markup, /data-dashboard-viewer-filter-selected-avatars/);
+  assert.match(markup, /data-dashboard-viewer-filter-overflow-count/);
+  assert.match(markup, /\(\+3\)/);
 });
 
 void test("renders dashboard filtered empty state with a clear action", () => {

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -681,6 +681,25 @@ void test("renders dashboard viewer filter as active from saved choices", () => 
   assert.match(markup, /TechSquidTV/);
 });
 
+void test("labels dashboard viewer filter with saved viewer absent from active sessions", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterPicker, {
+        viewerOptions: [],
+        selectedViewerNames: ["saved-viewer"],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /data-dashboard-viewer-filter-active="true"/);
+  assert.match(markup, /Filter sessions by viewer: saved-viewer/);
+});
+
 void test("summarizes multiple selected dashboard viewers in the picker trigger", () => {
   const options = buildDashboardViewerFilterOptions(
     flattenDashboardPlaybackItems(dashboardPlaybackGroups),

--- a/apps/frontend/src/components/ui/scroll-area.tsx
+++ b/apps/frontend/src/components/ui/scroll-area.tsx
@@ -2,11 +2,13 @@ import { ScrollArea as BaseScrollArea } from "@base-ui/react/scroll-area";
 import * as React from "react";
 import { cn } from "@/lib/utilities";
 
-type ScrollAreaProperties = React.ComponentProps<typeof BaseScrollArea.Root> & {
+type ScrollAreaProperties = React.ComponentPropsWithoutRef<
+  typeof BaseScrollArea.Root
+> & {
   viewportClassName?: string;
   contentClassName?: string;
 };
-type ScrollBarProperties = React.ComponentProps<
+type ScrollBarProperties = React.ComponentPropsWithoutRef<
   typeof BaseScrollArea.Scrollbar
 > & {
   thumbClassName?: string;
@@ -19,10 +21,10 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProperties>(
   ) {
     return (
       <BaseScrollArea.Root
-        ref={ref}
+        {...props}
         className={cn("relative overflow-hidden", className)}
         data-slot="scroll-area"
-        {...props}
+        ref={ref}
       >
         <BaseScrollArea.Viewport
           className={cn(
@@ -55,14 +57,14 @@ const ScrollBar = React.forwardRef<HTMLDivElement, ScrollBarProperties>(
   ) {
     return (
       <BaseScrollArea.Scrollbar
-        ref={ref}
+        {...props}
         orientation={orientation}
         className={cn(
           "flex touch-none p-px select-none transition-colors data-[orientation=horizontal]:absolute data-[orientation=horizontal]:right-0 data-[orientation=horizontal]:bottom-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-col data-[orientation=vertical]:absolute data-[orientation=vertical]:top-0 data-[orientation=vertical]:right-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-2.5",
           className,
         )}
         data-slot="scroll-area-scrollbar"
-        {...props}
+        ref={ref}
       >
         <BaseScrollArea.Thumb
           className={cn(

--- a/apps/frontend/src/components/ui/scroll-area.tsx
+++ b/apps/frontend/src/components/ui/scroll-area.tsx
@@ -1,0 +1,79 @@
+import { ScrollArea as BaseScrollArea } from "@base-ui/react/scroll-area";
+import * as React from "react";
+import { cn } from "@/lib/utilities";
+
+type ScrollAreaProperties = React.ComponentProps<typeof BaseScrollArea.Root> & {
+  viewportClassName?: string;
+  contentClassName?: string;
+};
+type ScrollBarProperties = React.ComponentProps<
+  typeof BaseScrollArea.Scrollbar
+> & {
+  thumbClassName?: string;
+};
+
+const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProperties>(
+  function ScrollArea(
+    { children, className, contentClassName, viewportClassName, ...props },
+    ref,
+  ) {
+    return (
+      <BaseScrollArea.Root
+        ref={ref}
+        className={cn("relative overflow-hidden", className)}
+        data-slot="scroll-area"
+        {...props}
+      >
+        <BaseScrollArea.Viewport
+          className={cn(
+            "w-full rounded-[inherit] outline-none",
+            viewportClassName,
+          )}
+          data-slot="scroll-area-viewport"
+        >
+          <BaseScrollArea.Content
+            className={cn("min-w-0", contentClassName)}
+            data-slot="scroll-area-content"
+          >
+            {children}
+          </BaseScrollArea.Content>
+        </BaseScrollArea.Viewport>
+        <ScrollBar />
+        <BaseScrollArea.Corner
+          className="bg-transparent"
+          data-slot="scroll-area-corner"
+        />
+      </BaseScrollArea.Root>
+    );
+  },
+);
+
+const ScrollBar = React.forwardRef<HTMLDivElement, ScrollBarProperties>(
+  function ScrollBar(
+    { className, orientation = "vertical", thumbClassName, ...props },
+    ref,
+  ) {
+    return (
+      <BaseScrollArea.Scrollbar
+        ref={ref}
+        orientation={orientation}
+        className={cn(
+          "flex touch-none p-px select-none transition-colors data-[orientation=horizontal]:absolute data-[orientation=horizontal]:right-0 data-[orientation=horizontal]:bottom-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-col data-[orientation=vertical]:absolute data-[orientation=vertical]:top-0 data-[orientation=vertical]:right-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-2.5",
+          className,
+        )}
+        data-slot="scroll-area-scrollbar"
+        {...props}
+      >
+        <BaseScrollArea.Thumb
+          className={cn(
+            "relative flex-1 rounded-full bg-border/80 transition-colors hover:bg-muted-foreground/60 before:absolute before:inset-0 before:-m-1",
+            thumbClassName,
+          )}
+          data-slot="scroll-area-thumb"
+        />
+      </BaseScrollArea.Scrollbar>
+    );
+  },
+);
+
+export { ScrollArea };


### PR DESCRIPTION

<img width="2136" height="928" alt="image" src="https://github.com/user-attachments/assets/d318e784-231d-4f4e-a0f3-3bd813f4817a" />

## Summary
- Add a frontend-only dashboard viewer filter by normalized viewer name with local device persistence.
- Use a compact fixed-width viewer dropdown with selected avatars, overflow count, search, scrollable options, and a clearable zero-result empty state.
- Extract the viewer filter and shared avatar presentation into focused frontend components so DashboardScreen only wires state and placement.

## Validation
- pnpm --filter @cliparr/frontend test
- pnpm --filter @cliparr/frontend lint
- pnpm preflight

Closes #143