### PR TITLE
chore(www): improve structured data coverage

### DIFF
--- a/apps/www/src/components/BaseLayout.astro
+++ b/apps/www/src/components/BaseLayout.astro
@@ -3,6 +3,12 @@ import { ClientRouter, fade } from "astro:transitions";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import { site } from "@/data/product";
+import {
+  jsonLdScriptContent,
+  normalizeStructuredData,
+  pageStructuredData,
+  type StructuredDataInput,
+} from "@/lib/structuredData";
 import "@/styles/global.css";
 
 interface Props {
@@ -15,7 +21,7 @@ interface Props {
   socialImageHeight?: number;
   socialImageType?: string;
   socialImageWidth?: number;
-  structuredData?: Record<string, unknown> | Record<string, unknown>[];
+  structuredData?: StructuredDataInput;
 }
 
 const {
@@ -43,49 +49,16 @@ const rssLinks = [
   { href: "/blog/rss.xml", title: `${site.name} blog` },
   { href: "/changelog/rss.xml", title: `${site.name} releases` },
 ] as const;
-const homepageSchema =
-  Astro.url.pathname === "/"
-    ? {
-        "@context": "https://schema.org",
-        "@id": `${site.url}/#software`,
-        "@type": "SoftwareApplication",
-        name: site.name,
-        description: site.description,
-        url: site.url,
-        image: socialImageUrl,
-        applicationCategory: "MultimediaApplication",
-        operatingSystem: "Docker, Linux",
-        isAccessibleForFree: true,
-        license: `${site.githubUrl}/blob/main/LICENSE`,
-        sameAs: [site.githubUrl],
-        offers: {
-          "@type": "Offer",
-          price: "0",
-          priceCurrency: "USD",
-        },
-      }
-    : null;
-const pageStructuredData: Record<string, unknown>[] = [];
-
-if (Array.isArray(structuredData)) {
-  pageStructuredData.push(...structuredData);
-} else if (structuredData) {
-  pageStructuredData.push(structuredData);
-}
-
-function isStructuredDataItem(
-  item: Record<string, unknown> | null,
-): item is Record<string, unknown> {
-  return item !== null;
-}
-
-function jsonLdScriptContent(item: Record<string, unknown>) {
-  return JSON.stringify(item).replaceAll("<", String.raw`\u003c`);
-}
-
-const structuredDataItems = [homepageSchema, ...pageStructuredData].filter(
-  isStructuredDataItem,
-);
+const structuredDataItems = [
+  pageStructuredData({
+    canonicalUrl,
+    description,
+    imageUrl: socialImageUrl,
+    isHomepage: Astro.url.pathname === "/",
+    title: pageTitle,
+  }),
+  ...normalizeStructuredData(structuredData),
+];
 ---
 
 <!doctype html>

--- a/apps/www/src/components/BaseLayout.astro
+++ b/apps/www/src/components/BaseLayout.astro
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import { site } from "@/data/product";
 import {
+  canonicalSiteUrl,
   jsonLdScriptContent,
   normalizeStructuredData,
   pageStructuredData,
@@ -43,7 +44,7 @@ const pageTitle = pageTitleText
 const pageTransition = fade({
   duration: "180ms",
 });
-const canonicalUrl = new URL(Astro.url.pathname, site.url).toString();
+const canonicalUrl = canonicalSiteUrl(Astro.url.pathname);
 const socialImageUrl = new URL(String(socialImage), site.url).toString();
 const rssLinks = [
   { href: "/blog/rss.xml", title: `${site.name} blog` },

--- a/apps/www/src/components/DocsLayout.astro
+++ b/apps/www/src/components/DocsLayout.astro
@@ -2,17 +2,23 @@
 import BaseLayout from "@/components/BaseLayout.astro";
 import DocsNav from "@/components/DocsNav.astro";
 import MermaidRenderer from "@/components/MermaidRenderer.astro";
+import type { StructuredDataInput } from "@/lib/structuredData";
 
 interface Props {
   title: string;
   description: string;
   currentSlug?: string;
+  structuredData?: StructuredDataInput;
 }
 
-const { title, description, currentSlug } = Astro.props;
+const { title, description, currentSlug, structuredData } = Astro.props;
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout
+  title={title}
+  description={description}
+  structuredData={structuredData}
+>
   <section class="border-b border-border bg-background">
     <div class="container-page py-12">
       <p class="section-eyebrow">Documentation</p>

--- a/apps/www/src/content.config.ts
+++ b/apps/www/src/content.config.ts
@@ -10,12 +10,31 @@ const docs = defineCollection({
     base: "./src/content/docs",
     pattern: "**/*.{md,mdx}",
   }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    section: z.enum(docsSectionIds),
-    order: z.number(),
-  }),
+  schema: z
+    .object({
+      title: z.string(),
+      description: z.string(),
+      section: z.enum(docsSectionIds),
+      order: z.number(),
+      schemaType: z.enum(["TechArticle", "HowTo"]).default("TechArticle"),
+      howTo: z
+        .object({
+          tools: z.array(z.string()).default([]),
+          steps: z
+            .array(
+              z.object({
+                name: z.string(),
+                text: z.string(),
+              }),
+            )
+            .min(1),
+        })
+        .optional(),
+    })
+    .refine((data) => data.schemaType !== "HowTo" || data.howTo, {
+      message: "howTo is required when schemaType is HowTo.",
+      path: ["howTo"],
+    }),
 });
 
 const blog = defineCollection({

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -3,6 +3,20 @@ title: Getting started
 description: Run Cliparr with Docker, keep settings persistent, and open the app for the first time.
 section: install-operate
 order: 10
+schemaType: HowTo
+howTo:
+  tools:
+    - Docker
+    - A modern web browser
+  steps:
+    - name: Start Cliparr with Docker
+      text: Run the Cliparr container, map port 7171, set a stable APP_KEY, and mount /data for persistent settings.
+    - name: Open Cliparr
+      text: Open http://localhost:7171 in a browser after the container starts.
+    - name: Connect a source
+      text: Connect Plex or Jellyfin, or choose Open Video for a browser-local file.
+    - name: Keep production settings persistent
+      text: Use Docker Compose with the same APP_KEY and volume across updates so provider connections and settings survive restarts.
 ---
 
 import Callout from "@/components/Callout.astro";

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -3,20 +3,6 @@ title: Getting started
 description: Run Cliparr with Docker, keep settings persistent, and open the app for the first time.
 section: install-operate
 order: 10
-schemaType: HowTo
-howTo:
-  tools:
-    - Docker
-    - A modern web browser
-  steps:
-    - name: Start Cliparr with Docker
-      text: Run the Cliparr container, map port 7171, set a stable APP_KEY, and mount /data for persistent settings.
-    - name: Open Cliparr
-      text: Open http://localhost:7171 in a browser after the container starts.
-    - name: Connect a source
-      text: Connect Plex or Jellyfin, or choose Open Video for a browser-local file.
-    - name: Keep production settings persistent
-      text: Use Docker Compose with the same APP_KEY and volume across updates so provider connections and settings survive restarts.
 ---
 
 import Callout from "@/components/Callout.astro";

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -10,6 +10,8 @@ export const site = {
   ogImageType: "image/jpeg",
   ogImageWidth: 1200,
   logo: "/logo-light.svg",
+  schemaLogo: "/pwa-icon-512.png",
+  sameAs: ["https://github.com/TechSquidTV/Cliparr"],
 };
 
 export const productIntro =

--- a/apps/www/src/lib/structuredData.ts
+++ b/apps/www/src/lib/structuredData.ts
@@ -47,6 +47,7 @@ function organizationStructuredData(): StructuredData {
     "@type": "Organization",
     "@id": organizationId,
     name: site.name,
+    description: site.description,
     url: site.url,
     logo: {
       "@type": "ImageObject",

--- a/apps/www/src/lib/structuredData.ts
+++ b/apps/www/src/lib/structuredData.ts
@@ -6,13 +6,28 @@ export type StructuredDataInput = StructuredData | StructuredData[];
 const organizationId = `${site.url}/#organization`;
 const webApplicationId = `${site.url}/#web-application`;
 const websiteId = `${site.url}/#website`;
+const siteOrigin = new URL(site.url).origin;
 
 export function absoluteSiteUrl(pathOrUrl: string | URL) {
   return new URL(String(pathOrUrl), site.url).toString();
 }
 
+export function canonicalSiteUrl(pathOrUrl: string | URL) {
+  const url = new URL(String(pathOrUrl), site.url);
+
+  if (
+    url.origin === siteOrigin &&
+    !url.pathname.endsWith("/") &&
+    !/\/[^/]+\.[^/]+$/u.test(url.pathname)
+  ) {
+    url.pathname = `${url.pathname}/`;
+  }
+
+  return url.toString();
+}
+
 export function webPageId(pageUrl: string | URL) {
-  return `${absoluteSiteUrl(pageUrl)}#webpage`;
+  return `${canonicalSiteUrl(pageUrl)}#webpage`;
 }
 
 export function organizationReference() {
@@ -102,7 +117,7 @@ export function pageStructuredData({
       mainEntityOfPage: { "@id": currentWebPageId },
       publisher: organizationReference(),
       sameAs: site.sameAs,
-      softwareHelp: absoluteSiteUrl("/docs"),
+      softwareHelp: canonicalSiteUrl("/docs"),
       offers: {
         "@type": "Offer",
         price: "0",

--- a/apps/www/src/lib/structuredData.ts
+++ b/apps/www/src/lib/structuredData.ts
@@ -1,0 +1,132 @@
+import { site } from "@/data/product";
+
+export type StructuredData = Record<string, unknown>;
+export type StructuredDataInput = StructuredData | StructuredData[];
+
+const organizationId = `${site.url}/#organization`;
+const webApplicationId = `${site.url}/#web-application`;
+const websiteId = `${site.url}/#website`;
+
+export function absoluteSiteUrl(pathOrUrl: string | URL) {
+  return new URL(String(pathOrUrl), site.url).toString();
+}
+
+export function webPageId(pageUrl: string | URL) {
+  return `${absoluteSiteUrl(pageUrl)}#webpage`;
+}
+
+export function organizationReference() {
+  return {
+    "@id": organizationId,
+  };
+}
+
+export function websiteReference() {
+  return {
+    "@id": websiteId,
+  };
+}
+
+function organizationStructuredData(): StructuredData {
+  return {
+    "@type": "Organization",
+    "@id": organizationId,
+    name: site.name,
+    url: site.url,
+    logo: {
+      "@type": "ImageObject",
+      "@id": `${site.url}/#logo`,
+      url: absoluteSiteUrl(site.schemaLogo),
+      width: 512,
+      height: 512,
+    },
+    sameAs: site.sameAs,
+  };
+}
+
+interface PageStructuredDataOptions {
+  canonicalUrl: string;
+  description: string;
+  imageUrl: string;
+  isHomepage: boolean;
+  title: string;
+}
+
+export function pageStructuredData({
+  canonicalUrl,
+  description,
+  imageUrl,
+  isHomepage,
+  title,
+}: PageStructuredDataOptions): StructuredData {
+  const currentWebPageId = webPageId(canonicalUrl);
+  const graph: StructuredData[] = [
+    organizationStructuredData(),
+    {
+      "@type": "WebSite",
+      "@id": websiteId,
+      name: site.name,
+      url: site.url,
+      description: site.description,
+      inLanguage: "en",
+      publisher: organizationReference(),
+    },
+    {
+      "@type": "WebPage",
+      "@id": currentWebPageId,
+      url: canonicalUrl,
+      name: title,
+      description,
+      image: imageUrl,
+      inLanguage: "en",
+      isPartOf: websiteReference(),
+      publisher: organizationReference(),
+      ...(isHomepage ? { mainEntity: { "@id": webApplicationId } } : {}),
+    },
+  ];
+
+  if (isHomepage) {
+    graph.push({
+      "@type": "WebApplication",
+      "@id": webApplicationId,
+      name: site.name,
+      description: site.description,
+      url: site.url,
+      image: imageUrl,
+      applicationCategory: "MultimediaApplication",
+      operatingSystem: "Web",
+      browserRequirements:
+        "Requires a modern browser with WebCodecs support for editing and export.",
+      isAccessibleForFree: true,
+      license: `${site.githubUrl}/blob/main/LICENSE`,
+      mainEntityOfPage: { "@id": currentWebPageId },
+      publisher: organizationReference(),
+      sameAs: site.sameAs,
+      softwareHelp: absoluteSiteUrl("/docs"),
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+    });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": graph,
+  };
+}
+
+export function normalizeStructuredData(
+  structuredData: StructuredDataInput | undefined,
+): StructuredData[] {
+  if (Array.isArray(structuredData)) {
+    return structuredData;
+  }
+
+  return structuredData ? [structuredData] : [];
+}
+
+export function jsonLdScriptContent(item: StructuredData) {
+  return JSON.stringify(item).replaceAll("<", String.raw`\u003c`);
+}

--- a/apps/www/src/pages/blog/[...slug].astro
+++ b/apps/www/src/pages/blog/[...slug].astro
@@ -54,7 +54,7 @@ const articleAuthor = author
   : organizationReference();
 const articleStructuredData = {
   "@context": "https://schema.org",
-  "@type": "TechArticle",
+  "@type": "BlogPosting",
   "@id": `${postUrl}#article`,
   headline: entry.data.title,
   description: entry.data.description,

--- a/apps/www/src/pages/blog/[...slug].astro
+++ b/apps/www/src/pages/blog/[...slug].astro
@@ -8,6 +8,7 @@ import { blogHeroImageFor } from "@/data/blogImages";
 import { site } from "@/data/product";
 import {
   absoluteSiteUrl,
+  canonicalSiteUrl,
   organizationReference,
   websiteReference,
   webPageId,
@@ -37,7 +38,7 @@ const dateFormatter = new Intl.DateTimeFormat("en", {
   timeZone: "UTC",
 });
 const tags = entry.data.tags as BlogTagId[];
-const postUrl = absoluteSiteUrl(`/blog/${entry.id}`);
+const postUrl = canonicalSiteUrl(`/blog/${entry.id}`);
 const heroImage = blogHeroImageFor(entry.data.heroImage);
 const heroImageAlt = entry.data.heroImageAlt ?? site.ogImageAlt;
 const socialImage = heroImage?.src ?? site.ogImage;

--- a/apps/www/src/pages/blog/[...slug].astro
+++ b/apps/www/src/pages/blog/[...slug].astro
@@ -6,6 +6,12 @@ import BaseLayout from "@/components/BaseLayout.astro";
 import { type BlogTagId, blogTagLabel, blogTagPath } from "@/data/blog";
 import { blogHeroImageFor } from "@/data/blogImages";
 import { site } from "@/data/product";
+import {
+  absoluteSiteUrl,
+  organizationReference,
+  websiteReference,
+  webPageId,
+} from "@/lib/structuredData";
 
 type BlogEntry = CollectionEntry<"blog">;
 
@@ -31,44 +37,37 @@ const dateFormatter = new Intl.DateTimeFormat("en", {
   timeZone: "UTC",
 });
 const tags = entry.data.tags as BlogTagId[];
-const postUrl = new URL(`/blog/${entry.id}`, site.url).toString();
+const postUrl = absoluteSiteUrl(`/blog/${entry.id}`);
 const heroImage = blogHeroImageFor(entry.data.heroImage);
 const heroImageAlt = entry.data.heroImageAlt ?? site.ogImageAlt;
 const socialImage = heroImage?.src ?? site.ogImage;
-const socialImageUrl = new URL(socialImage, site.url).toString();
+const socialImageUrl = absoluteSiteUrl(socialImage);
 const author = entry.data.author;
 const articleAuthor = author
   ? {
       "@type": "Person",
+      ...(author.url ? { "@id": `${author.url}#person` } : {}),
       name: author.name,
       ...(author.url ? { url: author.url } : {}),
     }
-  : {
-      "@type": "Organization",
-      name: site.name,
-      url: site.url,
-    };
+  : organizationReference();
 const articleStructuredData = {
   "@context": "https://schema.org",
-  "@type": "BlogPosting",
+  "@type": "TechArticle",
+  "@id": `${postUrl}#article`,
   headline: entry.data.title,
   description: entry.data.description,
   datePublished: entry.data.publishedAt,
-  ...(entry.data.updatedAt ? { dateModified: entry.data.updatedAt } : {}),
+  dateModified: entry.data.updatedAt ?? entry.data.publishedAt,
   url: postUrl,
-  mainEntityOfPage: postUrl,
+  mainEntityOfPage: { "@id": webPageId(postUrl) },
   image: socialImageUrl,
-  keywords: tags,
+  inLanguage: "en",
+  isPartOf: websiteReference(),
+  articleSection: "Blog",
+  keywords: tags.map((tag) => blogTagLabel(tag)),
   author: articleAuthor,
-  publisher: {
-    "@type": "Organization",
-    name: site.name,
-    url: site.url,
-    logo: {
-      "@type": "ImageObject",
-      url: new URL(site.logo, site.url).toString(),
-    },
-  },
+  publisher: organizationReference(),
 };
 ---
 

--- a/apps/www/src/pages/docs/[...slug].astro
+++ b/apps/www/src/pages/docs/[...slug].astro
@@ -4,7 +4,7 @@ import { getCollection, render } from "astro:content";
 import DocsLayout from "@/components/DocsLayout.astro";
 import { docsSections } from "@/data/docs";
 import {
-  absoluteSiteUrl,
+  canonicalSiteUrl,
   organizationReference,
   websiteReference,
   webPageId,
@@ -24,7 +24,7 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-const documentUrl = absoluteSiteUrl(`/docs/${entry.id}`);
+const documentUrl = canonicalSiteUrl(`/docs/${entry.id}`);
 const documentSection = docsSections.find(
   (section) => section.id === entry.data.section,
 );

--- a/apps/www/src/pages/docs/[...slug].astro
+++ b/apps/www/src/pages/docs/[...slug].astro
@@ -2,6 +2,13 @@
 import type { CollectionEntry } from "astro:content";
 import { getCollection, render } from "astro:content";
 import DocsLayout from "@/components/DocsLayout.astro";
+import { docsSections } from "@/data/docs";
+import {
+  absoluteSiteUrl,
+  organizationReference,
+  websiteReference,
+  webPageId,
+} from "@/lib/structuredData";
 
 type Props = {
   entry: CollectionEntry<"docs">;
@@ -17,12 +24,55 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+const documentUrl = absoluteSiteUrl(`/docs/${entry.id}`);
+const documentSection = docsSections.find(
+  (section) => section.id === entry.data.section,
+);
+const documentMainEntityOfPage = { "@id": webPageId(documentUrl) };
+const sharedDocumentStructuredData = {
+  "@context": "https://schema.org",
+  "@id": `${documentUrl}#article`,
+  description: entry.data.description,
+  url: documentUrl,
+  mainEntityOfPage: documentMainEntityOfPage,
+  inLanguage: "en",
+  isPartOf: websiteReference(),
+  author: organizationReference(),
+  publisher: organizationReference(),
+};
+const documentStructuredData =
+  entry.data.schemaType === "HowTo" && entry.data.howTo
+    ? {
+        ...sharedDocumentStructuredData,
+        "@type": "HowTo",
+        "@id": `${documentUrl}#howto`,
+        name: entry.data.title,
+        tool: entry.data.howTo.tools.map((tool: string) => ({
+          "@type": "HowToTool",
+          name: tool,
+        })),
+        step: entry.data.howTo.steps.map(
+          (step: { name: string; text: string }, index: number) => ({
+            "@type": "HowToStep",
+            position: index + 1,
+            name: step.name,
+            text: step.text,
+          }),
+        ),
+      }
+    : {
+        ...sharedDocumentStructuredData,
+        "@type": "TechArticle",
+        headline: entry.data.title,
+        articleSection: documentSection?.title ?? "Documentation",
+      };
 ---
 
 <DocsLayout
   title={entry.data.title}
   description={entry.data.description}
   currentSlug={entry.id}
+  structuredData={documentStructuredData}
 >
   <Content />
 </DocsLayout>

--- a/apps/www/src/pages/docs/index.astro
+++ b/apps/www/src/pages/docs/index.astro
@@ -3,16 +3,53 @@ import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 import DocsLayout from "@/components/DocsLayout.astro";
 import { docsForSection, docsSections } from "@/data/docs";
+import {
+  absoluteSiteUrl,
+  organizationReference,
+  websiteReference,
+  webPageId,
+} from "@/lib/structuredData";
 
 type DocsEntry = CollectionEntry<"docs">;
 
 const docs = (await getCollection("docs")) as DocsEntry[];
+const pageTitle = "Cliparr docs";
+const pageDescription =
+  "Small, practical guides for installing, configuring, and using Cliparr.";
+const docsUrl = absoluteSiteUrl("/docs");
+const listedDocs = docsSections.flatMap((section) =>
+  docsForSection(docs, section.id),
+);
+const docsStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": `${docsUrl}#collection`,
+  name: pageTitle,
+  description: pageDescription,
+  url: docsUrl,
+  mainEntityOfPage: { "@id": webPageId(docsUrl) },
+  inLanguage: "en",
+  isPartOf: websiteReference(),
+  publisher: organizationReference(),
+  hasPart: listedDocs.map((entry) => {
+    const entryUrl = absoluteSiteUrl(`/docs/${entry.id}`);
+    const isHowTo = entry.data.schemaType === "HowTo";
+
+    return {
+      "@type": isHowTo ? "HowTo" : "TechArticle",
+      "@id": `${entryUrl}${isHowTo ? "#howto" : "#article"}`,
+      name: entry.data.title,
+      url: entryUrl,
+    };
+  }),
+};
 ---
 
 <DocsLayout
-  title="Cliparr docs"
-  description="Small, practical guides for installing, configuring, and using Cliparr."
+  title={pageTitle}
+  description={pageDescription}
   currentSlug=""
+  structuredData={docsStructuredData}
 >
   <div class="space-y-10">
     {

--- a/apps/www/src/pages/docs/index.astro
+++ b/apps/www/src/pages/docs/index.astro
@@ -4,7 +4,7 @@ import { getCollection } from "astro:content";
 import DocsLayout from "@/components/DocsLayout.astro";
 import { docsForSection, docsSections } from "@/data/docs";
 import {
-  absoluteSiteUrl,
+  canonicalSiteUrl,
   organizationReference,
   websiteReference,
   webPageId,
@@ -16,7 +16,7 @@ const docs = (await getCollection("docs")) as DocsEntry[];
 const pageTitle = "Cliparr docs";
 const pageDescription =
   "Small, practical guides for installing, configuring, and using Cliparr.";
-const docsUrl = absoluteSiteUrl("/docs");
+const docsUrl = canonicalSiteUrl("/docs");
 const listedDocs = docsSections.flatMap((section) =>
   docsForSection(docs, section.id),
 );
@@ -32,7 +32,7 @@ const docsStructuredData = {
   isPartOf: websiteReference(),
   publisher: organizationReference(),
   hasPart: listedDocs.map((entry) => {
-    const entryUrl = absoluteSiteUrl(`/docs/${entry.id}`);
+    const entryUrl = canonicalSiteUrl(`/docs/${entry.id}`);
     const isHowTo = entry.data.schemaType === "HowTo";
 
     return {


### PR DESCRIPTION
## Summary
- Adds shared JSON-LD helpers for site identity, canonical URLs, and escaped script output.
- Emits Organization/WebSite/WebPage across the site, WebApplication on the homepage, BlogPosting for blog posts, and CollectionPage plus docs article data for documentation.
- Keeps HowTo schema opt-in for docs pages that visibly render step content, but does not mark the current getting-started page as HowTo.

## Validation
- `pnpm --filter @cliparr/www build`
- `pnpm --filter @cliparr/www lint`
- Rendered JSON-LD smoke check for home, blog, docs index, and getting-started routes
- `pnpm preflight` currently fails in out-of-scope `@cliparr/server` test `deduplicates Plex sources across logins with different user tokens`: expected `phone-user-token`, got `desktop-user-token`. The server fix is intentionally not included in this `www` PR.