### PR TITLE
fix(frontend): hide stale single-viewer filter

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -35,7 +35,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  activeDashboardViewerFilterNames,
   buildDashboardViewerFilterOptions,
+  canUseDashboardViewerFilter,
   countDashboardViewerFilterHiddenCards,
   filterDashboardPlaybackCardsByViewer,
   flattenDashboardPlaybackItems,
@@ -630,13 +632,22 @@ export default function DashboardScreen({
     () => flattenDashboardPlaybackItems(viewers),
     [viewers],
   );
-  const selectedViewerFilterNames = useMemo(
+  const storedViewerFilterNames = useMemo(
     () => sanitizeDashboardViewerFilterNames(selectedViewerNames),
     [selectedViewerNames],
   );
   const viewerFilterOptions = useMemo(
     () => buildDashboardViewerFilterOptions(playbackCards),
     [playbackCards],
+  );
+  const canFilterByViewer = canUseDashboardViewerFilter(viewerFilterOptions);
+  const selectedViewerFilterNames = useMemo(
+    () =>
+      activeDashboardViewerFilterNames(
+        viewerFilterOptions,
+        storedViewerFilterNames,
+      ),
+    [viewerFilterOptions, storedViewerFilterNames],
   );
   const filteredPlaybackCards = useMemo(
     () =>
@@ -693,8 +704,16 @@ export default function DashboardScreen({
     setSelectedViewerNames([]);
     writeDashboardViewerFilter([]);
   }, []);
-  const showViewerFilterControl =
-    viewerFilterOptions.length > 1 || selectedViewerFilterNames.length > 0;
+
+  useEffect(() => {
+    if (loading || canFilterByViewer || storedViewerFilterNames.length === 0) {
+      return;
+    }
+
+    clearViewerFilter();
+  }, [canFilterByViewer, clearViewerFilter, loading, storedViewerFilterNames]);
+
+  const showViewerFilterControl = canFilterByViewer;
   const renderViewerFilterPicker = () =>
     showViewerFilterControl ? (
       <DashboardViewerFilterPicker

--- a/apps/frontend/src/components/DashboardViewerFilter.tsx
+++ b/apps/frontend/src/components/DashboardViewerFilter.tsx
@@ -79,11 +79,11 @@ function DashboardViewerFilterTriggerSelection({
       data-dashboard-viewer-filter-selected-avatars
       aria-hidden="true"
     >
-      <span className="flex shrink-0 -space-x-2">
+      <span className="isolate flex shrink-0 -space-x-2">
         {visibleViewerOptions.map((option, index) => (
           <span
             key={option.normalizedName}
-            className="relative rounded-full ring-2 ring-background"
+            className="relative rounded-full bg-background ring-2 ring-background"
             style={{ zIndex: index + 1 }}
           >
             <DashboardViewerAvatar
@@ -93,15 +93,16 @@ function DashboardViewerFilterTriggerSelection({
             />
           </span>
         ))}
+        {hiddenViewerCount > 0 ? (
+          <span
+            className="relative inline-flex h-6 shrink-0 items-center rounded-full border border-border bg-background px-1.5 text-[11px] leading-none font-semibold text-muted-foreground ring-2 ring-background"
+            style={{ zIndex: visibleViewerOptions.length + 1 }}
+            data-dashboard-viewer-filter-overflow-count
+          >
+            (+{hiddenViewerCount})
+          </span>
+        ) : null}
       </span>
-      {hiddenViewerCount > 0 ? (
-        <span
-          className="inline-flex h-6 shrink-0 items-center rounded-full border border-border bg-background px-1.5 text-[11px] leading-none font-semibold text-muted-foreground"
-          data-dashboard-viewer-filter-overflow-count
-        >
-          (+{hiddenViewerCount})
-        </span>
-      ) : null}
     </span>
   );
 }
@@ -150,7 +151,7 @@ export function DashboardViewerFilterPicker({
     0,
   );
 
-  if (viewerOptions.length <= 1 && !filterActive) {
+  if (viewerOptions.length <= 1) {
     return null;
   }
 

--- a/apps/frontend/src/components/dashboardPlaybackItems.ts
+++ b/apps/frontend/src/components/dashboardPlaybackItems.ts
@@ -92,6 +92,21 @@ export function buildDashboardViewerFilterOptions(
   return [...options.values()];
 }
 
+export function canUseDashboardViewerFilter(
+  viewerOptions: readonly DashboardViewerFilterOption[],
+) {
+  return viewerOptions.length > 1;
+}
+
+export function activeDashboardViewerFilterNames(
+  viewerOptions: readonly DashboardViewerFilterOption[],
+  selectedViewerNames: readonly string[],
+) {
+  return canUseDashboardViewerFilter(viewerOptions)
+    ? sanitizeDashboardViewerFilterNames(selectedViewerNames)
+    : [];
+}
+
 export function filterDashboardPlaybackCardsByViewer(
   cards: DashboardPlaybackCardItem[],
   selectedViewerNames: readonly string[],

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -6,7 +6,9 @@ import { createElement, createRef, type ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   DASHBOARD_VIEWER_FILTER_STORAGE_KEY,
+  activeDashboardViewerFilterNames,
   buildDashboardViewerFilterOptions,
+  canUseDashboardViewerFilter,
   countDashboardViewerFilterHiddenCards,
   filterDashboardPlaybackCardsByViewer,
   flattenDashboardPlaybackItems,
@@ -611,6 +613,55 @@ void test("hides dashboard viewer filter with one viewer and no active filter", 
   assert.equal(markup, "");
 });
 
+void test("ignores saved dashboard viewer filters until multiple viewers are available", () => {
+  const oneViewerOptions = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems([dashboardPlaybackGroups[0]!]),
+  );
+  const multipleViewerOptions = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems(dashboardPlaybackGroups),
+  );
+
+  assert.equal(canUseDashboardViewerFilter(oneViewerOptions), false);
+  assert.deepEqual(
+    activeDashboardViewerFilterNames(oneViewerOptions, [
+      "TechSquidTV",
+      "Guest",
+    ]),
+    [],
+  );
+
+  assert.equal(canUseDashboardViewerFilter(multipleViewerOptions), true);
+  assert.deepEqual(
+    activeDashboardViewerFilterNames(multipleViewerOptions, [
+      " TechSquidTV ",
+      "GUEST",
+    ]),
+    ["techsquidtv", "guest"],
+  );
+});
+
+void test("hides dashboard viewer filter with one viewer and saved choices", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems([dashboardPlaybackGroups[0]!]),
+  );
+
+  const markup = renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardViewerFilterPicker, {
+        viewerOptions: options,
+        selectedViewerNames: ["techsquidtv", "guest"],
+        hiddenSessionCount: 0,
+        onToggleViewer: () => {},
+        onClearViewerFilter: () => {},
+      }),
+    ),
+  );
+
+  assert.equal(markup, "");
+});
+
 void test("renders dashboard viewer filter options for multiple viewers", () => {
   const options = buildDashboardViewerFilterOptions(
     flattenDashboardPlaybackItems(dashboardPlaybackGroups),
@@ -658,7 +709,7 @@ void test("renders scroll area structure for constrained dropdown content", () =
 
 void test("renders dashboard viewer filter as active from saved choices", () => {
   const options = buildDashboardViewerFilterOptions(
-    flattenDashboardPlaybackItems([dashboardPlaybackGroups[0]!]),
+    flattenDashboardPlaybackItems(dashboardPlaybackGroups),
   );
 
   const markup = renderToStaticMarkup(
@@ -682,12 +733,16 @@ void test("renders dashboard viewer filter as active from saved choices", () => 
 });
 
 void test("labels dashboard viewer filter with saved viewer absent from active sessions", () => {
+  const options = buildDashboardViewerFilterOptions(
+    flattenDashboardPlaybackItems(dashboardPlaybackGroups),
+  );
+
   const markup = renderToStaticMarkup(
     createElement(
       TooltipProvider,
       null,
       createElement(DashboardViewerFilterPicker, {
-        viewerOptions: [],
+        viewerOptions: options,
         selectedViewerNames: ["saved-viewer"],
         hiddenSessionCount: 0,
         onToggleViewer: () => {},
@@ -754,6 +809,8 @@ void test("renders dashboard viewer filter selected avatars with overflow count"
   assert.match(markup, /Filter sessions by viewer: 5 viewers/);
   assert.match(markup, /data-dashboard-viewer-filter-selected-avatars/);
   assert.match(markup, /data-dashboard-viewer-filter-overflow-count/);
+  assert.match(markup, /-space-x-2/);
+  assert.match(markup, /bg-background ring-2 ring-background/);
   assert.match(markup, /style="z-index:1".*style="z-index:2"/);
   assert.match(markup, /\(\+3\)/);
 });

--- a/apps/server/src/providers/jellyfin/playback.ts
+++ b/apps/server/src/providers/jellyfin/playback.ts
@@ -268,7 +268,7 @@ function isSubtitleMediaStream(stream: JellyfinMediaStream) {
 
 function streamIndexValue(value: unknown) {
   if (value === null || value === undefined) {
-    return undefined;
+    return;
   }
 
   const index = numberValue(value);


### PR DESCRIPTION
## Summary
- hide the dashboard viewer filter unless multiple current viewers are available
- ignore and clear stale persisted viewer filters when only zero or one viewer is active
- keep selected viewer chips overlapped while preventing outline bleed-through
- clean up a Jellyfin lint return that blocked full preflight

## Validation
- pnpm preflight