### PR TITLE
feat(www): add convert export metrics

### DIFF
--- a/apps/frontend/src/convert.ts
+++ b/apps/frontend/src/convert.ts
@@ -5,6 +5,7 @@ import { formatOptions } from "./components/editor/editorExportOptions";
 export {
   DEFAULT_GIF_EXPORT_PRESET,
   DEFAULT_VIDEO_EXPORT_QUALITY,
+  EXPORT_SIZE_ESTIMATE_ALGORITHM_VERSION,
   estimateExportOutputSize,
   exportFormatDurationDisabledReason,
   exportFormatSupportsAudio,

--- a/apps/frontend/src/lib/exportTypes.ts
+++ b/apps/frontend/src/lib/exportTypes.ts
@@ -76,6 +76,7 @@ export interface EstimateExportOutputSizeOptions {
 
 export const DEFAULT_GIF_EXPORT_PRESET: GifExportPreset = "balanced";
 export const DEFAULT_VIDEO_EXPORT_QUALITY: VideoExportQualityPreset = "sharp";
+export const EXPORT_SIZE_ESTIMATE_ALGORITHM_VERSION = 1;
 
 export const exportQualityOptions: ReadonlyArray<{
   value: ExportQualityPreset;

--- a/apps/www/astro.config.ts
+++ b/apps/www/astro.config.ts
@@ -1,6 +1,7 @@
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import sentry from "@sentry/astro";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import path from "node:path";
@@ -66,6 +67,7 @@ export default defineConfig({
         video: false,
       },
     }),
+    sentry(),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,6 +23,7 @@
     "@fontsource-variable/outfit": "^5.2.8",
     "@mediabunny/aac-encoder": "^1.49.0",
     "@mediabunny/ac3": "^1.49.0",
+    "@sentry/astro": "^10.58.0",
     "@tailwindcss/vite": "^4.3.1",
     "@techsquidtv/gifenc": "1.1.0",
     "astro": "^6.4.8",

--- a/apps/www/sentry.client.config.ts
+++ b/apps/www/sentry.client.config.ts
@@ -1,0 +1,42 @@
+import * as Sentry from "@sentry/astro";
+
+interface RuntimeConfig {
+  sentryDsn?: unknown;
+}
+
+void initializeSentry();
+
+async function initializeSentry() {
+  const dsn = await loadRuntimeSentryDsn();
+
+  if (!dsn) {
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    integrations: [],
+  });
+}
+
+async function loadRuntimeSentryDsn() {
+  try {
+    const response = await fetch("/__cliparr/runtime-config.json", {
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return "";
+    }
+
+    const config = (await response.json()) as RuntimeConfig;
+
+    return stringValue(config.sentryDsn);
+  } catch {
+    return "";
+  }
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/apps/www/sentry.server.config.ts
+++ b/apps/www/sentry.server.config.ts
@@ -1,0 +1,10 @@
+import * as Sentry from "@sentry/astro";
+
+const sentryDsn = process.env.SENTRY_DSN?.trim();
+
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    integrations: [],
+  });
+}

--- a/apps/www/src/components/convert/ConvertTool.tsx
+++ b/apps/www/src/components/convert/ConvertTool.tsx
@@ -46,6 +46,12 @@ import {
   selectedQualityForFormat,
   type SourceProbeResult,
 } from "@/components/convert/convertToolUtilities";
+import {
+  flushConvertMetrics,
+  recordConvertExportCompleted,
+  recordConvertExportFailed,
+  recordConvertExportStarted,
+} from "@/components/convert/convertMetrics";
 import { MediabunnySourcePreview } from "@/components/convert/MediabunnySourcePreview";
 
 type ProbeState =
@@ -545,8 +551,23 @@ export function ConvertTool() {
     setProgress(0);
     setExportError(null);
 
+    const startedAt = Date.now();
+    const metricContext = {
+      sourceFile,
+      probe: probeResult,
+      format,
+      selectedQuality,
+      resolution,
+      includeAudio: effectiveIncludeAudio,
+      outputDimensions,
+      outputSizeEstimate,
+      gifSettings: format === "gif" ? gifSettings : null,
+    };
+
+    recordConvertExportStarted(metricContext);
+
     try {
-      await runConvertExport({
+      const blob = await runConvertExport({
         source,
         fileName: outputFileName,
         probe: probeResult,
@@ -565,8 +586,19 @@ export function ConvertTool() {
         },
       });
 
+      recordConvertExportCompleted({
+        ...metricContext,
+        actualBytes: blob.size,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      });
+      void flushConvertMetrics();
       setProgress(1);
     } catch (error) {
+      recordConvertExportFailed({
+        ...metricContext,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      });
+      void flushConvertMetrics();
       setExportError(errorMessage(error, "Conversion failed."));
     } finally {
       setExporting(false);
@@ -577,8 +609,11 @@ export function ConvertTool() {
     format,
     gifSettings,
     outputFileName,
+    outputDimensions,
+    outputSizeEstimate,
     probeResult,
     resolution,
+    selectedQuality,
     source,
     sourceFile,
     videoQuality,

--- a/apps/www/src/components/convert/convertMetrics.test.ts
+++ b/apps/www/src/components/convert/convertMetrics.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildConvertMetricAttributes,
+  flushConvertMetrics,
+  normalizeConvertSourceFormat,
+  recordConvertExportCompleted,
+  recordConvertExportFailed,
+  type ConvertMetricsDependencies,
+} from "@/components/convert/convertMetrics";
+
+type MetricCall = {
+  kind: "count" | "distribution";
+  name: string;
+  value: number | undefined;
+  options?: {
+    attributes?: Record<string, unknown>;
+    unit?: string;
+  };
+};
+
+function createMetricRecorder() {
+  const calls: MetricCall[] = [];
+  const flushTimeouts: Array<number | undefined> = [];
+  const dependencies: ConvertMetricsDependencies = {
+    metrics: {
+      count: (name, value, options) => {
+        calls.push({ kind: "count", name, value, options });
+      },
+      distribution: (name, value, options) => {
+        calls.push({ kind: "distribution", name, value, options });
+      },
+    },
+    flush: (timeout) => {
+      flushTimeouts.push(timeout);
+
+      return Promise.resolve(true);
+    },
+  };
+
+  return { calls, dependencies, flushTimeouts };
+}
+
+function createSourceFile(name = "Private Show S01E02.mkv") {
+  return new File(["x".repeat(4096)], name, {
+    type: "video/x-matroska",
+    lastModified: 1234,
+  });
+}
+
+function createMetricContext() {
+  return {
+    sourceFile: createSourceFile(),
+    probe: {
+      durationSeconds: 42,
+      previewStartTimestampSeconds: 0,
+      dimensions: { width: 1920, height: 1080 },
+      hasAudio: true,
+    },
+    format: "mp4" as const,
+    selectedQuality: "balanced" as const,
+    resolution: "720" as const,
+    includeAudio: true,
+    outputDimensions: { width: 1280, height: 720 },
+    outputSizeEstimate: {
+      bytes: 1000,
+      basis: "codec-heuristic" as const,
+    },
+    gifSettings: null,
+  };
+}
+
+function metricCall(calls: readonly MetricCall[], name: string) {
+  const call = calls.find((candidate) => candidate.name === name);
+
+  assert.ok(call, `Expected metric ${name} to be recorded.`);
+
+  return call;
+}
+
+void test("normalizes convert source formats from extension and MIME type", () => {
+  assert.equal(
+    normalizeConvertSourceFormat({ name: "Episode.MKV", type: "" }),
+    "mkv",
+  );
+  assert.equal(
+    normalizeConvertSourceFormat({ name: "capture.bin", type: "video/mp2t" }),
+    "mpeg-ts",
+  );
+  assert.equal(
+    normalizeConvertSourceFormat({ name: "phone-clip.m4v", type: "" }),
+    "mp4",
+  );
+  assert.equal(
+    normalizeConvertSourceFormat({
+      name: "unknown.data",
+      type: "application/octet-stream",
+    }),
+    "unknown",
+  );
+});
+
+void test("metric attributes stay bounded and omit file-identifying values", () => {
+  const attributes = buildConvertMetricAttributes(createMetricContext());
+  const serializedAttributes = JSON.stringify(attributes);
+
+  assert.equal(attributes.surface, "www.convert");
+  assert.equal(attributes["source.format"], "mkv");
+  assert.equal(attributes["output.format"], "mp4");
+  assert.equal(attributes["estimator.version"], 1);
+  assert.doesNotMatch(serializedAttributes, /Private Show/);
+  assert.doesNotMatch(serializedAttributes, /S01E02/);
+  assert.equal(
+    Object.keys(attributes).some((key) =>
+      /(?:error|file|name|path|url)/i.test(key),
+    ),
+    false,
+  );
+});
+
+void test("completed convert metrics emit actual size, estimate delta, and ratio", () => {
+  const { calls, dependencies } = createMetricRecorder();
+
+  recordConvertExportCompleted(
+    {
+      ...createMetricContext(),
+      actualBytes: 1100,
+      durationMs: 2500,
+    },
+    dependencies,
+  );
+
+  assert.equal(metricCall(calls, "convert.export.completed").value, 1);
+  assert.equal(metricCall(calls, "convert.source.size_bytes").value, 4096);
+  assert.equal(metricCall(calls, "convert.source.duration_seconds").value, 42);
+  assert.equal(metricCall(calls, "convert.estimate.bytes").value, 1000);
+  assert.equal(metricCall(calls, "convert.output.bytes").value, 1100);
+  assert.equal(metricCall(calls, "convert.estimate.delta_bytes").value, 100);
+  assert.equal(metricCall(calls, "convert.estimate.ratio").value, 1.1);
+  assert.equal(metricCall(calls, "convert.export.duration_ms").value, 2500);
+  assert.equal(metricCall(calls, "convert.output.bytes").options?.unit, "byte");
+});
+
+void test("completed convert metrics skip estimate delta and ratio when unavailable", () => {
+  const { calls, dependencies } = createMetricRecorder();
+
+  recordConvertExportCompleted(
+    {
+      ...createMetricContext(),
+      outputSizeEstimate: { bytes: null, basis: "unavailable" },
+      actualBytes: 1100,
+      durationMs: 2500,
+    },
+    dependencies,
+  );
+
+  assert.equal(
+    calls.some((call) => call.name === "convert.estimate.bytes"),
+    false,
+  );
+  assert.equal(
+    calls.some((call) => call.name === "convert.estimate.delta_bytes"),
+    false,
+  );
+  assert.equal(
+    calls.some((call) => call.name === "convert.estimate.ratio"),
+    false,
+  );
+});
+
+void test("failed convert metrics omit raw error and file details", () => {
+  const { calls, dependencies } = createMetricRecorder();
+
+  recordConvertExportFailed(
+    {
+      ...createMetricContext(),
+      durationMs: 2500,
+    },
+    dependencies,
+  );
+
+  const serializedCalls = JSON.stringify(calls);
+
+  assert.equal(metricCall(calls, "convert.export.failed").value, 1);
+  assert.doesNotMatch(serializedCalls, /No compatible codec/);
+  assert.doesNotMatch(serializedCalls, /Private Show/);
+  assert.doesNotMatch(serializedCalls, /S01E02/);
+});
+
+void test("convert metric flushing uses the short best-effort timeout", () => {
+  const { dependencies, flushTimeouts } = createMetricRecorder();
+
+  void flushConvertMetrics(dependencies);
+
+  assert.deepEqual(flushTimeouts, [2000]);
+});

--- a/apps/www/src/components/convert/convertMetrics.ts
+++ b/apps/www/src/components/convert/convertMetrics.ts
@@ -1,0 +1,284 @@
+import * as Sentry from "@sentry/astro";
+import {
+  EXPORT_SIZE_ESTIMATE_ALGORITHM_VERSION,
+  type ExportFormat,
+  type ExportOutputDimensions,
+  type ExportQualityPreset,
+  type ExportResolution,
+  type ExportSizeEstimate,
+  type GifExportSettings,
+} from "@cliparr/frontend/convert";
+import type { SourceProbeResult } from "@/components/convert/convertToolUtilities";
+
+type ConvertSourceFormat =
+  | "gif"
+  | "mkv"
+  | "mov"
+  | "mp4"
+  | "mpeg-ts"
+  | "ogg"
+  | "unknown"
+  | "webm";
+
+type MetricAttributeValue = boolean | number | string;
+
+interface MetricOptions {
+  attributes?: Record<string, MetricAttributeValue>;
+  unit?: string;
+}
+
+interface ConvertMetricsClient {
+  count: (name: string, value?: number, options?: MetricOptions) => void;
+  distribution: (name: string, value: number, options?: MetricOptions) => void;
+}
+
+export interface ConvertMetricsDependencies {
+  metrics: ConvertMetricsClient;
+  flush: (timeout?: number) => PromiseLike<boolean>;
+}
+
+interface SourceFormatInput {
+  name?: string;
+  type?: string;
+}
+
+interface ConvertExportMetricContext {
+  sourceFile: SourceFormatInput & { size: number };
+  probe: SourceProbeResult;
+  format: ExportFormat;
+  selectedQuality: ExportQualityPreset;
+  resolution: ExportResolution;
+  includeAudio: boolean;
+  outputDimensions: ExportOutputDimensions | null;
+  outputSizeEstimate: ExportSizeEstimate;
+  gifSettings?: GifExportSettings | null;
+}
+
+interface ConvertExportCompletedMetricInput extends ConvertExportMetricContext {
+  actualBytes: number;
+  durationMs: number;
+}
+
+interface ConvertExportFailedMetricInput extends ConvertExportMetricContext {
+  durationMs: number;
+}
+
+const convertMetricsFlushTimeoutMs = 2000;
+const defaultConvertMetricsDependencies: ConvertMetricsDependencies = {
+  metrics: Sentry.metrics,
+  flush: Sentry.flush,
+};
+const sourceFormatByExtension: ReadonlyMap<string, ConvertSourceFormat> =
+  new Map([
+    ["gif", "gif"],
+    ["m2ts", "mpeg-ts"],
+    ["m4v", "mp4"],
+    ["mkv", "mkv"],
+    ["mov", "mov"],
+    ["mp4", "mp4"],
+    ["mts", "mpeg-ts"],
+    ["ogm", "ogg"],
+    ["ogg", "ogg"],
+    ["ogv", "ogg"],
+    ["qt", "mov"],
+    ["ts", "mpeg-ts"],
+    ["webm", "webm"],
+  ]);
+const sourceFormatByMimeType: ReadonlyMap<string, ConvertSourceFormat> =
+  new Map([
+    ["application/mp4", "mp4"],
+    ["application/ogg", "ogg"],
+    ["application/webm", "webm"],
+    ["application/x-matroska", "mkv"],
+    ["image/gif", "gif"],
+    ["video/gif", "gif"],
+    ["video/mp2t", "mpeg-ts"],
+    ["video/mp4", "mp4"],
+    ["video/ogg", "ogg"],
+    ["video/quicktime", "mov"],
+    ["video/webm", "webm"],
+    ["video/x-m4v", "mp4"],
+    ["video/x-matroska", "mkv"],
+  ]);
+
+export function normalizeConvertSourceFormat(
+  source: SourceFormatInput | null,
+): ConvertSourceFormat {
+  const extension = source?.name
+    ?.trim()
+    .match(/\.([^.]+)$/)
+    ?.at(1)
+    ?.toLowerCase();
+  const extensionFormat = extension
+    ? sourceFormatByExtension.get(extension)
+    : undefined;
+
+  if (extensionFormat) {
+    return extensionFormat;
+  }
+
+  const normalizedMimeType = source?.type
+    ?.trim()
+    .toLowerCase()
+    .split(";", 1)[0];
+
+  return normalizedMimeType
+    ? (sourceFormatByMimeType.get(normalizedMimeType) ?? "unknown")
+    : "unknown";
+}
+
+export function buildConvertMetricAttributes({
+  sourceFile,
+  probe,
+  format,
+  selectedQuality,
+  resolution,
+  includeAudio,
+  outputDimensions,
+  outputSizeEstimate,
+  gifSettings,
+}: ConvertExportMetricContext) {
+  return compactMetricAttributes({
+    surface: "www.convert",
+    "estimator.version": EXPORT_SIZE_ESTIMATE_ALGORITHM_VERSION,
+    "source.format": normalizeConvertSourceFormat(sourceFile),
+    "output.format": format,
+    "export.quality": selectedQuality,
+    "export.resolution": resolution,
+    "export.include_audio": includeAudio,
+    "source.has_audio": probe.hasAudio,
+    "output.width": outputDimensions?.width,
+    "output.height": outputDimensions?.height,
+    "estimate.basis": outputSizeEstimate.basis,
+    "gif.frame_rate": format === "gif" ? gifSettings?.frameRate : undefined,
+    "gif.max_colors": format === "gif" ? gifSettings?.maxColors : undefined,
+    "gif.palette_mode":
+      format === "gif"
+        ? stringMetricAttribute(gifSettings?.paletteMode)
+        : undefined,
+    "gif.dither_mode":
+      format === "gif"
+        ? stringMetricAttribute(gifSettings?.ditherMode)
+        : undefined,
+  });
+}
+
+export function recordConvertExportStarted(
+  context: ConvertExportMetricContext,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  dependencies.metrics.count("convert.export.started", 1, {
+    attributes: buildConvertMetricAttributes(context),
+  });
+}
+
+export function recordConvertExportCompleted(
+  input: ConvertExportCompletedMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  const attributes = buildConvertMetricAttributes(input);
+  const estimateBytes = input.outputSizeEstimate.bytes;
+
+  dependencies.metrics.count("convert.export.completed", 1, { attributes });
+  recordDistribution(
+    dependencies.metrics,
+    "convert.source.size_bytes",
+    input.sourceFile.size,
+    "byte",
+    attributes,
+  );
+  recordDistribution(
+    dependencies.metrics,
+    "convert.source.duration_seconds",
+    input.probe.durationSeconds,
+    "second",
+    attributes,
+  );
+  recordDistribution(
+    dependencies.metrics,
+    "convert.estimate.bytes",
+    estimateBytes,
+    "byte",
+    attributes,
+  );
+  recordDistribution(
+    dependencies.metrics,
+    "convert.output.bytes",
+    input.actualBytes,
+    "byte",
+    attributes,
+  );
+  recordDistribution(
+    dependencies.metrics,
+    "convert.export.duration_ms",
+    input.durationMs,
+    "millisecond",
+    attributes,
+  );
+
+  if (typeof estimateBytes !== "number" || estimateBytes <= 0) {
+    return;
+  }
+
+  recordDistribution(
+    dependencies.metrics,
+    "convert.estimate.delta_bytes",
+    input.actualBytes - estimateBytes,
+    "byte",
+    attributes,
+  );
+  recordDistribution(
+    dependencies.metrics,
+    "convert.estimate.ratio",
+    Number((input.actualBytes / estimateBytes).toFixed(3)),
+    undefined,
+    attributes,
+  );
+}
+
+export function recordConvertExportFailed(
+  input: ConvertExportFailedMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  dependencies.metrics.count("convert.export.failed", 1, {
+    attributes: buildConvertMetricAttributes(input),
+  });
+}
+
+export function flushConvertMetrics(
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  return dependencies.flush(convertMetricsFlushTimeoutMs);
+}
+
+function compactMetricAttributes(
+  fields: Record<string, MetricAttributeValue | undefined>,
+) {
+  return Object.fromEntries(
+    Object.entries(fields).filter(
+      (entry): entry is [string, MetricAttributeValue] =>
+        entry[1] !== undefined,
+    ),
+  );
+}
+
+function recordDistribution(
+  metrics: ConvertMetricsClient,
+  name: string,
+  value: number | null | undefined,
+  unit: string | undefined,
+  attributes: Record<string, MetricAttributeValue>,
+) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return;
+  }
+
+  metrics.distribution(name, value, {
+    attributes,
+    ...(unit ? { unit } : {}),
+  });
+}
+
+function stringMetricAttribute(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}

--- a/functions/__cliparr/runtime-config.json.js
+++ b/functions/__cliparr/runtime-config.json.js
@@ -1,0 +1,18 @@
+function stringValue(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function onRequestGet({ env }) {
+  const sentryDsn = stringValue(env.SENTRY_DSN);
+
+  return Response.json(
+    {
+      sentryDsn: sentryDsn || null,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,7 +169,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: 1.0.0-rc.4-273829f
-        version: 1.0.0-rc.4-273829f(zod@4.4.3)
+        version: 1.0.0-rc.4-273829f(@opentelemetry/api@1.9.1)(zod@4.4.3)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -219,6 +219,9 @@ importers:
       '@mediabunny/ac3':
         specifier: ^1.49.0
         version: 1.49.0(mediabunny@1.49.0)
+      '@sentry/astro':
+        specifier: ^10.58.0
+        version: 10.58.0(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(rollup@4.62.0)
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1574,6 +1577,42 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.8.0':
+    resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.8.0':
+    resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -2865,6 +2904,150 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry/astro@10.58.0':
+    resolution: {integrity: sha512-V+F+2zFA01UZ6KzCaaMnSlB9/x2S/cKA8YxAxiDW4f3vrEly3bMBMc9Kh0mFHvMxMSpV7wEdxboNJX2AoIYZDQ==}
+    engines: {node: '>=18.19.1'}
+    peerDependencies:
+      astro: '>=3.x || >=4.0.0-beta || >=7.0.0-beta'
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.58.0':
+    resolution: {integrity: sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.58.0':
+    resolution: {integrity: sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.58.0':
+    resolution: {integrity: sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.58.0':
+    resolution: {integrity: sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.58.0':
+    resolution: {integrity: sha512-7dTbYuoaSwSmF2GWDl7KK+sXQL8iqaZeZ2I/aFm+SvPZLckZF3OGFb2VsluWsSXQLnxtxPX9QP93viyK+VZsuA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.58.0':
+    resolution: {integrity: sha512-KICgacBS+I/eWzFlAembutSwFwy0WVSrGp8UMV9n1XZqqu4EBTlALRsbLNlDSv61UgH85L9L3vk91tgq6nJXAA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.58.0':
+    resolution: {integrity: sha512-qKOGVmt02wDaq7E70VekG8Z9XM641trJPoTHSeVUfGaXVcmGc46ZldTNtfWbxJq/8f/fge2pap60gn066ido2Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/replay-canvas@10.58.0':
+    resolution: {integrity: sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.58.0':
+    resolution: {integrity: sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==}
+    engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/server-utils@10.58.0':
+    resolution: {integrity: sha512-PywIl2jvl+tO5R4j+n72Lcf3ItanHcaMN/oL1U9ZHE8icaT2zpo2W4uOaslpQeQvqPC24HGZ3BW2etzsCFQbag==}
+    engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
+    engines: {node: '>= 18'}
+
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
     engines: {node: '>=20'}
@@ -3390,6 +3573,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3608,6 +3796,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3996,6 +4187,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -4548,6 +4743,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
@@ -4664,6 +4863,10 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-in-the-middle@3.1.0:
+    resolution: {integrity: sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -5193,6 +5396,13 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   motion-dom@12.40.0:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
 
@@ -5244,6 +5454,15 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -5359,6 +5578,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -5437,6 +5660,10 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -5446,6 +5673,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -5643,6 +5873,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
@@ -5931,6 +6165,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6418,8 +6655,14 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -7656,6 +7899,41 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.1.0
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.135.0':
@@ -8736,6 +9014,165 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
+  '@sentry/astro@10.58.0(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(rollup@4.62.0)':
+    dependencies:
+      '@sentry/browser': 10.58.0
+      '@sentry/core': 10.58.0
+      '@sentry/node': 10.58.0
+      '@sentry/vite-plugin': 5.3.0(rollup@4.62.0)
+      astro: 6.4.8(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+
+  '@sentry/browser@10.58.0':
+    dependencies:
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
+      '@sentry/feedback': 10.58.0
+      '@sentry/replay': 10.58.0
+      '@sentry/replay-canvas': 10.58.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.58.0': {}
+
+  '@sentry/feedback@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+
+  '@sentry/node-core@10.58.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.58.0
+      '@sentry/opentelemetry': 10.58.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.1.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.58.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.58.0
+      '@sentry/node-core': 10.58.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.58.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/server-utils': 10.58.0
+      import-in-the-middle: 3.1.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.58.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.58.0
+
+  '@sentry/replay-canvas@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+      '@sentry/replay': 10.58.0
+
+  '@sentry/replay@10.58.0':
+    dependencies:
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
+
+  '@sentry/rollup-plugin@5.3.0(rollup@4.62.0)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/server-utils@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+
+  '@sentry/vite-plugin@5.3.0(rollup@4.62.0)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0(rollup@4.62.0)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@shikijs/core@4.2.0':
     dependencies:
       '@shikijs/primitive': 4.2.0
@@ -9366,6 +9803,10 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -9679,6 +10120,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -10061,6 +10504,8 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@16.6.1: {}
+
   dotenv@17.4.2: {}
 
   drizzle-kit@1.0.0-rc.4-273829f:
@@ -10071,8 +10516,9 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4-273829f(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4-273829f(@opentelemetry/api@1.9.1)(zod@4.4.3):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 
   dset@3.1.4: {}
@@ -10632,6 +11078,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@16.5.0: {}
 
   globals@17.6.0: {}
@@ -10845,6 +11297,13 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  import-in-the-middle@3.1.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
 
@@ -11590,6 +12049,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minipass@7.1.3: {}
+
+  module-details-from-path@1.0.4: {}
+
   motion-dom@12.40.0:
     dependencies:
       motion-utils: 12.39.0
@@ -11623,6 +12086,10 @@ snapshots:
       '@types/nlcst': 2.0.3
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-mock-http@1.0.4: {}
 
@@ -11785,6 +12252,11 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
@@ -11849,6 +12321,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  progress@2.0.3: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -11861,6 +12335,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -12158,6 +12634,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   reselect@5.2.0: {}
 
@@ -12578,6 +13061,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
@@ -12963,7 +13448,14 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-pm-runs@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ minimumReleaseAgeExclude:
   - "@techsquidtv/gifenc@1.1.0"
 
 allowBuilds:
+  "@sentry/cli": true
   esbuild: true
   sharp: true
   workerd: true

--- a/workers/cliparr-web.js
+++ b/workers/cliparr-web.js
@@ -1,0 +1,26 @@
+function stringValue(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export default {
+  fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/__cliparr/runtime-config.json") {
+      const sentryDsn = stringValue(env.SENTRY_DSN);
+
+      return Response.json(
+        {
+          sentryDsn: sentryDsn || null,
+        },
+        {
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        },
+      );
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,13 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "cliparr-web",
+  "main": "./workers/cliparr-web.js",
   "compatibility_date": "2026-05-28",
   "assets": {
     "directory": "./apps/www/dist",
+    "binding": "ASSETS",
     "html_handling": "auto-trailing-slash",
     "not_found_handling": "404-page",
+    "run_worker_first": ["/__cliparr/runtime-config.json"],
   },
 }


### PR DESCRIPTION
## Summary

- add Sentry Application Metrics for public convert exports with bounded attributes for format, quality, resolution, audio, estimator version, and GIF settings
- record started, completed, failed, source size/duration, estimate bytes, output bytes, delta, ratio, and export duration metrics
- move the Sentry DSN to runtime env via `SENTRY_DSN`, with runtime config endpoints for Pages and the configured Cloudflare Worker static-assets deployment

## Design Notes

- `apps/www/src/components/convert/convertMetrics.ts` keeps the metrics contract, source-format normalization, low-cardinality attributes, and privacy filtering in one place instead of scattering direct Sentry calls through `ConvertTool`.
- Centralizing this logic makes the convert UI responsible only for export lifecycle timing and results, while the metrics module owns which fields are safe to emit and guarantees file names, paths, URLs, media titles, raw errors, and other high-cardinality data stay out of Application Metrics.
- The small dependency wrapper around `Sentry.metrics` and `Sentry.flush` makes metric emission testable without initializing Sentry, touching global SDK state, or relying on network side effects. The unit tests can assert the exact metrics, units, estimate ratio/delta behavior, best-effort flush timeout, and omission of sensitive fields.

## Validation

- `pnpm preflight`
- `pnpm --filter @cliparr/www build`
- `pnpm exec wrangler deploy --dry-run --config wrangler.jsonc`

## Deployment Notes

- `SENTRY_DSN` was uploaded to the configured Cloudflare Worker `cliparr-web` with Wrangler.
- Wrangler did not show a Cliparr Pages project in the active Cloudflare account, so no Pages project variable was changed.