### PR TITLE
fix(frontend): guard export decoder support

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -318,7 +318,7 @@ flowchart TD
     A3 --> B["User clicks Export"]
     B --> B1["useEditorExport resolves source/options and lazy-loads exportClip"]
     B1 --> C{"Output format is GIF?"}
-    C -- "Yes" --> D["Build fresh Mediabunny input and CanvasSink from export source"]
+    C -- "Yes" --> D["Build fresh Mediabunny input and assert source video is decodable before CanvasSink setup"]
     D --> E["Apply GIF Quality control as max height, frame rate, color count, palette mode, and dither settings"]
     E --> F["Draw frames with high-quality canvas scaling and burn subtitles when enabled"]
     F --> G{"Preset uses a stable sampled palette?"}
@@ -331,7 +331,8 @@ flowchart TD
     G5 --> G6["Return image/gif Blob"]
 
     C -- "No" --> H["exportClip builds fresh Mediabunny input from export source URL"]
-    H --> I["exportMetadata builds tags and artwork when metadata exists"]
+    H --> H1["Assert selected source video is decodable when conversion needs decoded frames"]
+    H1 --> I["exportMetadata builds tags and artwork when metadata exists"]
     I --> J["Create Output(BufferTarget)"]
     J --> K["Build conversion options for source video, selected audio, trim, resolution, tags, optional subtitles, and video quality"]
     K --> K1{"Video quality is Compact or Balanced?"}

--- a/apps/frontend/src/components/editor/editorPlaybackSources.ts
+++ b/apps/frontend/src/components/editor/editorPlaybackSources.ts
@@ -4,7 +4,11 @@ import {
   isHlsEditorMediaSource,
   type EditorMediaSource,
 } from "@/lib/editorMedia";
-import { getTrackCodec } from "@/lib/mediabunnyTrackAccess";
+import {
+  assessVideoTrackDecodability,
+  getTrackCodec,
+  videoTrackPreviewUnavailableMessage,
+} from "@/lib/mediabunnyTrackAccess";
 import type { PlaybackAudioSelection } from "@/providers/types";
 import {
   errorMessage,
@@ -251,18 +255,11 @@ async function assessPreviewVideoTrack(track: InputVideoTrack | null) {
     return { track: null, warning: undefined };
   }
 
-  const videoCodec = await getTrackCodec(track);
-  if (videoCodec === null) {
+  const decodability = await assessVideoTrackDecodability(track);
+  if (decodability.codec === null || !decodability.canDecode) {
     return {
       track: null,
-      warning: "Video codec is unknown.",
-    };
-  }
-
-  if (!(await track.canDecode())) {
-    return {
-      track: null,
-      warning: `Cannot decode ${videoCodec} video in this browser.`,
+      warning: videoTrackPreviewUnavailableMessage(decodability),
     };
   }
 

--- a/apps/frontend/src/convert.ts
+++ b/apps/frontend/src/convert.ts
@@ -37,8 +37,10 @@ export {
 } from "./lib/editorMedia";
 export { createCliparrInputFromSource } from "./lib/mediabunnyInput";
 export {
+  assessVideoTrackDecodability,
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
+  videoTrackPreviewUnavailableMessage,
 } from "./lib/mediabunnyTrackAccess";
 export type { MediaExportMetadata } from "./providers/types";
 export {

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -95,6 +95,9 @@ function createRuntime(overrides: Partial<ExportRuntime> = {}) {
     id: "video-1",
     hasOnlyKeyPackets: async () => false,
     canBeTransparent: async () => false,
+    canDecode: async () => true,
+    getFirstTimestamp: async () => 0,
+    getCodec: async () => "avc",
   };
   const audioTrack = {
     id: "audio-1",
@@ -129,7 +132,10 @@ function createRuntime(overrides: Partial<ExportRuntime> = {}) {
     describeDiscardedTracks: async () => "",
     patchMp4MetadataBoxes: () => {},
     createOutputFormat: () =>
-      ({ mimeType: "video/mp4" }) as unknown as OutputFormat,
+      ({
+        mimeType: "video/mp4",
+        getSupportedVideoCodecs: () => ["avc", "hevc", "vp9", "av1", "vp8"],
+      }) as unknown as OutputFormat,
     createBufferTarget: () => target as unknown as BufferTargetResult,
     createOutput: (options) => ({ options }) as unknown as OutputResult,
     createCanvasSink: () =>
@@ -437,6 +443,68 @@ void test("fails before execution when conversion would drop source audio", asyn
   assert.equal(context.disposed, true);
 });
 
+void test("fails before initializing video conversion when the source video codec cannot decode", async () => {
+  const context = createRuntime({
+    initConversion: async () => {
+      throw new Error("conversion should not initialize");
+    },
+  });
+  context.videoTrack.getCodec = async () => "vp9";
+  context.videoTrack.canDecode = async () => false;
+
+  await assert.rejects(
+    () =>
+      exportClipWithRuntime(
+        {
+          mediaSource,
+          startTime: 0,
+          endTime: 10,
+          format: "mp4",
+          resolution: "720",
+          includeAudio: true,
+          onProgress: () => {},
+        },
+        context.runtime,
+      ),
+    /This browser cannot decode vp9 video\. Try Chrome or Edge/,
+  );
+  assert.equal(context.disposed, true);
+});
+
+void test("allows original sharp exports to copy a carried source codec without browser decoding", async () => {
+  let initializedConversion = false;
+  const context = createRuntime({
+    getTrackTimelineOffsetSeconds: async () => 0,
+    initConversion: async () => {
+      initializedConversion = true;
+      return createConversion({
+        target: context.target,
+        bytes: [1, 2, 3],
+        utilizedAudio: false,
+      });
+    },
+  });
+  context.videoTrack.getCodec = async () => "vp9";
+  context.videoTrack.canDecode = async () => false;
+
+  const blob = await exportClipWithRuntime(
+    {
+      mediaSource,
+      startTime: 0,
+      endTime: 10,
+      format: "mp4",
+      resolution: "original",
+      includeAudio: false,
+      onProgress: () => {},
+    },
+    context.runtime,
+  );
+
+  assert.equal(initializedConversion, true);
+  assert.equal(blob.size, 3);
+  assert.equal(context.disposed, true);
+});
+
 void test("validates subtitle burn-in inputs and wires the burn-in processor", async () => {
   const processor = (() => ({})) as unknown as SubtitleProcessor;
   let capturedOptions: ConversionOptions | undefined;
@@ -677,6 +745,34 @@ void test("exports GIF frames through the browser encoder path", async () => {
       width: 4,
     },
   ]);
+  assert.equal(context.disposed, true);
+});
+
+void test("fails before creating a GIF canvas sink when the source video codec cannot decode", async () => {
+  const context = createRuntime({
+    createCanvasSink: () => {
+      throw new Error("GIF canvas sink should not be created");
+    },
+  });
+  context.videoTrack.getCodec = async () => "vp8";
+  context.videoTrack.canDecode = async () => false;
+
+  await assert.rejects(
+    () =>
+      exportClipWithRuntime(
+        {
+          mediaSource,
+          startTime: 0,
+          endTime: 2,
+          format: "gif",
+          resolution: "original",
+          includeAudio: false,
+          onProgress: () => {},
+        },
+        context.runtime,
+      ),
+    /This browser cannot decode vp8 video\. Try Chrome or Edge/,
+  );
   assert.equal(context.disposed, true);
 });
 

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -21,9 +21,12 @@ import type { EditorMediaSource } from "#/lib/editorMedia";
 import { createCliparrInputFromSource } from "#/lib/mediabunnyInput";
 import { ensureMediabunnyCodecs } from "#/lib/mediabunnyCodecs";
 import {
+  assessVideoTrackDecodability,
   getTrackTimelineOffsetSeconds,
   getVideoTrackDimensions,
   toSourceTimelineTime,
+  videoTrackExportUnsupportedMessage,
+  type VideoTrackDecodabilityAssessment,
 } from "#/lib/mediabunnyTrackAccess";
 import { selectPreferredPairableAudioTrack } from "#/lib/selectPreferredAudioTrack";
 import type {
@@ -158,6 +161,60 @@ export function createGifCanvas(
 function configureGifCanvasContext(context: CanvasRenderingContext2D) {
   context.imageSmoothingEnabled = true;
   context.imageSmoothingQuality = "high";
+}
+
+function assertVideoTrackDecodableForExport(
+  decodability: VideoTrackDecodabilityAssessment,
+) {
+  if (decodability.codec === null || !decodability.canDecode) {
+    throw new Error(videoTrackExportUnsupportedMessage(decodability));
+  }
+}
+
+async function videoExportRequiresSourceDecode({
+  track,
+  sourceVideoDimensions,
+  outputDimensions,
+  outputFormat,
+  videoQualityOptions,
+  trimStart,
+  shouldBurnSubtitles,
+  decodability,
+}: {
+  track: InputVideoTrack;
+  sourceVideoDimensions: { width: number; height: number } | null;
+  outputDimensions: { width: number; height: number } | null;
+  outputFormat: ReturnType<typeof createOutputFormat>;
+  videoQualityOptions: ReturnType<typeof videoQualityConversionOptions>;
+  trimStart: number;
+  shouldBurnSubtitles: boolean;
+  decodability: VideoTrackDecodabilityAssessment;
+}) {
+  if (
+    videoQualityOptions.forceTranscode ||
+    videoQualityOptions.bitrate !== undefined ||
+    shouldBurnSubtitles
+  ) {
+    return true;
+  }
+
+  if (
+    decodability.codec === null ||
+    !outputFormat.getSupportedVideoCodecs().includes(decodability.codec)
+  ) {
+    return true;
+  }
+
+  if (
+    sourceVideoDimensions &&
+    outputDimensions &&
+    (sourceVideoDimensions.width !== outputDimensions.width ||
+      sourceVideoDimensions.height !== outputDimensions.height)
+  ) {
+    return true;
+  }
+
+  return (await track.getFirstTimestamp()) < trimStart;
 }
 
 function selectGifPaletteSampleFrameIndexes(frameCount: number) {
@@ -416,6 +473,7 @@ export async function exportClipWithRuntime(
     const sourceVideoTrack = await input.getPrimaryVideoTrack({
       filter: async (track) => !(await track.hasOnlyKeyPackets()),
     });
+
     const sourceAudioTracks = await input.getAudioTracks();
     const preferredAudioTrack = await runtime.selectPreferredPairableAudioTrack(
       sourceVideoTrack,
@@ -439,6 +497,7 @@ export async function exportClipWithRuntime(
       resolution,
       format,
     );
+    const videoQualityOptions = videoQualityConversionOptions(videoQuality);
     const outputHeight = outputDimensions?.height;
     const clippedSubtitleCues =
       includeBurnedSubtitles && subtitleCues.length > 0
@@ -455,6 +514,24 @@ export async function exportClipWithRuntime(
     }
 
     const outputFormat = runtime.createOutputFormat(format);
+    if (sourceVideoTrack) {
+      const decodability = await assessVideoTrackDecodability(sourceVideoTrack);
+      if (
+        await videoExportRequiresSourceDecode({
+          track: sourceVideoTrack,
+          sourceVideoDimensions,
+          outputDimensions,
+          outputFormat,
+          videoQualityOptions,
+          trimStart,
+          shouldBurnSubtitles,
+          decodability,
+        })
+      ) {
+        assertVideoTrackDecodableForExport(decodability);
+      }
+    }
+
     const target = runtime.createBufferTarget();
     const metadataTags = await runtime.buildMetadataTags(
       metadata,
@@ -504,8 +581,6 @@ export async function exportClipWithRuntime(
     if (metadataTags) {
       conversionOptions.tags = metadataTags;
     }
-
-    const videoQualityOptions = videoQualityConversionOptions(videoQuality);
 
     if (sourceVideoTrack) {
       conversionOptions.video = (track) => ({
@@ -642,6 +717,10 @@ async function exportGifClipWithRuntime(
     if (!sourceVideoTrack) {
       throw new Error("GIF export requires a video track.");
     }
+
+    assertVideoTrackDecodableForExport(
+      await assessVideoTrackDecodability(sourceVideoTrack),
+    );
 
     if (includeBurnedSubtitles && !subtitleStyleSettings) {
       throw new Error("Subtitle burn-in was requested without style settings.");

--- a/apps/frontend/src/lib/mediabunnyTrackAccess.test.ts
+++ b/apps/frontend/src/lib/mediabunnyTrackAccess.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  videoTrackExportUnsupportedMessage,
+  videoTrackPreviewUnavailableMessage,
+  type VideoTrackDecodabilityAssessment,
+} from "@/lib/mediabunnyTrackAccess";
+
+void test("formats unsupported video track messages for preview and export contexts", () => {
+  const unsupportedVp9 = {
+    codec: "vp9",
+    canDecode: false,
+  } satisfies VideoTrackDecodabilityAssessment;
+
+  assert.equal(
+    videoTrackPreviewUnavailableMessage(unsupportedVp9),
+    "Preview unavailable: this browser cannot decode vp9 video.",
+  );
+  assert.equal(
+    videoTrackExportUnsupportedMessage(unsupportedVp9),
+    "This browser cannot decode vp9 video. Try Chrome or Edge, or use a source video codec this browser supports.",
+  );
+});
+
+void test("formats unknown video codec messages for preview and export contexts", () => {
+  const unknownCodec = {
+    codec: null,
+    canDecode: false,
+  } satisfies VideoTrackDecodabilityAssessment;
+
+  assert.equal(
+    videoTrackPreviewUnavailableMessage(unknownCodec),
+    "Preview unavailable: this browser cannot decode the source video track because its codec is unknown.",
+  );
+  assert.equal(
+    videoTrackExportUnsupportedMessage(unknownCodec),
+    "This browser cannot decode the source video track because its codec is unknown.",
+  );
+});

--- a/apps/frontend/src/lib/mediabunnyTrackAccess.ts
+++ b/apps/frontend/src/lib/mediabunnyTrackAccess.ts
@@ -1,8 +1,18 @@
-import type { InputAudioTrack, InputTrack, InputVideoTrack } from "mediabunny";
+import type {
+  InputAudioTrack,
+  InputTrack,
+  InputVideoTrack,
+  VideoCodec,
+} from "mediabunny";
 
 interface VideoTrackDimensions {
   width: number;
   height: number;
+}
+
+export interface VideoTrackDecodabilityAssessment {
+  codec: VideoCodec | null;
+  canDecode: boolean;
 }
 
 export async function describeInputTrack(track: InputTrack) {
@@ -27,6 +37,37 @@ export async function getTrackName(track: InputTrack) {
 
 export async function getTrackCodec(track: InputTrack) {
   return track.getCodec();
+}
+
+export async function assessVideoTrackDecodability(
+  track: InputVideoTrack,
+): Promise<VideoTrackDecodabilityAssessment> {
+  const codec = await track.getCodec();
+
+  return {
+    codec,
+    canDecode: codec !== null && (await track.canDecode()),
+  };
+}
+
+export function videoTrackPreviewUnavailableMessage(
+  decodability: VideoTrackDecodabilityAssessment,
+) {
+  if (decodability.codec === null) {
+    return "Preview unavailable: this browser cannot decode the source video track because its codec is unknown.";
+  }
+
+  return `Preview unavailable: this browser cannot decode ${decodability.codec} video.`;
+}
+
+export function videoTrackExportUnsupportedMessage(
+  decodability: VideoTrackDecodabilityAssessment,
+) {
+  if (decodability.codec === null) {
+    return "This browser cannot decode the source video track because its codec is unknown.";
+  }
+
+  return `This browser cannot decode ${decodability.codec} video. Try Chrome or Edge, or use a source video codec this browser supports.`;
 }
 
 export async function getVideoTrackDimensions(

--- a/apps/www/src/components/convert/MediabunnySourcePreview.tsx
+++ b/apps/www/src/components/convert/MediabunnySourcePreview.tsx
@@ -8,7 +8,9 @@ import {
   type DragEvent,
 } from "react";
 import {
+  assessVideoTrackDecodability,
   createCliparrInputFromSource,
+  videoTrackPreviewUnavailableMessage,
   type EditorFileMediaSource,
 } from "@cliparr/frontend/convert";
 import type {
@@ -223,9 +225,9 @@ export function MediabunnySourcePreview({
           );
         }
 
-        const codec = await videoTrack.getCodec();
-        if (codec === null || !(await videoTrack.canDecode())) {
-          throw new Error("This browser cannot decode the source video track.");
+        const decodability = await assessVideoTrackDecodability(videoTrack);
+        if (decodability.codec === null || !decodability.canDecode) {
+          throw new Error(videoTrackPreviewUnavailableMessage(decodability));
         }
         if (isStale()) {
           releaseInput();


### PR DESCRIPTION
## Summary
- add a shared Mediabunny video track decodability assessment helper
- fail GIF exports and decode-required video exports before creating browser decoder work
- preserve Sharp/original passthrough exports when the output can carry the source codec without browser decoding
- update export flow docs and regression coverage for unsupported browser codec cases

## Why
Safari 26.5 supports WebCodecs but may reject specific source codec/config combinations. The convert export path could reach Mediabunny decoder setup without a user-facing decodability guard. The guard now runs only when the export plan needs decoded frames, so remux/copy-style exports are not blocked unnecessarily.

## Validation
- pnpm preflight