### PR TITLE
chore(server): diagnose Plex HLS session identities

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -5,6 +5,7 @@ import { checkDatabaseHealth, initializeDatabase } from "@/db/database";
 import { errorHandler, notFoundHandler } from "@/http/errors";
 import { requestOriginIsPotentiallyTrustworthy } from "@/http/requestOrigin";
 import { configureLogging, requestLoggingMiddleware } from "@/logging";
+import { debugRouter } from "@/routes/debug";
 import { mediaRouter } from "@/routes/media";
 import { providersRouter } from "@/routes/providers";
 import { sessionRouter } from "@/routes/session";
@@ -65,6 +66,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   app.use("/api/session", sessionRouter);
   app.use("/api/sources", sourcesRouter);
   app.use("/api/media", mediaRouter);
+  app.use("/api/debug", debugRouter);
   app.use("/api/version", versionRouter);
   app.use("/api", notFoundHandler);
 

--- a/apps/server/src/providers/plex/playback.ts
+++ b/apps/server/src/providers/plex/playback.ts
@@ -14,6 +14,7 @@ import { getServerLogger } from "@/logging";
 import type { ProviderSessionRecord } from "@/session/store";
 import type {
   CurrentlyPlayingEntry,
+  MediaHandle,
   MediaExportMetadata,
   PlaybackAudioSelection,
   PlaybackExportEstimateMetadata,
@@ -23,9 +24,11 @@ import type {
   ProviderResource,
 } from "@/providers/types";
 import {
+  assertAllowedMediaHandleRequestUrl,
   createProviderMediaHandle,
   fetchMediaHandleRequest,
   mediaHandleRequestUrl,
+  playlistBasePath,
   proxyProviderMediaResponse,
   sanitizeLoggedMediaPath,
   shouldAttachProviderAuth,
@@ -177,12 +180,15 @@ interface PlexPlaybackUser {
 
 interface PlexPlaybackPlayer {
   machineIdentifier?: string | null;
+  platform?: string | null;
+  product?: string | null;
   state?: string | null;
   title?: string | null;
 }
 
 interface PlexPlaybackSession {
   id?: PlexIdValue;
+  location?: string | null;
 }
 
 interface PlexMetadataItem extends PlexMetadataPathItem {
@@ -470,6 +476,103 @@ function transcodeSessionId(path: string) {
   } catch {
     return null;
   }
+}
+
+function parsedMediaPath(path: string) {
+  try {
+    return new URL(path, "http://cliparr.local");
+  } catch {
+    return;
+  }
+}
+
+export function plexHlsSegmentSessionId(path: string) {
+  const sessionId = parsedMediaPath(path)?.pathname.match(
+    /\/video\/:\/transcode\/universal\/session\/([^/]+)/,
+  )?.[1];
+  return sessionId ? decodeURIComponent(sessionId) : undefined;
+}
+
+export function classifyPlexMediaHandleKind(path: string) {
+  const pathname = parsedMediaPath(path)?.pathname ?? "";
+  if (pathname.startsWith("/video/:/transcode/universal/session/")) {
+    return "hls-segment";
+  }
+  if (pathname.startsWith("/video/:/transcode/universal/start.")) {
+    return "hls-root";
+  }
+  if (pathname === "/video/:/transcode/universal/subtitles") {
+    return "subtitle-transcode";
+  }
+  if (
+    pathname.startsWith("/library/parts/") ||
+    pathname.startsWith("/library/streams/")
+  ) {
+    return "direct";
+  }
+  return "other";
+}
+
+function safeTranscodeQueryFields(path: string) {
+  const parsed = parsedMediaPath(path);
+  if (!parsed) {
+    return {};
+  }
+
+  const whitelistedFields = [
+    "path",
+    "transcodeSessionId",
+    "protocol",
+    "mediaIndex",
+    "partIndex",
+    "subtitles",
+    "directPlay",
+    "directStream",
+    "directStreamAudio",
+  ];
+  const fields: Record<string, string> = {};
+  for (const field of whitelistedFields) {
+    const value = parsed.searchParams.get(field);
+    if (value !== null) {
+      fields[`plex.transcode.query.${field}`] = value;
+    }
+  }
+
+  const hlsSegmentSessionId = plexHlsSegmentSessionId(path);
+  if (hlsSegmentSessionId) {
+    fields["plex.hls.segment_session.id"] = hlsSegmentSessionId;
+  }
+
+  return fields;
+}
+
+export function plexPlaybackIdentityDiagnostics(
+  item: PlexMetadataItem,
+  cliparrPreviewTranscodeSessionId: string,
+) {
+  return {
+    "plex.session.key": idValue(item?.sessionKey) ?? null,
+    "plex.session.id": idValue(item?.Session?.id) ?? null,
+    "plex.session.location": stringValue(item?.Session?.location) ?? null,
+    "plex.player.machine_identifier":
+      stringValue(item?.Player?.machineIdentifier) ?? null,
+    "plex.player.product": stringValue(item?.Player?.product) ?? null,
+    "plex.player.platform": stringValue(item?.Player?.platform) ?? null,
+    "plex.preview_transcode_session.id": cliparrPreviewTranscodeSessionId,
+  };
+}
+
+function plexSessionHeaderSource(
+  handle: Pick<MediaHandle, "providerMetadata">,
+  fallbackTranscodeSessionId: string | null,
+) {
+  if (handle.providerMetadata?.plex?.playbackSessionId) {
+    return "provider-metadata";
+  }
+  if (fallbackTranscodeSessionId) {
+    return "transcode-session-id";
+  }
+  return "none";
 }
 
 function isRetryableConnectionError(error: unknown) {
@@ -1326,6 +1429,10 @@ async function normalizeCurrentPlayback(
         providerAccountId: source.providerAccountId,
         playbackSessionId: plexPlaybackSessionId,
         transcodeSessionId: cliparrPreviewTranscodeSessionId,
+        ...plexPlaybackIdentityDiagnostics(
+          item,
+          cliparrPreviewTranscodeSessionId,
+        ),
         currentlyPlayingItem: {
           id: `${source.id}:${plexPlaybackSessionId}`,
           title: itemTitleValue(enrichedItem),
@@ -1437,6 +1544,242 @@ export async function listCurrentlyPlaying(
   return normalizeCurrentPlayback(session, source, context, data);
 }
 
+const PLEX_HLS_PROBE_BODY_SNIPPET_LENGTH = 400;
+
+interface PlexHlsProbeHeaderCandidate {
+  name: string;
+  value?: string;
+}
+
+function plexHlsProbeHeaderCandidates(
+  item: PlexMetadataItem,
+  cliparrPreviewTranscodeSessionId: string,
+): PlexHlsProbeHeaderCandidate[] {
+  return [
+    { name: "none" },
+    { name: "sessionKey", value: idValue(item?.sessionKey) },
+    { name: "Session.id", value: idValue(item?.Session?.id) },
+    {
+      name: "cliparrPreviewTranscodeSessionId",
+      value: cliparrPreviewTranscodeSessionId,
+    },
+    {
+      name: "Player.machineIdentifier",
+      value: stringValue(item?.Player?.machineIdentifier),
+    },
+  ];
+}
+
+function plexProbeMediaHandle(
+  context: PlexSourceContext,
+  path: string,
+): MediaHandle {
+  return {
+    id: "plex-hls-probe",
+    providerId: "plex",
+    sourceId: context.sourceId,
+    baseUrl: context.baseUrl,
+    path,
+    token: context.token,
+    lastAccessedAt: Date.now(),
+  };
+}
+
+function plexProbeHeaders(
+  context: PlexSourceContext,
+  candidate: PlexHlsProbeHeaderCandidate,
+) {
+  const headers = plexMediaHeaders({
+    "X-Plex-Token": context.token,
+  });
+  headers.set("Accept", "*/*");
+  if (candidate.value) {
+    headers.set("X-Plex-Session-Identifier", candidate.value);
+  }
+  return headers;
+}
+
+function plexProbeBodySnippet(body: string, context: PlexSourceContext) {
+  const snippet = body
+    .slice(0, PLEX_HLS_PROBE_BODY_SNIPPET_LENGTH)
+    .replaceAll(/\s+/g, " ")
+    .trim();
+  return context.token
+    ? snippet.replaceAll(context.token, "[redacted]")
+    : snippet;
+}
+
+async function probePlexMediaPath(
+  context: PlexSourceContext,
+  path: string,
+  candidate: PlexHlsProbeHeaderCandidate,
+) {
+  const handle = plexProbeMediaHandle(context, path);
+  await assertAllowedMediaHandleRequestUrl(handle);
+  const startedAt = Date.now();
+  const response = await fetch(mediaHandleRequestUrl(handle), {
+    headers: plexProbeHeaders(context, candidate),
+    redirect: "manual",
+  });
+  const contentType = response.headers.get("content-type") ?? "";
+  const textLike =
+    contentType.toLowerCase().includes("mpegurl") ||
+    contentType.toLowerCase().includes("json") ||
+    contentType.toLowerCase().includes("text") ||
+    !response.ok;
+  const body = textLike ? await response.text() : undefined;
+  if (!textLike) {
+    await response.body?.cancel();
+  }
+
+  return {
+    candidate: candidate.name,
+    status: response.status,
+    ok: response.ok,
+    contentType: contentType || null,
+    durationMs: Date.now() - startedAt,
+    bodySnippet: body ? plexProbeBodySnippet(body, context) : null,
+    body,
+  };
+}
+
+function firstHlsMediaUri(playlist: string) {
+  return playlist
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line && !line.startsWith("#"));
+}
+
+function resolvePlexPlaylistUri(
+  context: PlexSourceContext,
+  playlistPath: string,
+  uri: string,
+) {
+  const base = new URL(playlistBasePath(playlistPath), context.baseUrl);
+  const resolved = new URL(uri, base);
+  if (resolved.origin === new URL(context.baseUrl).origin) {
+    return `${resolved.pathname}${resolved.search}`;
+  }
+  return resolved.toString();
+}
+
+export async function probePlexHlsSessionIdentities(
+  session: ProviderSessionRecord,
+  source: MediaSource,
+) {
+  const { context, data } = await fetchCurrentlyPlayingData(source);
+  const item = dedupeCurrentlyPlayingMetadata(
+    data?.MediaContainer?.Metadata ?? [],
+  )[0];
+  if (!item) {
+    throw createApiError(
+      404,
+      "plex_hls_probe_no_current_item",
+      "No current Plex playback item was found",
+    );
+  }
+
+  const { plexPlaybackSessionId, cliparrPreviewTranscodeSessionId } =
+    derivePlexPlaybackIds(source.id, item);
+  const mediaSelection = deriveMediaSelection(item);
+  const enrichedItem = await enrichMetadataItem(context, item);
+  const previewPath = createPreviewPath(
+    enrichedItem,
+    cliparrPreviewTranscodeSessionId,
+    mediaSelection,
+  );
+  if (!previewPath) {
+    throw createApiError(
+      404,
+      "plex_hls_probe_no_preview_path",
+      "Current Plex playback item did not produce an HLS preview path",
+    );
+  }
+
+  const candidates = plexHlsProbeHeaderCandidates(
+    item,
+    cliparrPreviewTranscodeSessionId,
+  );
+  const startResults = [];
+  for (const candidate of candidates) {
+    const startResult = await probePlexMediaPath(
+      context,
+      previewPath,
+      candidate,
+    );
+    const firstUri = startResult.body
+      ? firstHlsMediaUri(startResult.body)
+      : null;
+    const firstMediaPath =
+      startResult.ok && firstUri
+        ? resolvePlexPlaylistUri(context, previewPath, firstUri)
+        : null;
+    const segmentResults = [];
+    if (firstMediaPath) {
+      for (const segmentCandidate of candidates) {
+        const segmentResult = await probePlexMediaPath(
+          context,
+          firstMediaPath,
+          segmentCandidate,
+        );
+        segmentResults.push({
+          ...segmentResult,
+          body: undefined,
+        });
+      }
+    }
+
+    startResults.push({
+      ...startResult,
+      body: undefined,
+      firstMediaPath: firstMediaPath
+        ? sanitizeLoggedMediaPath(firstMediaPath)
+        : null,
+      firstMediaKind: firstMediaPath
+        ? classifyPlexMediaHandleKind(firstMediaPath)
+        : null,
+      firstMediaSegmentSessionId: firstMediaPath
+        ? (plexHlsSegmentSessionId(firstMediaPath) ?? null)
+        : null,
+      segmentResults,
+    });
+  }
+
+  const identityDiagnostics = plexPlaybackIdentityDiagnostics(
+    item,
+    cliparrPreviewTranscodeSessionId,
+  );
+  logger.info("Ran Plex HLS session identity probe.", {
+    ...logEventFields("plex.hls_probe", "success"),
+    "session.id": session.id,
+    "source.id": source.id,
+    "provider.account.id": source.providerAccountId,
+    "plex.playback_session.id": plexPlaybackSessionId,
+    ...identityDiagnostics,
+  });
+
+  return {
+    source: {
+      id: source.id,
+      name: source.name,
+      providerAccountId: source.providerAccountId,
+    },
+    item: {
+      id: `${source.id}:${plexPlaybackSessionId}`,
+      ratingKey: idValue(enrichedItem?.ratingKey) ?? null,
+      metadataPath: metadataPath(enrichedItem) ?? null,
+      type: itemTypeValue(enrichedItem) || "video",
+    },
+    identities: identityDiagnostics,
+    preview: {
+      path: sanitizeLoggedMediaPath(previewPath),
+      kind: classifyPlexMediaHandleKind(previewPath),
+      query: safeTranscodeQueryFields(previewPath),
+    },
+    candidates: startResults,
+  };
+}
+
 export async function proxyMedia(
   session: ProviderSessionRecord,
   handleId: string,
@@ -1472,10 +1815,16 @@ export async function proxyMedia(
     headers.set("Range", range);
   }
 
+  const fallbackTranscodeSessionId = transcodeSessionId(handle.path);
   const playbackSessionId = useProviderAuth
     ? (handle.providerMetadata?.plex?.playbackSessionId ??
-      transcodeSessionId(handle.path))
+      fallbackTranscodeSessionId)
     : null;
+  const mediaHandleKind = classifyPlexMediaHandleKind(handle.path);
+  const sessionHeaderSource = plexSessionHeaderSource(
+    handle,
+    fallbackTranscodeSessionId,
+  );
   if (playbackSessionId) {
     headers.set("X-Plex-Session-Identifier", playbackSessionId);
   }
@@ -1485,10 +1834,13 @@ export async function proxyMedia(
     "session.id": session.id,
     "source.id": handle.sourceId,
     "upstream.url": sanitizeLoggedMediaPath(url.toString()),
+    "media.handle.kind": mediaHandleKind,
     "provider.auth.attached": useProviderAuth,
     "media.range.present": Boolean(range),
     "http.accept": accept,
     "plex.playback_session.id": playbackSessionId,
+    "plex.session_header.source": sessionHeaderSource,
+    ...safeTranscodeQueryFields(handle.path),
   });
 
   await proxyProviderMediaResponse(
@@ -1510,11 +1862,15 @@ export async function proxyMedia(
           "source.id": handle.sourceId,
           "upstream.url": sanitizeLoggedMediaPath(url.toString()),
           "upstream.status_code": upstream.status,
+          "upstream.content_type": upstream.headers.get("content-type"),
           "upstream.detail": detail,
+          "media.handle.kind": mediaHandleKind,
           "provider.auth.attached": useProviderAuth,
           "media.range.present": Boolean(range),
           "http.accept": accept,
           "plex.playback_session.id": playbackSessionId,
+          "plex.session_header.source": sessionHeaderSource,
+          ...safeTranscodeQueryFields(handle.path),
         });
         throw createApiError(
           upstream.status,

--- a/apps/server/src/providers/plexPlayback.test.ts
+++ b/apps/server/src/providers/plexPlayback.test.ts
@@ -7,6 +7,7 @@ import type {
 import type { MediaSource } from "@/db/mediaSourcesRepository";
 import type { ProviderSessionRecord } from "@/session/store";
 import {
+  classifyPlexMediaHandleKind,
   createPlexExportEstimateMetadata,
   createCliparrPlexTranscodeSessionId,
   createPlexViewerAvatarUrl,
@@ -15,6 +16,8 @@ import {
   deriveSubtitleTracks,
   listCurrentlyPlaying,
   playheadSecondsFromViewOffset,
+  plexHlsSegmentSessionId,
+  plexPlaybackIdentityDiagnostics,
   proxyMedia,
 } from "@/providers/plex/playback";
 import type { PlexSourceContext } from "@/providers/plex/shared";
@@ -214,6 +217,66 @@ void test("creates a Cliparr-owned Plex transcode session id", () => {
   );
 });
 
+void test("extracts Plex playback identity diagnostics", () => {
+  assert.deepEqual(
+    plexPlaybackIdentityDiagnostics(
+      {
+        sessionKey: "259",
+        Session: {
+          id: "client-playback-session-1",
+          location: "lan",
+        },
+        Player: {
+          machineIdentifier: "player-machine-1",
+          platform: "Chrome",
+          product: "Plex Web",
+        },
+      },
+      "cliparr-transcode-session-1",
+    ),
+    {
+      "plex.session.key": "259",
+      "plex.session.id": "client-playback-session-1",
+      "plex.session.location": "lan",
+      "plex.player.machine_identifier": "player-machine-1",
+      "plex.player.product": "Plex Web",
+      "plex.player.platform": "Chrome",
+      "plex.preview_transcode_session.id": "cliparr-transcode-session-1",
+    },
+  );
+});
+
+void test("classifies Plex media handle kinds", () => {
+  assert.equal(
+    classifyPlexMediaHandleKind(
+      "/video/:/transcode/universal/start.m3u8?transcodeSessionId=abc",
+    ),
+    "hls-root",
+  );
+  assert.equal(
+    classifyPlexMediaHandleKind(
+      "/video/:/transcode/universal/session/cliparr-session/base/00000.ts",
+    ),
+    "hls-segment",
+  );
+  assert.equal(
+    plexHlsSegmentSessionId(
+      "/video/:/transcode/universal/session/cliparr-session/base/00000.ts",
+    ),
+    "cliparr-session",
+  );
+  assert.equal(
+    classifyPlexMediaHandleKind(
+      "/video/:/transcode/universal/subtitles?transcodeSessionId=259",
+    ),
+    "subtitle-transcode",
+  );
+  assert.equal(
+    classifyPlexMediaHandleKind("/library/parts/1/file.mkv"),
+    "direct",
+  );
+});
+
 void test("keeps Plex subtitle extraction on the real playback session id", () => {
   const session = createSession();
   const context = createContext();
@@ -287,7 +350,7 @@ void test("keeps Plex subtitle extraction on the real playback session id", () =
   assert.equal(subtitleUrl.searchParams.get("subtitles"), "sidecar");
 });
 
-void test("sends the real Plex playback session header for synthetic HLS preview handles", async () => {
+void test("sends the real Plex playback session header for HLS preview handles", async () => {
   const session = createSession();
   const context = createContext();
   const plexPlaybackSessionId = "254";
@@ -327,6 +390,22 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     },
     lastAccessedAt: 0,
   });
+  const segmentHandleId = "hls-segment-handle";
+  session.mediaHandles.set(segmentHandleId, {
+    id: segmentHandleId,
+    providerId: "plex",
+    sourceId: context.sourceId,
+    baseUrl: context.baseUrl,
+    path: `/video/:/transcode/universal/session/${cliparrPreviewTranscodeSessionId}/base/00000.ts`,
+    token: context.token,
+    providerMetadata: {
+      plex: {
+        playbackSessionId: plexPlaybackSessionId,
+      },
+    },
+    basePath: `/video/:/transcode/universal/session/${cliparrPreviewTranscodeSessionId}/base/`,
+    lastAccessedAt: 0,
+  });
   const requestHeaders: Headers[] = [];
   const requestUrls: string[] = [];
   const originalFetch = globalThis.fetch;
@@ -338,6 +417,20 @@ void test("sends the real Plex playback session header for synthetic HLS preview
         : input.url,
     );
     requestHeaders.push(new Headers(init?.headers));
+    const requestUrl = new URL(
+      typeof input === "string" || input instanceof URL
+        ? input.toString()
+        : input.url,
+    );
+    if (requestUrl.pathname.endsWith(".ts")) {
+      return new globalThis.Response("segment", {
+        status: 200,
+        headers: {
+          "content-type": "video/mp2t",
+        },
+      });
+    }
+
     return new globalThis.Response("#EXTM3U\n#EXT-X-ENDLIST\n", {
       status: 200,
       headers: {
@@ -370,6 +463,30 @@ void test("sends the real Plex playback session header for synthetic HLS preview
     );
     assert.equal(requestHeaders[0]?.get("x-plex-token"), context.token);
     assert.equal(response.statusCode, 200);
+
+    const segmentResponse = createResponseRecorder();
+    await proxyMedia(
+      session,
+      segmentHandleId,
+      createRequest({ accept: "*/*" }) as ExpressRequest,
+      segmentResponse as unknown as ExpressResponse,
+    );
+
+    const segmentUrl = new URL(requestUrls[1] ?? "");
+    assert.equal(
+      segmentUrl.pathname,
+      `/video/:/transcode/universal/session/${cliparrPreviewTranscodeSessionId}/base/00000.ts`,
+    );
+    assert.equal(
+      requestHeaders[1]?.get("x-plex-session-identifier"),
+      plexPlaybackSessionId,
+    );
+    assert.notEqual(
+      requestHeaders[1]?.get("x-plex-session-identifier"),
+      cliparrPreviewTranscodeSessionId,
+    );
+    assert.equal(requestHeaders[1]?.get("x-plex-token"), context.token);
+    assert.equal(segmentResponse.statusCode, 200);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/apps/server/src/providers/shared/mediaProxy.ts
+++ b/apps/server/src/providers/shared/mediaProxy.ts
@@ -778,6 +778,34 @@ async function rewriteHlsPlaylist(
   const basePath = handle.basePath ?? playlistBasePath(handle.path);
   let rewrittenUriCount = 0;
   let strippedStartHintCount = 0;
+  const upstreamUriSamples: string[] = [];
+  const rewrittenUriSamples: string[] = [];
+  const segmentSessionIds = new Set<string>();
+
+  function rewriteAndRecordUri(uri: string) {
+    const nextPath = resolvePlaylistUri(basePath, uri);
+    const segmentSessionId = nextPath.match(
+      /\/video\/:\/transcode\/universal\/session\/([^/]+)/,
+    )?.[1];
+    if (segmentSessionId) {
+      segmentSessionIds.add(decodeURIComponent(segmentSessionId));
+    }
+    if (upstreamUriSamples.length < 5) {
+      upstreamUriSamples.push(sanitizeLoggedMediaPath(nextPath) ?? nextPath);
+    }
+
+    const rewritten = rewritePlaylistUri(
+      session,
+      handle,
+      basePath,
+      uri,
+      options,
+    );
+    if (rewrittenUriSamples.length < 5) {
+      rewrittenUriSamples.push(sanitizeLoggedMediaPath(rewritten) ?? rewritten);
+    }
+    return rewritten;
+  }
 
   const playlist = body
     .split("\n")
@@ -796,13 +824,13 @@ async function rewriteHlsPlaylist(
         return [
           line.replaceAll(/URI="([^"]+)"/g, (_match, uri: string) => {
             rewrittenUriCount += 1;
-            return `URI="${rewritePlaylistUri(session, handle, basePath, uri, options)}"`;
+            return `URI="${rewriteAndRecordUri(uri)}"`;
           }),
         ];
       }
 
       rewrittenUriCount += 1;
-      return [rewritePlaylistUri(session, handle, basePath, trimmed, options)];
+      return [rewriteAndRecordUri(trimmed)];
     })
     .join("\n");
 
@@ -816,6 +844,9 @@ async function rewriteHlsPlaylist(
     "upstream.status_code": upstream.status,
     "media.hls.rewritten_uri_count": rewrittenUriCount,
     "media.hls.stripped_start_hint_count": strippedStartHintCount,
+    "media.hls.upstream_uri.samples": upstreamUriSamples,
+    "media.hls.rewritten_uri.samples": rewrittenUriSamples,
+    "plex.hls.segment_session.ids": [...segmentSessionIds],
   });
 
   return playlist;

--- a/apps/server/src/routes/debug.test.ts
+++ b/apps/server/src/routes/debug.test.ts
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createApp } from "@/app";
+import { closeDatabase } from "@/db/database";
+import { upsertMediaSource } from "@/db/mediaSourcesRepository";
+import { upsertProviderAccountByAccessToken } from "@/db/providerAccountsRepository";
+import { createCliparrPlexTranscodeSessionId } from "@/providers/plex/playback";
+import { createProviderSession, getSessionCookieName } from "@/session/store";
+
+const TEST_APP_KEY = "debug-route-test-key-with-32-chars";
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+async function withDebugApp<T>(
+  options: { probeEnabled?: boolean },
+  callback: (baseUrl: string) => Promise<T>,
+) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliparr-debug-"));
+  const previousAppKey = process.env.APP_KEY;
+  const previousDataDir = process.env.CLIPARR_DATA_DIR;
+  const previousProbeFlag = process.env.CLIPARR_ENABLE_PLEX_HLS_PROBE;
+
+  process.env.APP_KEY = TEST_APP_KEY;
+  process.env.CLIPARR_DATA_DIR = dataDir;
+  if (options.probeEnabled) {
+    process.env.CLIPARR_ENABLE_PLEX_HLS_PROBE = "1";
+  } else {
+    delete process.env.CLIPARR_ENABLE_PLEX_HLS_PROBE;
+  }
+
+  const { app } = await createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  try {
+    await new Promise((resolve) => {
+      server.once("listening", resolve);
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+    closeDatabase();
+    restoreEnv("APP_KEY", previousAppKey);
+    restoreEnv("CLIPARR_DATA_DIR", previousDataDir);
+    restoreEnv("CLIPARR_ENABLE_PLEX_HLS_PROBE", previousProbeFlag);
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+function fetchInputUrl(input: Parameters<typeof fetch>[0]) {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+void test("hides the Plex HLS probe unless explicitly enabled", async () => {
+  await withDebugApp({ probeEnabled: false }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/debug/plex/hls-probe`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 404);
+    const body = (await response.json()) as { error?: { code?: string } };
+    assert.equal(body.error?.code, "debug_not_found");
+  });
+});
+
+void test("probes Plex HLS root and segment header candidates", async () => {
+  await withDebugApp({ probeEnabled: true }, async (baseUrl) => {
+    const account = upsertProviderAccountByAccessToken({
+      providerId: "plex",
+      label: "Plex Account",
+      accessToken: "user-token",
+    });
+    assert.ok(account);
+    const source = upsertMediaSource({
+      providerId: "plex",
+      providerAccountId: account.id,
+      externalId: "plex-server-1",
+      name: "Plex",
+      enabled: true,
+      baseUrl: "http://plex.local:32400",
+      connection: {
+        baseUrlMode: "manual",
+        connections: [
+          {
+            id: "plex-connection-1",
+            uri: "http://plex.local:32400",
+            local: true,
+            relay: false,
+            protocol: "http",
+            address: "plex.local",
+            port: 32_400,
+          },
+        ],
+        selectedConnectionId: "plex-connection-1",
+      },
+      credentials: {
+        accessToken: "provider-token",
+      },
+      metadata: {
+        owned: true,
+        provides: ["server"],
+      },
+    });
+    assert.ok(source);
+    const session = createProviderSession({
+      providerId: "plex",
+      providerAccountId: account.id,
+      userToken: "user-token",
+    });
+    const cliparrTranscodeSessionId = createCliparrPlexTranscodeSessionId(
+      source.id,
+      "259",
+    );
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (input, init) => {
+      const requestUrl = fetchInputUrl(input);
+      if (requestUrl.startsWith(baseUrl)) {
+        return originalFetch(input, init);
+      }
+
+      const url = new URL(requestUrl);
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("x-plex-token"), "provider-token");
+
+      if (url.pathname === "/status/sessions") {
+        return Response.json({
+          MediaContainer: {
+            Metadata: [
+              {
+                ratingKey: "14449",
+                key: "/library/metadata/14449",
+                sessionKey: "259",
+                type: "episode",
+                title: "Aliens of London (1)",
+                Session: {
+                  id: "client-playback-session-1",
+                  location: "lan",
+                },
+                Player: {
+                  machineIdentifier: "player-machine-1",
+                  platform: "Chrome",
+                  product: "Plex Web",
+                  title: "Chrome",
+                  state: "paused",
+                },
+              },
+            ],
+          },
+        });
+      }
+
+      if (url.pathname === "/library/metadata/14449") {
+        return Response.json({
+          MediaContainer: {
+            Metadata: [
+              {
+                ratingKey: "14449",
+                key: "/library/metadata/14449",
+                type: "episode",
+                Media: [
+                  {
+                    id: "19136",
+                    selected: 1,
+                    Part: [
+                      {
+                        id: "28746",
+                        selected: 1,
+                        Stream: [
+                          {
+                            id: "101156",
+                            streamType: 1,
+                            codec: "h264",
+                            selected: 1,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        });
+      }
+
+      if (url.pathname === "/video/:/transcode/universal/start.m3u8") {
+        if (
+          headers.get("x-plex-session-identifier") !==
+          "client-playback-session-1"
+        ) {
+          return new Response("bad header", { status: 400 });
+        }
+
+        return new Response(
+          [
+            "#EXTM3U",
+            "#EXT-X-TARGETDURATION:4",
+            "#EXTINF:4,",
+            `session/${cliparrTranscodeSessionId}/base/00000.ts`,
+          ].join("\n"),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/vnd.apple.mpegurl",
+            },
+          },
+        );
+      }
+
+      if (
+        url.pathname ===
+        `/video/:/transcode/universal/session/${cliparrTranscodeSessionId}/base/00000.ts`
+      ) {
+        if (
+          headers.get("x-plex-session-identifier") !==
+          "client-playback-session-1"
+        ) {
+          return new Response("segment not found", { status: 404 });
+        }
+
+        return new Response("segment", {
+          status: 200,
+          headers: {
+            "content-type": "video/mp2t",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    }) as typeof fetch;
+
+    try {
+      const response = await originalFetch(
+        `${baseUrl}/api/debug/plex/hls-probe`,
+        {
+          method: "POST",
+          headers: {
+            cookie: `${getSessionCookieName()}=${session.id}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ sourceId: source.id }),
+        },
+      );
+
+      assert.equal(response.status, 200);
+      const body = (await response.json()) as {
+        identities?: Record<string, string | null>;
+        candidates?: Array<{
+          candidate: string;
+          status: number;
+          firstMediaPath?: string | null;
+          firstMediaSegmentSessionId?: string | null;
+          segmentResults?: Array<{ candidate: string; status: number }>;
+        }>;
+      };
+      const serialized = JSON.stringify(body);
+      assert.equal(serialized.includes("provider-token"), false);
+      assert.equal(body.identities?.["plex.session.key"], "259");
+      assert.equal(
+        body.identities?.["plex.session.id"],
+        "client-playback-session-1",
+      );
+
+      const sessionIdCandidate = body.candidates?.find(
+        (candidate) => candidate.candidate === "Session.id",
+      );
+      assert.equal(sessionIdCandidate?.status, 200);
+      assert.equal(
+        sessionIdCandidate?.firstMediaPath,
+        `/video/:/transcode/universal/session/${cliparrTranscodeSessionId}/base/00000.ts`,
+      );
+      assert.equal(
+        sessionIdCandidate?.firstMediaSegmentSessionId,
+        cliparrTranscodeSessionId,
+      );
+      assert.equal(
+        sessionIdCandidate?.segmentResults?.find(
+          (candidate) => candidate.candidate === "Session.id",
+        )?.status,
+        200,
+      );
+
+      assert.equal(
+        body.candidates?.find(
+          (candidate) => candidate.candidate === "sessionKey",
+        )?.status,
+        400,
+      );
+      assert.equal(
+        sessionIdCandidate?.segmentResults?.find(
+          (candidate) => candidate.candidate === "sessionKey",
+        )?.status,
+        404,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/server/src/routes/debug.ts
+++ b/apps/server/src/routes/debug.ts
@@ -1,0 +1,90 @@
+import { Router } from "express";
+import {
+  compactLogFields,
+  logDurationFields,
+  logErrorFields,
+  logEventFields,
+} from "@cliparr/shared/logging";
+import { listMediaSources } from "@/db/mediaSourcesRepository";
+import { asyncHandler, createApiError, isApiError } from "@/http/errors";
+import { getServerLogger, warnWithError } from "@/logging";
+import { probePlexHlsSessionIdentities } from "@/providers/plex/playback";
+import { requireAccountSession, setNoStore } from "@/session/request";
+
+export const debugRouter = Router();
+
+const logger = getServerLogger(["provider", "plex", "playback"]);
+const PLEX_HLS_PROBE_ENV = "CLIPARR_ENABLE_PLEX_HLS_PROBE";
+
+function plexHlsProbeEnabled() {
+  return process.env[PLEX_HLS_PROBE_ENV] === "1";
+}
+
+function requestedSourceId(body: unknown) {
+  if (!body || typeof body !== "object") {
+    return;
+  }
+
+  const sourceId = (body as { sourceId?: unknown }).sourceId;
+  return typeof sourceId === "string" && sourceId.trim()
+    ? sourceId.trim()
+    : undefined;
+}
+
+debugRouter.post(
+  "/plex/hls-probe",
+  asyncHandler(async (request, res) => {
+    setNoStore(res);
+    if (!plexHlsProbeEnabled()) {
+      throw createApiError(404, "debug_not_found", "Debug route was not found");
+    }
+
+    const startedAt = Date.now();
+    const session = requireAccountSession(request);
+    const sourceId = requestedSourceId(request.body);
+    const sources = listMediaSources({
+      enabledOnly: true,
+      providerId: "plex",
+      providerAccountId: session.providerAccountId,
+    });
+    const source = sourceId
+      ? sources.find((candidate) => candidate.id === sourceId)
+      : sources[0];
+    if (!source) {
+      throw createApiError(
+        404,
+        "plex_hls_probe_source_not_found",
+        "No enabled Plex source was found for this session",
+      );
+    }
+
+    try {
+      const result = await probePlexHlsSessionIdentities(session, source);
+      res.json(result);
+
+      logger.info("Plex HLS probe completed.", {
+        ...logEventFields("debug.plex_hls_probe", "success"),
+        ...logDurationFields(startedAt),
+        "session.id": session.id,
+        "provider.account.id": session.providerAccountId,
+        "source.id": source.id,
+      });
+    } catch (error) {
+      warnWithError(
+        logger,
+        error,
+        "Plex HLS probe failed.",
+        compactLogFields({
+          ...logEventFields("debug.plex_hls_probe", "failure"),
+          ...logDurationFields(startedAt),
+          ...logErrorFields(error),
+          "session.id": session.id,
+          "provider.account.id": session.providerAccountId,
+          "source.id": source.id,
+          "http.status_code": isApiError(error) ? error.status : undefined,
+        }),
+      );
+      throw error;
+    }
+  }),
+);


### PR DESCRIPTION
## Summary

- Replaces the speculative Plex HLS header change with diagnostic-only instrumentation.
- Keeps current HLS semantics stable: preview handles continue to use stored Plex playback session metadata; no synthetic segment header change.
- Adds structured Plex identity logs for sessionKey, Session.id/location, Player.machineIdentifier/product/platform, selected header source, Cliparr preview transcode id, and subtitle transcode id.
- Adds safe transcode request and playlist rewrite logs with sanitized paths, whitelisted query fields, upstream status/content type, and HLS segment ids.
- Adds env-gated `CLIPARR_ENABLE_PLEX_HLS_PROBE=1` route: `POST /api/debug/plex/hls-probe` for authenticated sessions. The route returns 404 while disabled.

## Validation

- `pnpm --filter @cliparr/server exec node --import tsx --test src/providers/plexPlayback.test.ts src/routes/debug.test.ts src/providers/mediaProxy.test.ts`
- `pnpm preflight` reached server tests but failed twice in unrelated existing `src/db/providerPersistence.test.ts` token ownership assertions:
  - `merges Plex account components bridged by a repeated login`: expected `phone-user-token`, got `second-user-token`
  - `deduplicates Plex sources across logins with different user tokens`: expected `phone-user-token`, got `desktop-user-token`
- `pnpm --filter @cliparr/server exec node --import tsx --test src/db/providerPersistence.test.ts` also fails in isolation with those same two assertions.