### PR TITLE
fix(server): force Jellyfin HLS preview transcode

### DIFF
--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -594,6 +594,13 @@ export function buildPreviewPath(
     playSessionId: jellyfinPlaySessionId,
     maxAudioChannels: "2",
     audioCodec: "aac",
+    videoCodec: "h264",
+    videoBitRate: "12000000",
+    maxWidth: "1920",
+    maxHeight: "1080",
+    maxVideoBitDepth: "8",
+    allowVideoStreamCopy: "false",
+    enableAutoStreamCopy: "false",
     enableAdaptiveBitrateStreaming: "false",
     alwaysBurnInSubtitleWhenTranscoding: "false",
   });

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -267,6 +267,10 @@ function isSubtitleMediaStream(stream: JellyfinMediaStream) {
 }
 
 function streamIndexValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
   const index = numberValue(value);
   return index !== undefined && index >= 0 ? index : undefined;
 }

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -266,6 +266,11 @@ function isSubtitleMediaStream(stream: JellyfinMediaStream) {
   return normalizedString(stream?.Type) === "subtitle";
 }
 
+function streamIndexValue(value: unknown) {
+  const index = numberValue(value);
+  return index !== undefined && index >= 0 ? index : undefined;
+}
+
 function positiveNumber(value: unknown) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
@@ -344,6 +349,16 @@ function jellyfinSubtitleTrackTitle(stream: JellyfinMediaStream) {
   );
 }
 
+function selectedJellyfinAudioStreamIndex(
+  sessionInfo: JellyfinSessionInfo,
+  mediaSource?: JellyfinMediaSource,
+) {
+  return (
+    streamIndexValue(sessionInfo?.PlayState?.AudioStreamIndex) ??
+    streamIndexValue(mediaSource?.DefaultAudioStreamIndex)
+  );
+}
+
 function deriveSelectedAudioTrack(
   sessionInfo: JellyfinSessionInfo,
   item: JellyfinItem,
@@ -367,9 +382,10 @@ function deriveSelectedAudioTrack(
     return undefined;
   }
 
-  const selectedAudioStreamIndex =
-    numberValue(sessionInfo?.PlayState?.AudioStreamIndex) ??
-    numberValue(mediaSource?.DefaultAudioStreamIndex);
+  const selectedAudioStreamIndex = selectedJellyfinAudioStreamIndex(
+    sessionInfo,
+    mediaSource,
+  );
 
   if (selectedAudioStreamIndex === undefined) {
     if (audioStreams.length !== 1) {
@@ -578,6 +594,7 @@ export function buildPreviewPath(
   mediaSourceId: string | undefined,
   context: JellyfinSourceContext,
   jellyfinPlaySessionId: string,
+  audioStreamIndex?: number,
 ) {
   const itemId = stringValue(item?.Id);
   if (
@@ -604,6 +621,10 @@ export function buildPreviewPath(
     enableAdaptiveBitrateStreaming: "false",
     alwaysBurnInSubtitleWhenTranscoding: "false",
   });
+
+  if (audioStreamIndex !== undefined) {
+    params.set("audioStreamIndex", String(audioStreamIndex));
+  }
 
   return `/Videos/${encodeURIComponent(itemId)}/master.m3u8?${params.toString()}`;
 }
@@ -848,6 +869,10 @@ async function normalizeCurrentPlayback(
     mediaSourceId,
     playbackInfo,
   );
+  const audioStreamIndex = selectedJellyfinAudioStreamIndex(
+    sessionInfo,
+    mediaSource,
+  );
   const mediaPath = jellyfinPlaySessionId
     ? buildStaticStreamPath(
         enrichedItem,
@@ -862,6 +887,7 @@ async function normalizeCurrentPlayback(
         mediaSourceId,
         context,
         jellyfinPlaySessionId,
+        audioStreamIndex,
       )
     : undefined;
   const imagePath = itemImagePath(enrichedItem);

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -223,6 +223,13 @@ void test("disables Jellyfin subtitle burn-in on HLS previews", () => {
   assert.equal(url.searchParams.get("mediaSourceId"), "media-source-1");
   assert.equal(url.searchParams.get("deviceId"), "cliparr-device-1");
   assert.equal(url.searchParams.get("playSessionId"), "play-session-1");
+  assert.equal(url.searchParams.get("videoCodec"), "h264");
+  assert.equal(url.searchParams.get("videoBitRate"), "12000000");
+  assert.equal(url.searchParams.get("maxWidth"), "1920");
+  assert.equal(url.searchParams.get("maxHeight"), "1080");
+  assert.equal(url.searchParams.get("maxVideoBitDepth"), "8");
+  assert.equal(url.searchParams.get("allowVideoStreamCopy"), "false");
+  assert.equal(url.searchParams.get("enableAutoStreamCopy"), "false");
   assert.equal(
     url.searchParams.get("alwaysBurnInSubtitleWhenTranscoding"),
     "false",

--- a/apps/server/src/providers/jellyfinPlayback.test.ts
+++ b/apps/server/src/providers/jellyfinPlayback.test.ts
@@ -122,6 +122,9 @@ function createJellyfinPlaybackFetch(options: {
   jellyfinPlaySessionId?: string | null | (() => string | null);
   jellyfinClientSessionId?: string;
   mediaSourceId?: string;
+  playStateAudioStreamIndex?: number | null;
+  defaultAudioStreamIndex?: number | null;
+  audioStreams?: Array<Record<string, unknown>>;
   title?: string;
 }) {
   const {
@@ -129,19 +132,9 @@ function createJellyfinPlaybackFetch(options: {
     jellyfinPlaySessionId = "playback-info-session-1",
     jellyfinClientSessionId = "client-session-1",
     mediaSourceId = "media-source-1",
-    title = "Chapter 1: The Dark Revenge",
-  } = options;
-  const mediaSource = {
-    Id: mediaSourceId,
-    DefaultAudioStreamIndex: 1,
-    MediaStreams: [
-      {
-        Type: "Video",
-        Index: 0,
-        Codec: "h264",
-        Width: 1920,
-        Height: 1080,
-      },
+    playStateAudioStreamIndex = 1,
+    defaultAudioStreamIndex = 1,
+    audioStreams = [
       {
         Type: "Audio",
         Index: 1,
@@ -150,6 +143,23 @@ function createJellyfinPlaybackFetch(options: {
         Title: "English",
         IsDefault: true,
       },
+    ],
+    title = "Chapter 1: The Dark Revenge",
+  } = options;
+  const mediaSource = {
+    Id: mediaSourceId,
+    ...(defaultAudioStreamIndex === null
+      ? {}
+      : { DefaultAudioStreamIndex: defaultAudioStreamIndex }),
+    MediaStreams: [
+      {
+        Type: "Video",
+        Index: 0,
+        Codec: "h264",
+        Width: 1920,
+        Height: 1080,
+      },
+      ...audioStreams,
     ],
   };
   const item = {
@@ -179,7 +189,9 @@ function createJellyfinPlaybackFetch(options: {
           PlayState: {
             MediaSourceId: mediaSourceId,
             IsPaused: true,
-            AudioStreamIndex: 1,
+            ...(playStateAudioStreamIndex === null
+              ? {}
+              : { AudioStreamIndex: playStateAudioStreamIndex }),
             PositionTicks: 1_234_560_000,
           },
           NowPlayingItem: item,
@@ -327,6 +339,50 @@ void test("uses Jellyfin PlaybackInfo play session ids for currently playing str
       hlsUrl.searchParams.get("playSessionId"),
       "client-session-1",
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test("uses Jellyfin PlayState audio stream index for HLS previews", async () => {
+  const session = createSession();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createJellyfinPlaybackFetch({
+    itemId: "item-1",
+    playStateAudioStreamIndex: 3,
+    defaultAudioStreamIndex: 1,
+    audioStreams: [
+      {
+        Type: "Audio",
+        Index: 1,
+        Codec: "aac",
+        Language: "deu",
+        Title: "German",
+        IsDefault: true,
+      },
+      {
+        Type: "Audio",
+        Index: 3,
+        Codec: "aac",
+        Language: "eng",
+        Title: "English",
+      },
+    ],
+  });
+
+  try {
+    const entries = await listCurrentlyPlaying(session, createSource());
+
+    const hlsHandle = [...session.mediaHandles.values()].find((handle) =>
+      handle.path.includes("/master.m3u8?"),
+    );
+    assert.ok(hlsHandle);
+
+    const hlsUrl = new URL(hlsHandle.path, "http://cliparr.local");
+    assert.equal(hlsUrl.searchParams.get("audioStreamIndex"), "3");
+    assert.equal(entries[0]?.item.selectedAudioTrack?.trackNumber, 2);
+    assert.equal(entries[0]?.item.selectedAudioTrack?.languageCode, "eng");
+    assert.equal(entries[0]?.item.selectedAudioTrack?.title, "English");
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
Forces Jellyfin HLS preview URLs to request H.264 video transcoding with 1080p/8-bit limits and stream-copy disabled, so Jellyfin can tone-map HDR during preview playback instead of preserving HDR colors in an HLS remux.

Also sends the active Jellyfin AudioStreamIndex in Cliparr generated HLS preview URLs, so preview/export audio matches the track the viewer is actually listening to in Jellyfin instead of falling back to the media-source default.

Fixes #137
Fixes #149

Validation:
- node --import tsx --test src/providers/jellyfinPlayback.test.ts
- pnpm --filter @cliparr/server lint:types
- pnpm --filter @cliparr/server lint:eslint
- pnpm preflight