### PR TITLE
feat(www): make convert installable

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,7 +7,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "lint": "pnpm lint:eslint && pnpm lint:types",
-    "lint:eslint": "pnpm exec eslint \"src/**/*.astro\" \"src/**/*.{ts,tsx}\" \"scripts/**/*.ts\" \"astro.config.ts\" \"public/service-worker.js\"",
+    "lint:eslint": "pnpm exec eslint \"src/**/*.astro\" \"src/**/*.{ts,tsx}\" \"scripts/**/*.ts\" \"astro.config.ts\" \"public/**/*.js\"",
     "lint:types": "astro-check && tsc --noEmit --project tsconfig.scripts.json",
     "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "docs:sync": "tsx scripts/sync-readme.ts --write",

--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -3,6 +3,12 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
 
+/convert/service-worker.js
+  Cache-Control: no-cache
+
+/convert/manifest.webmanifest
+  Cache-Control: no-cache
+
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 

--- a/apps/www/public/convert/manifest.webmanifest
+++ b/apps/www/public/convert/manifest.webmanifest
@@ -1,0 +1,47 @@
+{
+  "id": "/convert",
+  "name": "Cliparr Convert",
+  "short_name": "Convert",
+  "description": "Convert local video files to MP4, WebM, MOV, MKV, or GIF entirely in your browser.",
+  "start_url": "/convert/",
+  "scope": "/convert/",
+  "display": "standalone",
+  "background_color": "#171717",
+  "theme_color": "#171717",
+  "categories": ["photo", "video", "utilities"],
+  "icons": [
+    {
+      "src": "/pwa-icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Convert Video",
+      "short_name": "Convert",
+      "description": "Open the local browser video converter.",
+      "url": "/convert/",
+      "icons": [
+        {
+          "src": "/pwa-icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/www/public/convert/service-worker.js
+++ b/apps/www/public/convert/service-worker.js
@@ -1,0 +1,145 @@
+const CACHE_PREFIX = "cliparr-convert-pwa";
+const CACHE_VERSION = "v1";
+const SHELL_CACHE = `${CACHE_PREFIX}-shell-${CACHE_VERSION}`;
+const ASSET_CACHE = `${CACHE_PREFIX}-assets-${CACHE_VERSION}`;
+const CONVERT_SHELL_URL = "/convert/";
+const APP_SHELL_URLS = [
+  CONVERT_SHELL_URL,
+  "/convert/manifest.webmanifest",
+  "/favicon.png",
+  "/pwa-icon-192.png",
+  "/pwa-icon-512.png",
+  "/pwa-maskable-512.png",
+  "/logo-light.svg",
+];
+
+function isConvertCache(cacheName) {
+  return cacheName.startsWith(`${CACHE_PREFIX}-`);
+}
+
+function isCurrentCache(cacheName) {
+  return cacheName === SHELL_CACHE || cacheName === ASSET_CACHE;
+}
+
+function isSameOrigin(url) {
+  return url.origin === self.location.origin;
+}
+
+function isConvertNavigationPath(pathname) {
+  return pathname === "/convert" || pathname.startsWith("/convert/");
+}
+
+function isNetworkOnlyPath(pathname) {
+  return (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/__cliparr/")
+  );
+}
+
+function isNavigationRequest(request) {
+  return (
+    request.mode === "navigate" ||
+    request.headers.get("accept")?.includes("text/html")
+  );
+}
+
+function isCacheableAssetRequest(request, url) {
+  if (!isSameOrigin(url) || isNetworkOnlyPath(url.pathname)) {
+    return false;
+  }
+
+  if (url.pathname.startsWith("/_astro/")) {
+    return true;
+  }
+
+  if (url.pathname.startsWith("/convert/")) {
+    return true;
+  }
+
+  return ["font", "image", "manifest", "script", "style"].includes(
+    request.destination,
+  );
+}
+
+async function cacheAppShell() {
+  const cache = await caches.open(SHELL_CACHE);
+  await cache.addAll(APP_SHELL_URLS);
+}
+
+async function deleteOldCaches() {
+  const cacheNames = await caches.keys();
+  await Promise.all(
+    cacheNames
+      .filter(
+        (cacheName) => isConvertCache(cacheName) && !isCurrentCache(cacheName),
+      )
+      .map((cacheName) => caches.delete(cacheName)),
+  );
+}
+
+async function networkFirstConvertNavigation(request) {
+  const cache = await caches.open(SHELL_CACHE);
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      await cache.put(CONVERT_SHELL_URL, response.clone());
+    }
+    return response;
+  } catch {
+    return (await cache.match(CONVERT_SHELL_URL)) || Response.error();
+  }
+}
+
+async function staleWhileRevalidateAsset(request) {
+  const cache = await caches.open(ASSET_CACHE);
+  const cachedResponse = await cache.match(request);
+  const networkResponsePromise = fetch(request)
+    .then((response) => {
+      if (response.ok) {
+        void cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => {});
+
+  return cachedResponse || (await networkResponsePromise) || Response.error();
+}
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(cacheAppShell().catch(() => {}));
+  globalThis.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    deleteOldCaches()
+      .catch(() => {})
+      .then(() => globalThis.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (!isSameOrigin(url) || isNetworkOnlyPath(url.pathname)) {
+    return;
+  }
+
+  if (isNavigationRequest(request)) {
+    if (isConvertNavigationPath(url.pathname)) {
+      event.respondWith(networkFirstConvertNavigation(request));
+    }
+    return;
+  }
+
+  if (isCacheableAssetRequest(request, url)) {
+    event.respondWith(staleWhileRevalidateAsset(request));
+  }
+});

--- a/apps/www/src/components/BaseLayout.astro
+++ b/apps/www/src/components/BaseLayout.astro
@@ -23,6 +23,9 @@ interface Props {
   socialImageType?: string;
   socialImageWidth?: number;
   structuredData?: StructuredDataInput;
+  manifestHref?: string | null;
+  appleTouchIconHref?: string | null;
+  appleMobileWebAppTitle?: string;
 }
 
 const {
@@ -36,6 +39,9 @@ const {
   socialImageType = site.ogImageType,
   socialImageWidth = site.ogImageWidth,
   structuredData,
+  manifestHref = null,
+  appleTouchIconHref = null,
+  appleMobileWebAppTitle,
 } = Astro.props;
 const pageTitleText = seoTitle ?? title;
 const pageTitle = pageTitleText
@@ -98,9 +104,24 @@ const structuredDataItems = [
     <meta name="twitter:image" content={socialImageUrl} />
     <meta name="twitter:image:alt" content={socialImageAlt} />
     <link rel="icon" href="/favicon.png" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    {manifestHref ? <link rel="manifest" href={manifestHref} /> : null}
     <meta name="theme-color" content="#171717" />
-    <link rel="apple-touch-icon" href="/pwa-icon-192.png" />
+    {
+      appleTouchIconHref ? (
+        <link rel="apple-touch-icon" href={appleTouchIconHref} />
+      ) : null
+    }
+    {
+      appleMobileWebAppTitle ? (
+        <>
+          <meta name="apple-mobile-web-app-capable" content="yes" />
+          <meta
+            name="apple-mobile-web-app-title"
+            content={appleMobileWebAppTitle}
+          />
+        </>
+      ) : null
+    }
     <title>{pageTitle}</title>
     {
       structuredDataItems.map((item) => (

--- a/apps/www/src/components/convert/ConvertPwaInstallPrompt.test.ts
+++ b/apps/www/src/components/convert/ConvertPwaInstallPrompt.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ConvertPwaInstallPromptView } from "@/components/convert/ConvertPwaInstallPrompt";
+
+void test("renders mobile native Convert PWA install prompt", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConvertPwaInstallPromptView, {
+      state: { formFactor: "mobile", mode: "native" },
+      onDismiss: () => {},
+      onInstall: () => {},
+    }),
+  );
+
+  assert.match(markup, /Add Cliparr Convert to your home screen/);
+  assert.match(markup, /data-convert-pwa-install-mode="native"/);
+  assert.match(markup, />Install</);
+});
+
+void test("renders mobile iOS Convert PWA install guide", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConvertPwaInstallPromptView, {
+      state: { formFactor: "mobile", mode: "ios" },
+      onDismiss: () => {},
+      onInstall: () => {},
+    }),
+  );
+
+  assert.match(markup, /Share menu/);
+  assert.match(markup, /Add to Home Screen/);
+  assert.match(markup, /data-convert-pwa-install-mode="ios"/);
+  assert.match(markup, />Share</);
+});
+
+void test("renders subtle desktop Convert PWA install button", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConvertPwaInstallPromptView, {
+      state: { formFactor: "desktop", mode: "native" },
+      onDismiss: () => {},
+      onInstall: () => {},
+    }),
+  );
+
+  assert.match(markup, /Install app/);
+  assert.match(markup, /data-convert-pwa-form-factor="desktop"/);
+  assert.doesNotMatch(markup, /Add Cliparr Convert to your home screen/);
+});
+
+void test("hides Convert PWA install prompt by default", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConvertPwaInstallPromptView, {
+      state: { formFactor: "desktop", mode: "hidden" },
+      onDismiss: () => {},
+      onInstall: () => {},
+    }),
+  );
+
+  assert.equal(markup, "");
+});

--- a/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
+++ b/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
@@ -1,0 +1,295 @@
+import { compactPrimaryButtonClasses } from "@cliparr/frontend/convert";
+import { Download, Share, Smartphone, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  flushConvertMetrics,
+  recordConvertPwaInstallPromptShown,
+} from "@/components/convert/convertMetrics";
+import {
+  CONVERT_COARSE_POINTER_MEDIA_QUERY,
+  CONVERT_MOBILE_INSTALL_MEDIA_QUERY,
+  CONVERT_STANDALONE_DISPLAY_MEDIA_QUERY,
+  getConvertPwaInstallEnvironment,
+  getDeferredConvertPwaInstallPrompt,
+  metricInputForConvertPwaInstallState,
+  promptForConvertPwaInstall,
+  readConvertPwaInstallDismissed,
+  recordConvertPwaInstallAccept,
+  recordConvertPwaInstallClick,
+  recordConvertPwaInstallDismiss,
+  registerConvertServiceWorker,
+  resolveConvertPwaInstallState,
+  startConvertPwaInstallPromptHandling,
+  subscribeToConvertPwaInstallPrompt,
+  writeConvertPwaInstallDismissed,
+  type BeforeInstallPromptEvent,
+  type ConvertPwaInstallState,
+} from "@/components/convert/convertPwa";
+
+startConvertPwaInstallPromptHandling();
+registerConvertServiceWorker();
+
+export interface ConvertPwaInstallPromptViewProps {
+  state: ConvertPwaInstallState;
+  prompting?: boolean;
+  onDismiss: () => void;
+  onInstall: () => void;
+}
+
+function addMediaQueryChangeListener(query: string, onChange: () => void) {
+  if (
+    globalThis.window === undefined ||
+    typeof globalThis.matchMedia !== "function"
+  ) {
+    return () => {};
+  }
+
+  const mediaQuery = globalThis.matchMedia(query);
+  const listener = () => onChange();
+
+  if (typeof mediaQuery.addEventListener === "function") {
+    mediaQuery.addEventListener("change", listener);
+    return () => mediaQuery.removeEventListener("change", listener);
+  }
+
+  mediaQuery.addListener(listener);
+  return () => mediaQuery.removeListener(listener);
+}
+
+function getCurrentConvertPwaInstallState(
+  installPrompt: BeforeInstallPromptEvent | null,
+  dismissed: boolean,
+): ConvertPwaInstallState {
+  if (globalThis.window === undefined || typeof navigator === "undefined") {
+    return { formFactor: "desktop", mode: "hidden" };
+  }
+
+  return resolveConvertPwaInstallState({
+    ...getConvertPwaInstallEnvironment(installPrompt),
+    dismissed,
+  });
+}
+
+export function ConvertPwaInstallPromptView({
+  state,
+  prompting = false,
+  onDismiss,
+  onInstall,
+}: ConvertPwaInstallPromptViewProps) {
+  if (state.mode === "hidden") {
+    return null;
+  }
+
+  if (state.formFactor === "desktop") {
+    return (
+      <div className="mt-5 hidden sm:flex">
+        <button
+          type="button"
+          onClick={onInstall}
+          disabled={prompting}
+          className="focus-ring inline-flex h-8 items-center justify-center gap-2 rounded-md border border-border bg-background px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          aria-label="Install Cliparr Convert"
+          title="Install Cliparr Convert"
+          data-convert-pwa-install-mode="native"
+          data-convert-pwa-form-factor="desktop"
+        >
+          <Download className="h-3.5 w-3.5" />
+          {prompting ? "Opening" : "Install app"}
+        </button>
+      </div>
+    );
+  }
+
+  const isIosGuide = state.mode === "ios";
+  const Icon = isIosGuide ? Share : Smartphone;
+
+  return (
+    <section
+      className="mt-5 rounded-lg border border-border bg-card p-3 text-card-foreground shadow-sm sm:hidden"
+      aria-label="Install Cliparr Convert"
+      data-convert-pwa-install-mode={state.mode}
+      data-convert-pwa-form-factor="mobile"
+    >
+      <div className="flex items-start gap-3">
+        <div className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <h2 className="text-sm font-semibold text-foreground">
+            Add Cliparr Convert to your home screen
+          </h2>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {isIosGuide
+              ? "Use the browser Share menu, then Add to Home Screen."
+              : "Install the converter for quick full-screen access and offline launches."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="focus-ring inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label="Dismiss install prompt"
+          title="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 pl-12">
+        {state.mode === "native" ? (
+          <button
+            type="button"
+            onClick={onInstall}
+            disabled={prompting}
+            className={compactPrimaryButtonClasses}
+          >
+            <Download className="h-4 w-4" />
+            {prompting ? "Opening" : "Install"}
+          </button>
+        ) : (
+          <span className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-background px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-foreground">
+            <Share className="h-4 w-4" />
+            Share
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function ConvertPwaInstallPrompt() {
+  const [installPrompt, setInstallPrompt] =
+    useState<BeforeInstallPromptEvent | null>(() =>
+      getDeferredConvertPwaInstallPrompt(),
+    );
+  const [dismissed, setDismissed] = useState(() =>
+    readConvertPwaInstallDismissed(),
+  );
+  const [state, setState] = useState<ConvertPwaInstallState>(() =>
+    getCurrentConvertPwaInstallState(
+      getDeferredConvertPwaInstallPrompt(),
+      readConvertPwaInstallDismissed(),
+    ),
+  );
+  const [prompting, setPrompting] = useState(false);
+  const shownMetricKeys = useRef(new Set<string>());
+
+  const refreshState = useCallback(
+    (nextInstallPrompt = installPrompt, nextDismissed = dismissed) => {
+      setState(
+        getCurrentConvertPwaInstallState(nextInstallPrompt, nextDismissed),
+      );
+    },
+    [dismissed, installPrompt],
+  );
+
+  useEffect(() => {
+    startConvertPwaInstallPromptHandling();
+    registerConvertServiceWorker();
+  }, []);
+
+  useEffect(() => {
+    return subscribeToConvertPwaInstallPrompt((nextInstallPrompt) => {
+      setInstallPrompt(nextInstallPrompt);
+      refreshState(nextInstallPrompt);
+    });
+  }, [refreshState]);
+
+  useEffect(() => {
+    const refresh = () => refreshState();
+    const cleanups = [
+      addMediaQueryChangeListener(CONVERT_MOBILE_INSTALL_MEDIA_QUERY, refresh),
+      addMediaQueryChangeListener(CONVERT_COARSE_POINTER_MEDIA_QUERY, refresh),
+      addMediaQueryChangeListener(
+        CONVERT_STANDALONE_DISPLAY_MEDIA_QUERY,
+        refresh,
+      ),
+    ];
+
+    window.addEventListener("resize", refresh);
+    globalThis.addEventListener("orientationchange", refresh);
+
+    return () => {
+      for (const cleanup of cleanups) {
+        cleanup();
+      }
+      window.removeEventListener("resize", refresh);
+      globalThis.removeEventListener("orientationchange", refresh);
+    };
+  }, [refreshState]);
+
+  useEffect(() => {
+    const input = metricInputForConvertPwaInstallState(state);
+    if (!input) {
+      return;
+    }
+
+    const metricKey = `${input.formFactor}:${input.installMode}`;
+    if (shownMetricKeys.current.has(metricKey)) {
+      return;
+    }
+
+    shownMetricKeys.current.add(metricKey);
+    recordConvertPwaInstallPromptShown(input);
+    void flushConvertMetrics();
+  }, [state]);
+
+  const dismiss = useCallback(() => {
+    const input = metricInputForConvertPwaInstallState(state);
+    if (input) {
+      recordConvertPwaInstallDismiss(input);
+    }
+
+    writeConvertPwaInstallDismissed(true);
+    setDismissed(true);
+    refreshState(installPrompt, true);
+  }, [installPrompt, refreshState, state]);
+
+  const install = useCallback(async () => {
+    if (!installPrompt) {
+      return;
+    }
+
+    const input = metricInputForConvertPwaInstallState(state);
+    if (input) {
+      recordConvertPwaInstallClick(input);
+    }
+
+    setPrompting(true);
+    try {
+      const result = await promptForConvertPwaInstall(installPrompt);
+      setInstallPrompt(null);
+
+      if (!result) {
+        refreshState(null);
+        return;
+      }
+
+      if (result.outcome === "accepted") {
+        if (input) {
+          recordConvertPwaInstallAccept(input);
+        }
+        refreshState(null);
+        return;
+      }
+
+      if (input) {
+        recordConvertPwaInstallDismiss(input);
+      }
+      writeConvertPwaInstallDismissed(true);
+      setDismissed(true);
+      refreshState(null, true);
+    } finally {
+      setPrompting(false);
+    }
+  }, [installPrompt, refreshState, state]);
+
+  return (
+    <ConvertPwaInstallPromptView
+      state={state}
+      prompting={prompting}
+      onDismiss={dismiss}
+      onInstall={() => void install()}
+    />
+  );
+}

--- a/apps/www/src/components/convert/convertMetrics.test.ts
+++ b/apps/www/src/components/convert/convertMetrics.test.ts
@@ -6,6 +6,12 @@ import {
   normalizeConvertSourceFormat,
   recordConvertExportCompleted,
   recordConvertExportFailed,
+  recordConvertPwaInstallAccepted,
+  recordConvertPwaInstallClicked,
+  recordConvertPwaInstallDismissed,
+  recordConvertPwaInstalled,
+  recordConvertPwaInstallPromptAvailable,
+  recordConvertPwaInstallPromptShown,
   type ConvertMetricsDependencies,
 } from "@/components/convert/convertMetrics";
 
@@ -187,10 +193,75 @@ void test("failed convert metrics omit raw error and file details", () => {
   assert.doesNotMatch(serializedCalls, /S01E02/);
 });
 
-void test("convert metric flushing uses the short best-effort timeout", () => {
+void test("convert metric flushing uses the short best-effort timeout", async () => {
   const { dependencies, flushTimeouts } = createMetricRecorder();
 
-  void flushConvertMetrics(dependencies);
+  assert.equal(await flushConvertMetrics(dependencies), true);
 
   assert.deepEqual(flushTimeouts, [2000]);
+});
+
+void test("PWA install metrics stay bounded", () => {
+  const { calls, dependencies } = createMetricRecorder();
+  const input = {
+    formFactor: "mobile" as const,
+    installMode: "native" as const,
+  };
+
+  recordConvertPwaInstallPromptAvailable(input, dependencies);
+  recordConvertPwaInstallPromptShown(input, dependencies);
+  recordConvertPwaInstallClicked(input, dependencies);
+  recordConvertPwaInstallAccepted(input, dependencies);
+  recordConvertPwaInstallDismissed(input, dependencies);
+  recordConvertPwaInstalled(input, dependencies);
+
+  assert.equal(
+    metricCall(calls, "convert.pwa.install.prompt.available").value,
+    1,
+  );
+  assert.equal(metricCall(calls, "convert.pwa.install.prompt.shown").value, 1);
+  assert.equal(metricCall(calls, "convert.pwa.install.clicked").value, 1);
+  assert.equal(metricCall(calls, "convert.pwa.install.accepted").value, 1);
+  assert.equal(metricCall(calls, "convert.pwa.install.dismissed").value, 1);
+  assert.equal(metricCall(calls, "convert.pwa.installed").value, 1);
+
+  const attributes = metricCall(calls, "convert.pwa.install.prompt.available")
+    .options?.attributes;
+  assert.deepEqual(attributes, {
+    surface: "www.convert",
+    form_factor: "mobile",
+    install_mode: "native",
+  });
+});
+
+void test("metric calls are best effort when the metrics client fails", async () => {
+  const dependencies: ConvertMetricsDependencies = {
+    metrics: {
+      count: () => {
+        throw new Error("metrics unavailable");
+      },
+      distribution: () => {
+        throw new Error("metrics unavailable");
+      },
+    },
+    flush: () => {
+      throw new Error("flush unavailable");
+    },
+  };
+
+  assert.doesNotThrow(() => {
+    recordConvertExportCompleted(
+      {
+        ...createMetricContext(),
+        actualBytes: 1100,
+        durationMs: 2500,
+      },
+      dependencies,
+    );
+    recordConvertPwaInstallClicked(
+      { formFactor: "desktop", installMode: "native" },
+      dependencies,
+    );
+  });
+  assert.equal(await flushConvertMetrics(dependencies), false);
 });

--- a/apps/www/src/components/convert/convertMetrics.ts
+++ b/apps/www/src/components/convert/convertMetrics.ts
@@ -63,6 +63,14 @@ interface ConvertExportFailedMetricInput extends ConvertExportMetricContext {
   durationMs: number;
 }
 
+export type ConvertPwaInstallFormFactor = "desktop" | "mobile";
+type ConvertPwaInstallMode = "ios" | "native";
+
+export interface ConvertPwaInstallMetricInput {
+  formFactor: ConvertPwaInstallFormFactor;
+  installMode: ConvertPwaInstallMode;
+}
+
 const convertMetricsFlushTimeoutMs = 2000;
 const defaultConvertMetricsDependencies: ConvertMetricsDependencies = {
   metrics: Sentry.metrics,
@@ -167,9 +175,11 @@ export function recordConvertExportStarted(
   context: ConvertExportMetricContext,
   dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
 ) {
-  dependencies.metrics.count("convert.export.started", 1, {
-    attributes: buildConvertMetricAttributes(context),
-  });
+  recordCount(
+    dependencies.metrics,
+    "convert.export.started",
+    buildConvertMetricAttributes(context),
+  );
 }
 
 export function recordConvertExportCompleted(
@@ -179,7 +189,7 @@ export function recordConvertExportCompleted(
   const attributes = buildConvertMetricAttributes(input);
   const estimateBytes = input.outputSizeEstimate.bytes;
 
-  dependencies.metrics.count("convert.export.completed", 1, { attributes });
+  recordCount(dependencies.metrics, "convert.export.completed", attributes);
   recordDistribution(
     dependencies.metrics,
     "convert.source.size_bytes",
@@ -240,15 +250,83 @@ export function recordConvertExportFailed(
   input: ConvertExportFailedMetricInput,
   dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
 ) {
-  dependencies.metrics.count("convert.export.failed", 1, {
-    attributes: buildConvertMetricAttributes(input),
-  });
+  recordCount(
+    dependencies.metrics,
+    "convert.export.failed",
+    buildConvertMetricAttributes(input),
+  );
 }
 
-export function flushConvertMetrics(
+export async function flushConvertMetrics(
   dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
 ) {
-  return dependencies.flush(convertMetricsFlushTimeoutMs);
+  try {
+    return await dependencies.flush(convertMetricsFlushTimeoutMs);
+  } catch {
+    return false;
+  }
+}
+
+export function recordConvertPwaInstallPromptAvailable(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric(
+    "convert.pwa.install.prompt.available",
+    input,
+    dependencies,
+  );
+}
+
+export function recordConvertPwaInstallPromptShown(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric(
+    "convert.pwa.install.prompt.shown",
+    input,
+    dependencies,
+  );
+}
+
+export function recordConvertPwaInstallClicked(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric(
+    "convert.pwa.install.clicked",
+    input,
+    dependencies,
+  );
+}
+
+export function recordConvertPwaInstallAccepted(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric(
+    "convert.pwa.install.accepted",
+    input,
+    dependencies,
+  );
+}
+
+export function recordConvertPwaInstallDismissed(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric(
+    "convert.pwa.install.dismissed",
+    input,
+    dependencies,
+  );
+}
+
+export function recordConvertPwaInstalled(
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies = defaultConvertMetricsDependencies,
+) {
+  recordConvertPwaInstallMetric("convert.pwa.installed", input, dependencies);
 }
 
 function compactMetricAttributes(
@@ -262,6 +340,30 @@ function compactMetricAttributes(
   );
 }
 
+function recordConvertPwaInstallMetric(
+  name: string,
+  input: ConvertPwaInstallMetricInput,
+  dependencies: ConvertMetricsDependencies,
+) {
+  recordCount(dependencies.metrics, name, {
+    surface: "www.convert",
+    form_factor: input.formFactor,
+    install_mode: input.installMode,
+  });
+}
+
+function recordCount(
+  metrics: ConvertMetricsClient,
+  name: string,
+  attributes: Record<string, MetricAttributeValue>,
+) {
+  try {
+    metrics.count(name, 1, { attributes });
+  } catch {
+    return;
+  }
+}
+
 function recordDistribution(
   metrics: ConvertMetricsClient,
   name: string,
@@ -273,10 +375,14 @@ function recordDistribution(
     return;
   }
 
-  metrics.distribution(name, value, {
-    attributes,
-    ...(unit ? { unit } : {}),
-  });
+  try {
+    metrics.distribution(name, value, {
+      attributes,
+      ...(unit ? { unit } : {}),
+    });
+  } catch {
+    return;
+  }
 }
 
 function stringMetricAttribute(value: unknown) {

--- a/apps/www/src/components/convert/convertPwa.test.ts
+++ b/apps/www/src/components/convert/convertPwa.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  isIosLikeDevice,
+  metricInputForConvertPwaInstallState,
+  readConvertPwaInstallDismissed,
+  resolveConvertPwaInstallState,
+  writeConvertPwaInstallDismissed,
+  type ConvertPwaInstallEnvironment,
+} from "@/components/convert/convertPwa";
+
+function installEnvironment(
+  overrides: Partial<ConvertPwaInstallEnvironment> = {},
+): ConvertPwaInstallEnvironment {
+  return {
+    appInstalled: false,
+    coarsePointer: true,
+    dismissed: false,
+    hasInstallPrompt: true,
+    isSecureContext: true,
+    maxTouchPoints: 5,
+    mobileViewport: true,
+    navigatorStandalone: false,
+    standaloneDisplayMode: false,
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/125 Mobile Safari/537.36",
+    ...overrides,
+  };
+}
+
+function desktopEnvironment(
+  overrides: Partial<ConvertPwaInstallEnvironment> = {},
+): ConvertPwaInstallEnvironment {
+  return installEnvironment({
+    coarsePointer: false,
+    maxTouchPoints: 0,
+    mobileViewport: false,
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 Chrome/125 Safari/537.36",
+    ...overrides,
+  });
+}
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    key(index) {
+      return [...values.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
+}
+
+void test("allows native Convert PWA install UI on secure mobile surfaces", () => {
+  assert.deepEqual(resolveConvertPwaInstallState(installEnvironment()), {
+    formFactor: "mobile",
+    mode: "native",
+  });
+});
+
+void test("uses iOS guide mode when native install prompts are unavailable", () => {
+  assert.deepEqual(
+    resolveConvertPwaInstallState(
+      installEnvironment({
+        hasInstallPrompt: false,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1",
+      }),
+    ),
+    { formFactor: "mobile", mode: "ios" },
+  );
+  assert.equal(
+    isIosLikeDevice("Mozilla/5.0 (Macintosh; Intel Mac OS X)", 5),
+    true,
+  );
+});
+
+void test("keeps desktop install UI subtle and prompt-gated", () => {
+  assert.deepEqual(resolveConvertPwaInstallState(desktopEnvironment()), {
+    formFactor: "desktop",
+    mode: "native",
+  });
+  assert.deepEqual(
+    resolveConvertPwaInstallState(
+      desktopEnvironment({ hasInstallPrompt: false }),
+    ),
+    { formFactor: "desktop", mode: "hidden" },
+  );
+});
+
+void test("hides Convert PWA install UI when unavailable or already handled", () => {
+  for (const overrides of [
+    { dismissed: true },
+    { isSecureContext: false },
+    { appInstalled: true },
+    { navigatorStandalone: true },
+    { standaloneDisplayMode: true },
+  ] satisfies Array<Partial<ConvertPwaInstallEnvironment>>) {
+    assert.equal(
+      resolveConvertPwaInstallState(installEnvironment(overrides)).mode,
+      "hidden",
+    );
+  }
+});
+
+void test("persists Convert PWA install dismissal state", () => {
+  const storage = memoryStorage();
+
+  assert.equal(readConvertPwaInstallDismissed(storage), false);
+  writeConvertPwaInstallDismissed(true, storage);
+  assert.equal(readConvertPwaInstallDismissed(storage), true);
+  writeConvertPwaInstallDismissed(false, storage);
+  assert.equal(readConvertPwaInstallDismissed(storage), false);
+});
+
+void test("maps visible install states to bounded metric input", () => {
+  assert.deepEqual(
+    metricInputForConvertPwaInstallState({
+      formFactor: "mobile",
+      mode: "ios",
+    }),
+    { formFactor: "mobile", installMode: "ios" },
+  );
+  assert.equal(
+    metricInputForConvertPwaInstallState({
+      formFactor: "desktop",
+      mode: "hidden",
+    }),
+    null,
+  );
+});
+
+void test("defines the Convert PWA as a separate manifest identity", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      new URL("../../../public/convert/manifest.webmanifest", import.meta.url),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+
+  assert.equal(manifest.id, "/convert");
+  assert.equal(manifest.name, "Cliparr Convert");
+  assert.equal(manifest.start_url, "/convert/");
+  assert.equal(manifest.scope, "/convert/");
+});

--- a/apps/www/src/components/convert/convertPwa.ts
+++ b/apps/www/src/components/convert/convertPwa.ts
@@ -1,0 +1,356 @@
+import {
+  flushConvertMetrics,
+  recordConvertPwaInstallAccepted,
+  recordConvertPwaInstallClicked,
+  recordConvertPwaInstallDismissed,
+  recordConvertPwaInstalled,
+  recordConvertPwaInstallPromptAvailable,
+  type ConvertPwaInstallFormFactor,
+  type ConvertPwaInstallMetricInput,
+} from "@/components/convert/convertMetrics";
+
+const CONVERT_PWA_INSTALL_DISMISSED_KEY =
+  "cliparr-convert:pwa-install-dismissed";
+const CONVERT_PWA_SERVICE_WORKER_URL = "/convert/service-worker.js";
+const CONVERT_PWA_SERVICE_WORKER_SCOPE = "/convert/";
+export const CONVERT_MOBILE_INSTALL_MEDIA_QUERY = "(max-width: 639.98px)";
+export const CONVERT_COARSE_POINTER_MEDIA_QUERY = "(pointer: coarse)";
+export const CONVERT_STANDALONE_DISPLAY_MEDIA_QUERY =
+  "(display-mode: standalone)";
+
+type ConvertPwaInstallPromptMode = "hidden" | "ios" | "native";
+type ConvertPwaInstallPromptListener = (
+  installPrompt: BeforeInstallPromptEvent | null,
+) => void;
+
+let deferredInstallPrompt: BeforeInstallPromptEvent | null = null;
+let installPromptHandlingStarted = false;
+let serviceWorkerRegistrationStarted = false;
+let appInstalled = false;
+let lastNativeInstallMetricInput: ConvertPwaInstallMetricInput | null = null;
+const installPromptListeners = new Set<ConvertPwaInstallPromptListener>();
+
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms?: string[];
+  readonly userChoice?: Promise<{
+    outcome: "accepted" | "dismissed";
+    platform: string;
+  }>;
+  prompt: () => Promise<void>;
+}
+
+export interface ConvertPwaInstallEnvironment {
+  readonly appInstalled: boolean;
+  readonly coarsePointer: boolean;
+  readonly dismissed: boolean;
+  readonly hasInstallPrompt: boolean;
+  readonly isSecureContext: boolean;
+  readonly maxTouchPoints: number;
+  readonly mobileViewport: boolean;
+  readonly navigatorStandalone: boolean;
+  readonly standaloneDisplayMode: boolean;
+  readonly userAgent: string;
+}
+
+export interface ConvertPwaInstallState {
+  readonly formFactor: ConvertPwaInstallFormFactor;
+  readonly mode: ConvertPwaInstallPromptMode;
+}
+
+interface NavigatorWithStandalone extends Navigator {
+  readonly standalone?: boolean;
+}
+
+function safeLocalStorage() {
+  try {
+    const storage = globalThis.localStorage;
+    return typeof storage?.getItem === "function" ? storage : undefined;
+  } catch {
+    return;
+  }
+}
+
+function safeMatchMedia(query: string) {
+  const browserWindow = globalThis.window;
+  if (
+    browserWindow === undefined ||
+    typeof browserWindow.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return browserWindow.matchMedia(query).matches;
+}
+
+function notifyInstallPromptListeners() {
+  for (const listener of installPromptListeners) {
+    listener(deferredInstallPrompt);
+  }
+}
+
+function metricInputForCurrentEnvironment(): ConvertPwaInstallMetricInput {
+  return {
+    formFactor:
+      safeMatchMedia(CONVERT_MOBILE_INSTALL_MEDIA_QUERY) &&
+      isMobilePwaDevice(navigator.userAgent, navigator.maxTouchPoints ?? 0)
+        ? "mobile"
+        : "desktop",
+    installMode: "native",
+  };
+}
+
+function recordAndFlush(
+  recorder: (input: ConvertPwaInstallMetricInput) => void,
+  input: ConvertPwaInstallMetricInput,
+) {
+  recorder(input);
+  void flushConvertMetrics();
+}
+
+export function getDeferredConvertPwaInstallPrompt() {
+  return deferredInstallPrompt;
+}
+
+export function subscribeToConvertPwaInstallPrompt(
+  listener: ConvertPwaInstallPromptListener,
+) {
+  listener(deferredInstallPrompt);
+  installPromptListeners.add(listener);
+
+  return () => {
+    installPromptListeners.delete(listener);
+  };
+}
+
+export function startConvertPwaInstallPromptHandling() {
+  const browserWindow = globalThis.window;
+  if (
+    installPromptHandlingStarted ||
+    browserWindow === undefined ||
+    typeof browserWindow.addEventListener !== "function"
+  ) {
+    return;
+  }
+
+  installPromptHandlingStarted = true;
+
+  browserWindow.addEventListener("beforeinstallprompt", (event) => {
+    event.preventDefault();
+    deferredInstallPrompt = event as BeforeInstallPromptEvent;
+    lastNativeInstallMetricInput = metricInputForCurrentEnvironment();
+    recordAndFlush(
+      recordConvertPwaInstallPromptAvailable,
+      lastNativeInstallMetricInput,
+    );
+    notifyInstallPromptListeners();
+  });
+
+  browserWindow.addEventListener("appinstalled", () => {
+    appInstalled = true;
+    deferredInstallPrompt = null;
+    recordAndFlush(
+      recordConvertPwaInstalled,
+      lastNativeInstallMetricInput ?? metricInputForCurrentEnvironment(),
+    );
+    notifyInstallPromptListeners();
+  });
+}
+
+export function registerConvertServiceWorker(
+  production = Boolean(import.meta.env?.PROD),
+) {
+  const browserWindow = globalThis.window;
+  if (
+    serviceWorkerRegistrationStarted ||
+    !production ||
+    browserWindow === undefined ||
+    !browserWindow.isSecureContext ||
+    !("serviceWorker" in navigator)
+  ) {
+    return;
+  }
+
+  serviceWorkerRegistrationStarted = true;
+
+  if (document.readyState === "complete") {
+    registerConvertServiceWorkerNow();
+    return;
+  }
+
+  browserWindow.addEventListener("load", registerConvertServiceWorkerNow, {
+    once: true,
+  });
+}
+
+function registerConvertServiceWorkerNow() {
+  void navigator.serviceWorker
+    .register(CONVERT_PWA_SERVICE_WORKER_URL, {
+      scope: CONVERT_PWA_SERVICE_WORKER_SCOPE,
+    })
+    .then((registration) => registration.update().catch(() => {}))
+    .catch(() => {});
+}
+
+export async function promptForConvertPwaInstall(
+  installPrompt: BeforeInstallPromptEvent | null = deferredInstallPrompt,
+) {
+  if (!installPrompt) {
+    return null;
+  }
+
+  try {
+    await installPrompt.prompt();
+    return (await installPrompt.userChoice?.catch(() => null)) ?? null;
+  } catch {
+    return null;
+  } finally {
+    if (installPrompt === deferredInstallPrompt) {
+      deferredInstallPrompt = null;
+      notifyInstallPromptListeners();
+    }
+  }
+}
+
+export function readConvertPwaInstallDismissed(storage = safeLocalStorage()) {
+  return storage?.getItem(CONVERT_PWA_INSTALL_DISMISSED_KEY) === "true";
+}
+
+export function writeConvertPwaInstallDismissed(
+  dismissed: boolean,
+  storage = safeLocalStorage(),
+) {
+  if (!storage) {
+    return;
+  }
+
+  if (dismissed) {
+    storage.setItem(CONVERT_PWA_INSTALL_DISMISSED_KEY, "true");
+    return;
+  }
+
+  storage.removeItem(CONVERT_PWA_INSTALL_DISMISSED_KEY);
+}
+
+export function isIosLikeDevice(userAgent: string, maxTouchPoints: number) {
+  return (
+    /\b(ipad|iphone|ipod)\b/i.test(userAgent) ||
+    (/\bmacintosh\b/i.test(userAgent) && maxTouchPoints > 1)
+  );
+}
+
+function isMobilePwaDevice(userAgent: string, maxTouchPoints: number) {
+  return (
+    maxTouchPoints > 0 &&
+    (/\b(android|webos|iphone|ipad|ipod|iemobile|opera mini)\b/i.test(
+      userAgent,
+    ) ||
+      isIosLikeDevice(userAgent, maxTouchPoints))
+  );
+}
+
+function isStandalonePwa(environment: ConvertPwaInstallEnvironment) {
+  return (
+    environment.appInstalled ||
+    environment.standaloneDisplayMode ||
+    environment.navigatorStandalone
+  );
+}
+
+function hiddenState(
+  environment: ConvertPwaInstallEnvironment,
+): ConvertPwaInstallState {
+  return {
+    formFactor:
+      environment.mobileViewport &&
+      isMobilePwaDevice(environment.userAgent, environment.maxTouchPoints)
+        ? "mobile"
+        : "desktop",
+    mode: "hidden",
+  };
+}
+
+export function resolveConvertPwaInstallState(
+  environment: ConvertPwaInstallEnvironment,
+): ConvertPwaInstallState {
+  const isMobileDevice = isMobilePwaDevice(
+    environment.userAgent,
+    environment.maxTouchPoints,
+  );
+  const formFactor: ConvertPwaInstallFormFactor =
+    environment.mobileViewport && isMobileDevice ? "mobile" : "desktop";
+
+  if (
+    environment.dismissed ||
+    !environment.isSecureContext ||
+    isStandalonePwa(environment)
+  ) {
+    return hiddenState(environment);
+  }
+
+  if (formFactor === "mobile") {
+    if (environment.hasInstallPrompt) {
+      return { formFactor, mode: "native" };
+    }
+
+    if (
+      environment.coarsePointer &&
+      isIosLikeDevice(environment.userAgent, environment.maxTouchPoints)
+    ) {
+      return { formFactor, mode: "ios" };
+    }
+
+    return { formFactor, mode: "hidden" };
+  }
+
+  return environment.hasInstallPrompt
+    ? { formFactor, mode: "native" }
+    : { formFactor, mode: "hidden" };
+}
+
+export function getConvertPwaInstallEnvironment(
+  installPrompt: BeforeInstallPromptEvent | null,
+): ConvertPwaInstallEnvironment {
+  const navigatorWithStandalone = navigator as NavigatorWithStandalone;
+  const browserWindow = globalThis.window;
+
+  return {
+    appInstalled,
+    coarsePointer: safeMatchMedia(CONVERT_COARSE_POINTER_MEDIA_QUERY),
+    dismissed: readConvertPwaInstallDismissed(),
+    hasInstallPrompt: Boolean(installPrompt),
+    isSecureContext: browserWindow.isSecureContext,
+    maxTouchPoints: navigator.maxTouchPoints ?? 0,
+    mobileViewport: safeMatchMedia(CONVERT_MOBILE_INSTALL_MEDIA_QUERY),
+    navigatorStandalone: navigatorWithStandalone.standalone === true,
+    standaloneDisplayMode: safeMatchMedia(
+      CONVERT_STANDALONE_DISPLAY_MEDIA_QUERY,
+    ),
+    userAgent: navigator.userAgent,
+  };
+}
+
+export function metricInputForConvertPwaInstallState(
+  state: ConvertPwaInstallState,
+): ConvertPwaInstallMetricInput | null {
+  return state.mode === "hidden"
+    ? null
+    : { formFactor: state.formFactor, installMode: state.mode };
+}
+
+export function recordConvertPwaInstallClick(
+  input: ConvertPwaInstallMetricInput,
+) {
+  recordAndFlush(recordConvertPwaInstallClicked, input);
+}
+
+export function recordConvertPwaInstallAccept(
+  input: ConvertPwaInstallMetricInput,
+) {
+  recordAndFlush(recordConvertPwaInstallAccepted, input);
+}
+
+export function recordConvertPwaInstallDismiss(
+  input: ConvertPwaInstallMetricInput,
+) {
+  recordAndFlush(recordConvertPwaInstallDismissed, input);
+}

--- a/apps/www/src/pages/convert.astro
+++ b/apps/www/src/pages/convert.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/components/BaseLayout.astro";
+import { ConvertPwaInstallPrompt } from "@/components/convert/ConvertPwaInstallPrompt";
 import { ConvertTool } from "@/components/convert/ConvertTool";
 import { site } from "@/data/product";
 import {
@@ -50,6 +51,9 @@ const structuredData = {
   title="Convert"
   seoTitle="Convert Video: MP4, WebM, MKV, MOV, and GIF"
   description={description}
+  manifestHref="/convert/manifest.webmanifest"
+  appleTouchIconHref="/pwa-icon-192.png"
+  appleMobileWebAppTitle="Cliparr Convert"
   structuredData={structuredData}
 >
   <main class="bg-background text-foreground">
@@ -63,6 +67,7 @@ const structuredData = {
           <p class="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
             {description}
           </p>
+          <ConvertPwaInstallPrompt client:load />
         </div>
 
         <div class="mt-7">

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -384,7 +384,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ["apps/*/public/service-worker.js"],
+    files: ["apps/*/public/**/service-worker.js"],
     languageOptions: {
       globals: {
         ...globals.serviceworker,


### PR DESCRIPTION
## Summary
- make /convert its own installable PWA with a dedicated manifest and scoped service worker
- add mobile install UI, iOS guidance, and a subtle desktop install button
- add bounded best-effort Sentry metrics for install events while preserving offline conversion support

## Validation
- pnpm --filter @cliparr/www test
- pnpm --filter @cliparr/www lint
- pnpm build:web
- pnpm preflight

## Notes
- The service worker is scoped to /convert/ and leaves non-convert navigations, runtime config, and API-style requests network-only.
- Existing blog branch changes were left out of this branch.