### PR TITLE
feat(frontend): add subtitle timeline cue tracks

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -351,6 +351,24 @@ flowchart TD
     T --> U["Do not reopen the finished Blob just to recheck audio"]
 ```
 
+## Subtitle Timeline Invariants
+
+- Subtitle timeline editing is session-local and only applies to the currently
+  selected supported text subtitle track.
+- `useSubtitleCues` owns subtitle download/parse state. `useEditorSubtitles`
+  converts the loaded cues into canonical `subtitleTimeline` cue objects with
+  stable ids for drag/resize updates.
+- Subtitle timeline rows are derived from canonical cue timing. Overlapping cues
+  create additional lanes below the clip row, and lane placement is recalculated
+  after timing changes.
+- Preview and export consume adjusted subtitle cues from the timeline model, not
+  the original parsed cue list.
+- Concurrent active cues render as separate composited cues at the same default
+  subtitle anchor. They are not merged into one cue and are not auto-stacked;
+  positioning controls are future work.
+- Text editing, add/remove, provider-side subtitle writes, lazy cue loading, and
+  sidecar export/persistence are outside the v1 timeline scope.
+
 ## End-To-End Summary
 
 ```mermaid

--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -44,6 +44,7 @@ flowchart TD
     E --> E1["editorShortcutCommands"]
     J --> J1["useSubtitleCues"]
     J --> J2["selectPreferredSubtitleTrack"]
+    J --> J3["subtitleTimeline editable cue model"]
 
     F["SourcesDialog"] --> F1["useSourcesState"]
     F1 --> F2["sourcesStateUtils"]
@@ -369,9 +370,11 @@ flowchart LR
     D --> P["Preview canvas with optional subtitles"]
     P --> Q["Framegrab dialog"]
     Q --> R["PNG clipboard or image download"]
-    S --> T["useEditorSubtitles loads and clips subtitle cues"]
-    T --> P
-    T --> U["Export subtitle burn-in readiness"]
+    S --> T["useEditorSubtitles loads subtitle cues"]
+    T --> T1["subtitleTimeline maps cues into editable timeline actions"]
+    T1 --> T2["Adjusted cues feed preview and export"]
+    T2 --> P
+    T2 --> U["Export subtitle burn-in readiness"]
     B --> G["useEditorExport source selection"]
     C --> G
     F --> G

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -44,6 +44,10 @@ import {
 } from "@/components/editor/EditorLayout";
 import { useEditorFramegrab } from "@/components/editor/useEditorFramegrab";
 import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
+import {
+  isValidSubtitleTimelineActionRange,
+  subtitleCueIdFromActionId,
+} from "@/components/editor/subtitleTimeline";
 import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
@@ -91,9 +95,11 @@ export default function EditorScreen({ session, onBack }: Properties) {
     subtitleLoading,
     subtitleError,
     subtitlePreviewEnabled,
+    subtitleTimelineTrack,
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    updateSubtitleCueTimings,
   } = useEditorSubtitles({
     session,
     startTime,
@@ -255,6 +261,29 @@ export default function EditorScreen({ session, onBack }: Properties) {
     },
     [duration],
   );
+  const isValidTimelineActionRange = useCallback(
+    ({
+      action,
+      start,
+      end,
+    }: {
+      action: { id: string };
+      start: number;
+      end: number;
+    }) => {
+      if (subtitleCueIdFromActionId(action.id)) {
+        return isValidSubtitleTimelineActionRange({
+          actionId: action.id,
+          startTime: start,
+          endTime: end,
+          duration,
+        });
+      }
+
+      return isValidTimelineRange(start, end);
+    },
+    [duration, isValidTimelineRange],
+  );
   const handlePreviewTimeCommit = useCallback(
     (nextTime: number) => {
       if (!duration || duration <= 0) {
@@ -364,6 +393,7 @@ export default function EditorScreen({ session, onBack }: Properties) {
     timelineWheelRegionRef,
     timelineData,
     timelineEffects,
+    timelineSubtitleActionLabels,
     activeTimelineScale,
     timelineScaleCount,
     handleTimelineScroll,
@@ -386,6 +416,8 @@ export default function EditorScreen({ session, onBack }: Properties) {
     onClipRangeCommit: (nextStart, nextEnd) => {
       void warmClipSelection(nextStart, nextEnd);
     },
+    subtitleTimelineTrack,
+    updateSubtitleCueTimings,
   });
 
   useEffect(() => {
@@ -518,6 +550,7 @@ export default function EditorScreen({ session, onBack }: Properties) {
       timelineWheelRegionRef={timelineWheelRegionRef}
       timelineData={timelineData}
       timelineEffects={timelineEffects}
+      timelineSubtitleActionLabels={timelineSubtitleActionLabels}
       activeTimelineScale={activeTimelineScale}
       timelineScaleCount={timelineScaleCount}
       playbackReadyRange={isHlsPreviewSource ? playbackReadyRange : null}
@@ -527,7 +560,7 @@ export default function EditorScreen({ session, onBack }: Properties) {
       handleTimelineChange={handleTimelineChange}
       handleTimelineActionMoveEnd={handleTimelineActionMoveEnd}
       handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
-      isValidTimelineRange={isValidTimelineRange}
+      isValidTimelineActionRange={isValidTimelineActionRange}
       seekToTime={seekToTime}
       onCursorDragStart={() => {
         if (playing) {

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -21,6 +21,10 @@ import {
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
 } from "@/lib/selectPreferredSubtitleTrack";
+import {
+  formatSubtitleTrackLabel,
+  formatSubtitleTrackTechnicalSummary,
+} from "@/lib/subtitleTrackLabels";
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
@@ -47,32 +51,6 @@ interface EditorSubtitlePanelProperties {
   subtitleLoading: boolean;
   subtitleError: string | null;
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
-}
-
-function subtitleTrackLabel(track: PlaybackSubtitleTrack) {
-  const parts = [
-    track.title?.trim(),
-    track.languageCode?.trim()?.toUpperCase(),
-  ].filter(Boolean);
-  const codec = track.codec?.trim()?.toUpperCase();
-  const flags = [
-    track.isForced ? "Forced" : null,
-    track.isHearingImpaired ? "SDH" : null,
-    track.isDefault ? "Default" : null,
-    track.isExternal ? "External" : null,
-    subtitleTrackSupportsBurnIn(track) ? null : "Unsupported",
-  ].filter(Boolean);
-
-  const baseLabel = parts[0] ?? parts[1] ?? "Unnamed subtitle track";
-  const detailParts = [
-    parts[0] && parts[1] ? parts[1] : null,
-    codec,
-    flags.join(" · "),
-  ].filter(Boolean);
-
-  return detailParts.length > 0
-    ? `${baseLabel} (${detailParts.join(" | ")})`
-    : baseLabel;
 }
 
 export function EditorSubtitlePanel({
@@ -195,7 +173,7 @@ export function EditorSubtitlePanel({
 
                   return (
                     <SelectItem key={trackKey} value={trackKey}>
-                      {subtitleTrackLabel(track)}
+                      {formatSubtitleTrackLabel(track, { variant: "selector" })}
                     </SelectItem>
                   );
                 })}
@@ -212,13 +190,7 @@ export function EditorSubtitlePanel({
                 <p>{subtitleWarning}</p>
                 {selectedSubtitleTrack && (
                   <p className="text-ui-label text-muted-foreground">
-                    {selectedSubtitleTrack.codec?.toUpperCase() ??
-                      "Unknown codec"}
-                    {selectedSubtitleTrack.languageCode
-                      ? ` · ${selectedSubtitleTrack.languageCode.toUpperCase()}`
-                      : ""}
-                    {selectedSubtitleTrack.isForced ? " · Forced" : ""}
-                    {selectedSubtitleTrack.isHearingImpaired ? " · SDH" : ""}
+                    {formatSubtitleTrackTechnicalSummary(selectedSubtitleTrack)}
                   </p>
                 )}
               </div>

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -2,10 +2,11 @@ import { useCallback } from "react";
 import { Timeline, type TimelineState } from "@xzdarcy/react-timeline-editor";
 import "@xzdarcy/react-timeline-editor/dist/react-timeline-editor.css";
 import type { CSSProperties, RefObject } from "react";
-import { Scissors } from "lucide-react";
+import { Captions, Scissors } from "lucide-react";
 import type { PlaybackReadyRange } from "@/components/editor/useEditorPlayback";
 import { isPlaybackReadyRangeVisible } from "@/components/editor/editorPlaybackWarmupRange";
 import {
+  CLIP_TIMELINE_ROW_HEIGHT,
   formatTime,
   getTimelineFillPercentages,
   TIMELINE_START_LEFT,
@@ -20,13 +21,14 @@ interface EditorTimelineProperties {
   timelineWheelRegionRef: RefObject<HTMLDivElement | null>;
   timelineData: ClipTimelineData;
   timelineEffects: ClipTimelineEffects;
+  timelineSubtitleActionLabels: ReadonlyMap<string, string>;
   activeTimelineScale: TimelineZoomLevel;
   timelineScaleCount: number;
   playbackReadyRange: PlaybackReadyRange | null;
   loadingPreview: boolean;
   playing: boolean;
   handleTimelineScroll: (data: { scrollLeft: number }) => void;
-  handleTimelineChange: (data: ClipTimelineData) => void;
+  handleTimelineChange: (data: ClipTimelineData) => boolean | void;
   handleTimelineActionMoveEnd: (params: {
     action: { id: string };
     start: number;
@@ -36,8 +38,13 @@ interface EditorTimelineProperties {
     action: { id: string };
     start: number;
     end: number;
+    dir?: "right" | "left";
   }) => void;
-  isValidTimelineRange: (start: number, end: number) => boolean;
+  isValidTimelineActionRange: (params: {
+    action: { id: string };
+    start: number;
+    end: number;
+  }) => boolean;
   seekToTime: (time: number) => Promise<void> | void;
   onCursorDragStart: () => void;
   onCursorDrag: (time: number) => void;
@@ -48,6 +55,7 @@ export function EditorTimeline({
   timelineWheelRegionRef,
   timelineData,
   timelineEffects,
+  timelineSubtitleActionLabels,
   activeTimelineScale,
   timelineScaleCount,
   playbackReadyRange,
@@ -57,7 +65,7 @@ export function EditorTimeline({
   handleTimelineChange,
   handleTimelineActionMoveEnd,
   handleTimelineActionResizeEnd,
-  isValidTimelineRange,
+  isValidTimelineActionRange,
   seekToTime,
   onCursorDragStart,
   onCursorDrag,
@@ -99,7 +107,12 @@ export function EditorTimeline({
   const renderClipTimelineAction = useCallback(
     (action: ClipTimelineAction) => {
       const isSource = action.effectId === "source";
+      const isSubtitle = action.effectId === "subtitle";
       const readyFillStyle = getReadyFillStyle(action);
+      const subtitleLabel = isSubtitle
+        ? (timelineSubtitleActionLabels.get(action.id) ?? "Subtitle")
+        : null;
+      const actionLabel = isSource ? "Source" : (subtitleLabel ?? "Selection");
 
       return (
         <div className="cliparr-timeline-action-content">
@@ -112,13 +125,17 @@ export function EditorTimeline({
             />
           )}
           <span className="cliparr-timeline-action-label">
-            {!isSource && <Scissors className="h-3.5 w-3.5" />}
-            {isSource ? "Source" : "Selection"}
+            {isSubtitle ? (
+              <Captions className="h-3.5 w-3.5" />
+            ) : (
+              !isSource && <Scissors className="h-3.5 w-3.5" />
+            )}
+            {actionLabel}
           </span>
         </div>
       );
     },
-    [getReadyFillStyle, playbackReadyRange],
+    [getReadyFillStyle, playbackReadyRange, timelineSubtitleActionLabels],
   );
 
   return (
@@ -133,15 +150,19 @@ export function EditorTimeline({
         minScaleCount={timelineScaleCount}
         maxScaleCount={timelineScaleCount}
         startLeft={TIMELINE_START_LEFT}
-        rowHeight={44}
+        rowHeight={CLIP_TIMELINE_ROW_HEIGHT}
         autoScroll
         hideCursor={false}
-        dragLine
+        dragLine={false}
         disableDrag={loadingPreview || playing}
         onScroll={handleTimelineScroll}
         onChange={handleTimelineChange}
-        onActionMoving={({ start, end }) => isValidTimelineRange(start, end)}
-        onActionResizing={({ start, end }) => isValidTimelineRange(start, end)}
+        onActionMoving={({ action, start, end }) =>
+          isValidTimelineActionRange({ action, start, end })
+        }
+        onActionResizing={({ action, start, end }) =>
+          isValidTimelineActionRange({ action, start, end })
+        }
         onActionMoveEnd={handleTimelineActionMoveEnd}
         onActionResizeEnd={handleTimelineActionResizeEnd}
         onClickTimeArea={(time) => {

--- a/apps/frontend/src/components/editor/editorUtilities.ts
+++ b/apps/frontend/src/components/editor/editorUtilities.ts
@@ -3,6 +3,9 @@ import type { ComponentProps } from "react";
 
 export const MIN_CLIP_SECONDS = 0.1;
 export const TIMELINE_START_LEFT = 24;
+export const SOURCE_TIMELINE_ROW_HEIGHT = 32;
+export const CLIP_TIMELINE_ROW_HEIGHT = 44;
+export const SUBTITLE_TIMELINE_ROW_HEIGHT = 34;
 const MAX_TIMELINE_ZOOM_SCALE_COUNT = 2000;
 export const TIMELINE_ZOOM_WHEEL_STEP = 80;
 const MIN_FOCUSED_TIMELINE_SELECTION_PIXELS = 96;

--- a/apps/frontend/src/components/editor/subtitleExportSummary.ts
+++ b/apps/frontend/src/components/editor/subtitleExportSummary.ts
@@ -3,6 +3,7 @@ import {
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
 } from "@/lib/selectPreferredSubtitleTrack";
+import { formatSubtitleTrackLabel } from "@/lib/subtitleTrackLabels";
 
 interface BuildSubtitleExportSummaryOptions {
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
@@ -19,18 +20,6 @@ export interface SubtitleExportSummary {
   detail: string;
   tone: "muted" | "ready" | "warning";
   disabledReason: string | null;
-}
-
-function subtitleTrackDisplayName(track: PlaybackSubtitleTrack | null) {
-  if (!track) {
-    return "No subtitle track selected";
-  }
-
-  return (
-    track.title?.trim() ||
-    track.languageCode?.trim()?.toUpperCase() ||
-    "Selected subtitle track"
-  );
 }
 
 export function buildSubtitleExportSummary({
@@ -58,7 +47,9 @@ export function buildSubtitleExportSummary({
     };
   }
 
-  const trackName = subtitleTrackDisplayName(selectedSubtitleTrack);
+  const trackName = formatSubtitleTrackLabel(selectedSubtitleTrack, {
+    variant: "summary",
+  });
 
   if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack)) {
     return {

--- a/apps/frontend/src/components/editor/subtitleTimeline.test.ts
+++ b/apps/frontend/src/components/editor/subtitleTimeline.test.ts
@@ -1,0 +1,381 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applySubtitleCueTimingUpdates,
+  assignSubtitleCueLanes,
+  buildSubtitleTimelineTrack,
+  isValidSubtitleCueRange,
+  isValidSubtitleTimelineActionRange,
+  roundSubtitleCueTimingUpdate,
+  snapSubtitleCueTimingUpdateToAdjacentCue,
+  subtitleCuesInTimelineWindow,
+  subtitleTimelineActionId,
+  subtitleTimelineTrackToCues,
+  type SubtitleTimelineCue,
+} from "@/components/editor/subtitleTimeline";
+
+function cue(
+  id: string,
+  startTime: number,
+  endTime: number,
+): SubtitleTimelineCue {
+  return {
+    id,
+    sourceIndex: Number(id.replaceAll(/\D/g, "")) || 0,
+    startTime,
+    endTime,
+    text: `Cue ${id}`,
+    lines: [`Cue ${id}`],
+  };
+}
+
+void test("places non-overlapping subtitle cues in the first lane", () => {
+  const lanes = assignSubtitleCueLanes([
+    cue("cue-1", 0, 1),
+    cue("cue-2", 1, 2),
+    cue("cue-3", 3, 4),
+  ]);
+
+  assert.equal(lanes.length, 1);
+  assert.deepEqual(
+    lanes[0]?.cues.map((item) => item.id),
+    ["cue-1", "cue-2", "cue-3"],
+  );
+});
+
+void test("creates lower subtitle lanes only while cues overlap", () => {
+  const lanes = assignSubtitleCueLanes([
+    cue("cue-1", 0, 4),
+    cue("cue-2", 1, 2),
+    cue("cue-3", 2, 3),
+    cue("cue-4", 4, 5),
+  ]);
+
+  assert.equal(lanes.length, 2);
+  assert.deepEqual(
+    lanes[0]?.cues.map((item) => item.id),
+    ["cue-1", "cue-4"],
+  );
+  assert.deepEqual(
+    lanes[1]?.cues.map((item) => item.id),
+    ["cue-2", "cue-3"],
+  );
+});
+
+void test("sorts subtitle cues before assigning lanes", () => {
+  const lanes = assignSubtitleCueLanes([
+    cue("cue-3", 3, 4),
+    cue("cue-1", 0, 2),
+    cue("cue-2", 1, 3),
+  ]);
+
+  assert.deepEqual(
+    lanes.map((lane) => lane.cues.map((item) => item.id)),
+    [["cue-1", "cue-3"], ["cue-2"]],
+  );
+});
+
+void test("filters subtitle cues to the projected timeline window", () => {
+  assert.deepEqual(
+    subtitleCuesInTimelineWindow({
+      cues: [
+        cue("before", 0, 1),
+        cue("touching-start", 1, 2),
+        cue("inside", 3, 4),
+        cue("touching-end", 5, 6),
+        cue("after", 7, 8),
+      ],
+      startTime: 2,
+      endTime: 5,
+    }).map((item) => item.id),
+    ["touching-start", "inside", "touching-end"],
+  );
+});
+
+void test("updates subtitle cue timing without changing unrelated cues", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      {
+        id: "a",
+        startTime: 0,
+        endTime: 1,
+        text: "Hello",
+        lines: ["Hello"],
+      },
+      {
+        id: "b",
+        startTime: 2,
+        endTime: 3,
+        text: "World",
+        lines: ["World"],
+      },
+    ],
+  });
+
+  const next = applySubtitleCueTimingUpdates({
+    track,
+    duration: 10,
+    updates: [{ cueId: "stream:1:cue:0", startTime: 0.5, endTime: 1.5 }],
+  });
+
+  assert.notEqual(next, track);
+  assert.deepEqual(
+    next?.cues.map((item) => [item.id, item.startTime, item.endTime]),
+    [
+      ["stream:1:cue:0", 0.5, 1.5],
+      ["stream:1:cue:1", 2, 3],
+    ],
+  );
+});
+
+void test("rounds subtitle cue timing updates to timeline precision", () => {
+  assert.deepEqual(
+    roundSubtitleCueTimingUpdate({
+      cueId: "cue-1",
+      startTime: 1.234,
+      endTime: 5.678,
+    }),
+    {
+      cueId: "cue-1",
+      startTime: 1.23,
+      endTime: 5.68,
+    },
+  );
+});
+
+void test("snaps moved subtitle cues adjacent to nearby cue boundaries", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      {
+        startTime: 0,
+        endTime: 1,
+        text: "First",
+        lines: ["First"],
+      },
+      {
+        startTime: 2.02,
+        endTime: 3.02,
+        text: "Second",
+        lines: ["Second"],
+      },
+    ],
+  });
+
+  const snappedUpdate = snapSubtitleCueTimingUpdateToAdjacentCue({
+    track,
+    duration: 10,
+    thresholdSeconds: 0.1,
+    mode: "move",
+    update: {
+      cueId: "stream:1:cue:1",
+      startTime: 1.04,
+      endTime: 2.04,
+    },
+  });
+
+  assert.deepEqual(snappedUpdate, {
+    cueId: "stream:1:cue:1",
+    startTime: 1,
+    endTime: 2,
+  });
+
+  const updatedTrack = applySubtitleCueTimingUpdates({
+    track,
+    duration: 10,
+    updates: [snappedUpdate],
+  });
+
+  assert.deepEqual(
+    assignSubtitleCueLanes(updatedTrack?.cues ?? []).map((lane) =>
+      lane.cues.map((item) => item.id),
+    ),
+    [["stream:1:cue:0", "stream:1:cue:1"]],
+  );
+});
+
+void test("snaps only the resized subtitle cue boundary", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      {
+        startTime: 0,
+        endTime: 1,
+        text: "First",
+        lines: ["First"],
+      },
+      {
+        startTime: 1.5,
+        endTime: 2,
+        text: "Second",
+        lines: ["Second"],
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    snapSubtitleCueTimingUpdateToAdjacentCue({
+      track,
+      duration: 10,
+      thresholdSeconds: 0.1,
+      mode: "resize-right",
+      update: {
+        cueId: "stream:1:cue:0",
+        startTime: 0,
+        endTime: 1.47,
+      },
+    }),
+    {
+      cueId: "stream:1:cue:0",
+      startTime: 0,
+      endTime: 1.5,
+    },
+  );
+});
+
+void test("does not snap subtitle cues outside the snap threshold", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      {
+        startTime: 0,
+        endTime: 1,
+        text: "First",
+        lines: ["First"],
+      },
+      {
+        startTime: 2,
+        endTime: 3,
+        text: "Second",
+        lines: ["Second"],
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    snapSubtitleCueTimingUpdateToAdjacentCue({
+      track,
+      duration: 10,
+      thresholdSeconds: 0.1,
+      mode: "move",
+      update: {
+        cueId: "stream:1:cue:1",
+        startTime: 1.2,
+        endTime: 2.2,
+      },
+    }),
+    {
+      cueId: "stream:1:cue:1",
+      startTime: 1.2,
+      endTime: 2.2,
+    },
+  );
+});
+
+void test("rejects invalid subtitle cue timing updates", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      {
+        startTime: 1,
+        endTime: 2,
+        text: "Hello",
+        lines: ["Hello"],
+      },
+    ],
+  });
+
+  assert.equal(
+    applySubtitleCueTimingUpdates({
+      track,
+      duration: 10,
+      updates: [{ cueId: "stream:1:cue:0", startTime: 2, endTime: 2 }],
+    }),
+    track,
+  );
+  assert.equal(
+    applySubtitleCueTimingUpdates({
+      track,
+      duration: 10,
+      updates: [{ cueId: "stream:1:cue:0", startTime: -1, endTime: 2 }],
+    }),
+    track,
+  );
+  assert.equal(
+    applySubtitleCueTimingUpdates({
+      track,
+      duration: 10,
+      updates: [{ cueId: "stream:1:cue:0", startTime: 1, endTime: 11 }],
+    }),
+    track,
+  );
+});
+
+void test("validates subtitle cue ranges independently from clip minimum length", () => {
+  assert.equal(
+    isValidSubtitleCueRange({ startTime: 1, endTime: 1.01, duration: 2 }),
+    true,
+  );
+  assert.equal(
+    isValidSubtitleCueRange({ startTime: 1, endTime: 1, duration: 2 }),
+    false,
+  );
+});
+
+void test("validates only subtitle timeline action ranges", () => {
+  assert.equal(
+    isValidSubtitleTimelineActionRange({
+      actionId: subtitleTimelineActionId("cue-1"),
+      startTime: 1,
+      endTime: 1.01,
+      duration: 2,
+    }),
+    true,
+  );
+  assert.equal(
+    isValidSubtitleTimelineActionRange({
+      actionId: "selected-clip",
+      startTime: 1,
+      endTime: 1.01,
+      duration: 2,
+    }),
+    false,
+  );
+});
+
+void test("converts subtitle timeline tracks back to sorted subtitle cues", () => {
+  const track = buildSubtitleTimelineTrack({
+    trackKey: "stream:1",
+    label: "English",
+    cues: [
+      { startTime: 2, endTime: 3, text: "Second", lines: ["Second"] },
+      {
+        id: "first",
+        startTime: 0,
+        endTime: 1,
+        text: "First",
+        lines: ["First"],
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    subtitleTimelineTrackToCues(track).map((item) => ({
+      id: item.id,
+      startTime: item.startTime,
+      text: item.text,
+    })),
+    [
+      { id: "first", startTime: 0, text: "First" },
+      { id: "stream:1:cue:0", startTime: 2, text: "Second" },
+    ],
+  );
+});

--- a/apps/frontend/src/components/editor/subtitleTimeline.ts
+++ b/apps/frontend/src/components/editor/subtitleTimeline.ts
@@ -1,0 +1,352 @@
+import { roundTimelineTime } from "@/components/editor/editorUtilities";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+
+export interface SubtitleTimelineCue {
+  id: string;
+  sourceCueId?: string;
+  sourceIndex: number;
+  startTime: number;
+  endTime: number;
+  text: string;
+  lines: string[];
+}
+
+export interface SubtitleTimelineTrack {
+  id: string;
+  trackKey: string;
+  label: string;
+  cues: SubtitleTimelineCue[];
+}
+
+export interface SubtitleTimelineLane {
+  index: number;
+  cues: SubtitleTimelineCue[];
+}
+
+export interface SubtitleCueTimingUpdate {
+  cueId: string;
+  startTime: number;
+  endTime: number;
+}
+
+export type SubtitleCueTimingUpdateMode =
+  | "move"
+  | "resize-left"
+  | "resize-right";
+
+const subtitleActionPrefix = "subtitle-cue:";
+
+export function subtitleTimelineActionId(cueId: string) {
+  return `${subtitleActionPrefix}${cueId}`;
+}
+
+export function subtitleCueIdFromActionId(actionId: string) {
+  return actionId.startsWith(subtitleActionPrefix)
+    ? actionId.slice(subtitleActionPrefix.length)
+    : null;
+}
+
+function isSubtitleTimelineActionId(actionId: string) {
+  return subtitleCueIdFromActionId(actionId) !== null;
+}
+
+export function buildSubtitleTimelineTrack({
+  trackKey,
+  label,
+  cues,
+}: {
+  trackKey: string;
+  label: string;
+  cues: readonly SubtitleCue[];
+}): SubtitleTimelineTrack {
+  return {
+    id: `subtitle-track:${trackKey}`,
+    trackKey,
+    label,
+    cues: cues.map((cue, index) => ({
+      id: `${trackKey}:cue:${index}`,
+      sourceCueId: cue.id,
+      sourceIndex: index,
+      startTime: cue.startTime,
+      endTime: cue.endTime,
+      text: cue.text,
+      lines: [...cue.lines],
+    })),
+  };
+}
+
+export function subtitleTimelineTrackToCues(
+  track: SubtitleTimelineTrack | null | undefined,
+) {
+  if (!track) {
+    return [];
+  }
+
+  return sortSubtitleTimelineCues(track.cues).map<SubtitleCue>((cue) => ({
+    id: cue.sourceCueId ?? cue.id,
+    startTime: cue.startTime,
+    endTime: cue.endTime,
+    text: cue.text,
+    lines: [...cue.lines],
+  }));
+}
+
+function sortSubtitleTimelineCues(cues: readonly SubtitleTimelineCue[]) {
+  return cues.toSorted((left, right) => {
+    const startDelta = left.startTime - right.startTime;
+    if (startDelta !== 0) {
+      return startDelta;
+    }
+
+    const endDelta = left.endTime - right.endTime;
+    if (endDelta !== 0) {
+      return endDelta;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function assignSubtitleCueLanes(
+  cues: readonly SubtitleTimelineCue[],
+): SubtitleTimelineLane[] {
+  const lanes: SubtitleTimelineLane[] = [];
+  const laneEndTimes: number[] = [];
+
+  for (const cue of sortSubtitleTimelineCues(cues)) {
+    let laneIndex = laneEndTimes.findIndex(
+      (endTime) => endTime <= cue.startTime,
+    );
+    if (laneIndex === -1) {
+      laneIndex = lanes.length;
+      lanes.push({ index: laneIndex, cues: [] });
+      laneEndTimes.push(Number.NEGATIVE_INFINITY);
+    }
+
+    lanes[laneIndex]?.cues.push(cue);
+    laneEndTimes[laneIndex] = cue.endTime;
+  }
+
+  return lanes;
+}
+
+export function subtitleCuesInTimelineWindow({
+  cues,
+  startTime,
+  endTime,
+}: {
+  cues: readonly SubtitleTimelineCue[];
+  startTime: number;
+  endTime: number;
+}) {
+  if (
+    !Number.isFinite(startTime) ||
+    !Number.isFinite(endTime) ||
+    endTime <= startTime
+  ) {
+    return [];
+  }
+
+  return cues.filter(
+    (cue) => cue.endTime >= startTime && cue.startTime <= endTime,
+  );
+}
+
+export function isValidSubtitleCueRange({
+  startTime,
+  endTime,
+  duration,
+}: {
+  startTime: number;
+  endTime: number;
+  duration: number;
+}) {
+  return (
+    Number.isFinite(startTime) &&
+    Number.isFinite(endTime) &&
+    Number.isFinite(duration) &&
+    duration > 0 &&
+    startTime >= 0 &&
+    endTime <= duration &&
+    endTime > startTime
+  );
+}
+
+export function isValidSubtitleTimelineActionRange({
+  actionId,
+  startTime,
+  endTime,
+  duration,
+}: {
+  actionId: string;
+  startTime: number;
+  endTime: number;
+  duration: number;
+}) {
+  return (
+    isSubtitleTimelineActionId(actionId) &&
+    isValidSubtitleCueRange({ startTime, endTime, duration })
+  );
+}
+
+export function roundSubtitleCueTimingUpdate(
+  update: SubtitleCueTimingUpdate,
+): SubtitleCueTimingUpdate {
+  return {
+    cueId: update.cueId,
+    startTime: roundTimelineTime(update.startTime),
+    endTime: roundTimelineTime(update.endTime),
+  };
+}
+
+export function snapSubtitleCueTimingUpdateToAdjacentCue({
+  track,
+  update,
+  duration,
+  thresholdSeconds,
+  mode,
+}: {
+  track: SubtitleTimelineTrack | null | undefined;
+  update: SubtitleCueTimingUpdate;
+  duration: number;
+  thresholdSeconds: number;
+  mode: SubtitleCueTimingUpdateMode;
+}): SubtitleCueTimingUpdate {
+  const roundedUpdate = roundSubtitleCueTimingUpdate(update);
+  if (
+    !track ||
+    !Number.isFinite(thresholdSeconds) ||
+    thresholdSeconds <= 0 ||
+    !isValidSubtitleCueRange({
+      startTime: roundedUpdate.startTime,
+      endTime: roundedUpdate.endTime,
+      duration,
+    })
+  ) {
+    return roundedUpdate;
+  }
+
+  const cueDuration = roundTimelineTime(
+    roundedUpdate.endTime - roundedUpdate.startTime,
+  );
+  const snapCandidates: Array<{
+    distance: number;
+    update: SubtitleCueTimingUpdate;
+  }> = [];
+
+  const considerSnap = (
+    distance: number,
+    snappedUpdate: SubtitleCueTimingUpdate,
+  ) => {
+    if (
+      distance > thresholdSeconds ||
+      !isValidSubtitleCueRange({
+        startTime: snappedUpdate.startTime,
+        endTime: snappedUpdate.endTime,
+        duration,
+      })
+    ) {
+      return;
+    }
+
+    snapCandidates.push({ distance, update: snappedUpdate });
+  };
+
+  for (const cue of track.cues) {
+    if (cue.id === roundedUpdate.cueId) {
+      continue;
+    }
+
+    const cueStart = roundTimelineTime(cue.startTime);
+    const cueEnd = roundTimelineTime(cue.endTime);
+
+    if (mode === "move" || mode === "resize-left") {
+      const snappedStart = cueEnd;
+      considerSnap(Math.abs(roundedUpdate.startTime - snappedStart), {
+        cueId: roundedUpdate.cueId,
+        startTime: snappedStart,
+        endTime:
+          mode === "move"
+            ? roundTimelineTime(snappedStart + cueDuration)
+            : roundedUpdate.endTime,
+      });
+    }
+
+    if (mode === "move" || mode === "resize-right") {
+      const snappedEnd = cueStart;
+      considerSnap(Math.abs(roundedUpdate.endTime - snappedEnd), {
+        cueId: roundedUpdate.cueId,
+        startTime:
+          mode === "move"
+            ? roundTimelineTime(snappedEnd - cueDuration)
+            : roundedUpdate.startTime,
+        endTime: snappedEnd,
+      });
+    }
+  }
+
+  const bestSnap = snapCandidates.toSorted(
+    (left, right) => left.distance - right.distance,
+  )[0];
+
+  return bestSnap
+    ? roundSubtitleCueTimingUpdate(bestSnap.update)
+    : roundedUpdate;
+}
+
+export function applySubtitleCueTimingUpdates({
+  track,
+  updates,
+  duration,
+}: {
+  track: SubtitleTimelineTrack | null;
+  updates: readonly SubtitleCueTimingUpdate[];
+  duration: number;
+}) {
+  if (!track || updates.length === 0) {
+    return track;
+  }
+
+  const validUpdates = new Map(
+    updates
+      .filter((update) =>
+        isValidSubtitleCueRange({
+          startTime: update.startTime,
+          endTime: update.endTime,
+          duration,
+        }),
+      )
+      .map((update) => [update.cueId, update]),
+  );
+
+  if (validUpdates.size === 0) {
+    return track;
+  }
+
+  let changed = false;
+  const cues = track.cues.map((cue) => {
+    const update = validUpdates.get(cue.id);
+    if (
+      !update ||
+      (cue.startTime === update.startTime && cue.endTime === update.endTime)
+    ) {
+      return cue;
+    }
+
+    changed = true;
+    return {
+      ...cue,
+      startTime: update.startTime,
+      endTime: update.endTime,
+    };
+  });
+
+  return changed ? { ...track, cues } : track;
+}
+
+export function subtitleCueTimelineLabel(
+  cue: Pick<SubtitleTimelineCue, "text">,
+) {
+  const label = cue.text.replaceAll(/\s+/g, " ").trim();
+  return label || "Subtitle";
+}

--- a/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
+++ b/apps/frontend/src/components/editor/useEditorPlaybackRenderLoop.ts
@@ -4,8 +4,8 @@ import {
   fromSourceTimelineTime,
   toSourceTimelineTime,
 } from "@/lib/mediabunnyTrackAccess";
-import { getActiveSubtitleCue } from "@/lib/subtitles/getActiveSubtitleCue";
-import { renderSubtitleCue } from "@/lib/subtitles/renderSubtitleCue";
+import { getActiveSubtitleCues } from "@/lib/subtitles/getActiveSubtitleCue";
+import { renderSubtitleCues } from "@/lib/subtitles/renderSubtitleCue";
 import type { SubtitleCue, SubtitleStyleSettings } from "@/lib/subtitles/types";
 import { errorMessage, themeValue } from "@/components/editor/editorUtilities";
 
@@ -98,17 +98,17 @@ export function useEditorPlaybackRenderLoop({
       context.drawImage(frame.canvas, 0, 0, canvas.width, canvas.height);
 
       if (subtitlesEnabledRef.current && subtitleStyleSettingsRef.current) {
-        const cue = getActiveSubtitleCue(
+        const cues = getActiveSubtitleCues(
           subtitleCuesRef.current,
           fromSourceTimelineTime(
             frame.timestamp,
             sourceTimelineOffsetRef.current,
           ),
         );
-        if (cue) {
-          renderSubtitleCue(
+        if (cues.length > 0) {
+          renderSubtitleCues(
             context,
-            cue,
+            cues,
             subtitleStyleSettingsRef.current,
             canvas.width,
             canvas.height,

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -12,12 +12,28 @@ import {
 import { trimSubtitleCues } from "@/lib/subtitles/trimSubtitleCues";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import { buildSubtitleExportSummary } from "@/components/editor/subtitleExportSummary";
+import {
+  applySubtitleCueTimingUpdates,
+  buildSubtitleTimelineTrack,
+  subtitleTimelineTrackToCues,
+  type SubtitleCueTimingUpdate,
+  type SubtitleTimelineTrack,
+} from "@/components/editor/subtitleTimeline";
 import { useSubtitleCues } from "@/components/editor/useSubtitleCues";
 
 interface UseEditorSubtitlesProperties {
   session: EditorSession;
   startTime: number;
   endTime: number;
+}
+
+function subtitleTrackTimelineLabel(track: PlaybackSubtitleTrack) {
+  const parts = [
+    track.title?.trim(),
+    track.languageCode?.trim()?.toUpperCase(),
+  ].filter(Boolean);
+
+  return parts.join(" / ") || "Subtitle track";
 }
 
 export function useEditorSubtitles({
@@ -31,6 +47,8 @@ export function useEditorSubtitles({
   const [subtitleEnabled, setSubtitleEnabled] = useState(false);
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] =
     useState("none");
+  const [subtitleTimelineTrack, setSubtitleTimelineTrack] =
+    useState<SubtitleTimelineTrack | null>(null);
 
   const subtitleTracks = useMemo<PlaybackSubtitleTrack[]>(
     () =>
@@ -53,9 +71,10 @@ export function useEditorSubtitles({
     );
   }, [selectedSubtitleTrackKey, subtitleTracks]);
   const {
-    subtitleCues,
+    subtitleCues: downloadedSubtitleCues,
     subtitleLoading,
     subtitleError,
+    loadedSubtitleTrackKey,
     resetSubtitleCues,
     clearSubtitleError,
   } = useSubtitleCues({
@@ -63,6 +82,20 @@ export function useEditorSubtitles({
     subtitleEnabled,
     providerId: session.source.providerId,
   });
+  const selectedDownloadedSubtitleCues = useMemo(
+    () =>
+      loadedSubtitleTrackKey === selectedSubtitleTrackKey
+        ? downloadedSubtitleCues
+        : [],
+    [downloadedSubtitleCues, loadedSubtitleTrackKey, selectedSubtitleTrackKey],
+  );
+  const subtitleCues = useMemo(
+    () =>
+      subtitleTimelineTrack
+        ? subtitleTimelineTrackToCues(subtitleTimelineTrack)
+        : selectedDownloadedSubtitleCues,
+    [selectedDownloadedSubtitleCues, subtitleTimelineTrack],
+  );
   const subtitlePreviewEnabled =
     subtitleEnabled &&
     subtitleTrackSupportsBurnIn(selectedSubtitleTrack) &&
@@ -97,6 +130,38 @@ export function useEditorSubtitles({
   useEffect(() => {
     saveSubtitleStyleSettings(subtitleStyleSettings);
   }, [subtitleStyleSettings]);
+
+  useEffect(() => {
+    setSubtitleTimelineTrack(null);
+  }, [session.id, selectedSubtitleTrackKey]);
+
+  useEffect(() => {
+    if (
+      !selectedSubtitleTrack ||
+      loadedSubtitleTrackKey !== selectedSubtitleTrackKey ||
+      downloadedSubtitleCues.length === 0
+    ) {
+      return;
+    }
+
+    const trackKey = selectedSubtitleTrackKey;
+    setSubtitleTimelineTrack((current) => {
+      if (current?.trackKey === trackKey) {
+        return current;
+      }
+
+      return buildSubtitleTimelineTrack({
+        trackKey,
+        label: subtitleTrackTimelineLabel(selectedSubtitleTrack),
+        cues: downloadedSubtitleCues,
+      });
+    });
+  }, [
+    downloadedSubtitleCues,
+    loadedSubtitleTrackKey,
+    selectedSubtitleTrack,
+    selectedSubtitleTrackKey,
+  ]);
 
   useEffect(() => {
     const preferredSubtitleTrack = selectPreferredSubtitleTrack(
@@ -144,6 +209,19 @@ export function useEditorSubtitles({
     [clearSubtitleError, resetSubtitleCues, subtitleTracks],
   );
 
+  const updateSubtitleCueTimings = useCallback(
+    (updates: readonly SubtitleCueTimingUpdate[], duration: number) => {
+      setSubtitleTimelineTrack((current) =>
+        applySubtitleCueTimingUpdates({
+          track: current,
+          updates,
+          duration,
+        }),
+      );
+    },
+    [],
+  );
+
   return {
     subtitleTracks,
     selectedSubtitleTrack,
@@ -156,8 +234,10 @@ export function useEditorSubtitles({
     subtitleLoading,
     subtitleError,
     subtitlePreviewEnabled,
+    subtitleTimelineTrack,
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    updateSubtitleCueTimings,
   };
 }

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -9,6 +9,7 @@ import {
   loadSubtitleStyleSettings,
   saveSubtitleStyleSettings,
 } from "@/lib/subtitles/settings";
+import { formatSubtitleTrackLabel } from "@/lib/subtitleTrackLabels";
 import { trimSubtitleCues } from "@/lib/subtitles/trimSubtitleCues";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import { buildSubtitleExportSummary } from "@/components/editor/subtitleExportSummary";
@@ -25,15 +26,6 @@ interface UseEditorSubtitlesProperties {
   session: EditorSession;
   startTime: number;
   endTime: number;
-}
-
-function subtitleTrackTimelineLabel(track: PlaybackSubtitleTrack) {
-  const parts = [
-    track.title?.trim(),
-    track.languageCode?.trim()?.toUpperCase(),
-  ].filter(Boolean);
-
-  return parts.join(" / ") || "Subtitle track";
 }
 
 export function useEditorSubtitles({
@@ -152,7 +144,9 @@ export function useEditorSubtitles({
 
       return buildSubtitleTimelineTrack({
         trackKey,
-        label: subtitleTrackTimelineLabel(selectedSubtitleTrack),
+        label: formatSubtitleTrackLabel(selectedSubtitleTrack, {
+          variant: "timeline",
+        }),
         cues: downloadedSubtitleCues,
       });
     });

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -17,6 +17,9 @@ import {
   roundTimelineTime,
   MIN_CLIP_SECONDS,
   TIMELINE_START_LEFT,
+  CLIP_TIMELINE_ROW_HEIGHT,
+  SOURCE_TIMELINE_ROW_HEIGHT,
+  SUBTITLE_TIMELINE_ROW_HEIGHT,
   timelineTimeToPixel,
   type ClipTimelineData,
   type ClipTimelineEffects,
@@ -26,6 +29,17 @@ import {
   resolveTimelineScrollWheelUpdate,
   resolveTimelineZoomUpdate,
 } from "@/components/editor/timelineZoom";
+import {
+  assignSubtitleCueLanes,
+  snapSubtitleCueTimingUpdateToAdjacentCue,
+  subtitleCueIdFromActionId,
+  subtitleCuesInTimelineWindow,
+  subtitleCueTimelineLabel,
+  subtitleTimelineActionId,
+  type SubtitleCueTimingUpdate,
+  type SubtitleCueTimingUpdateMode,
+  type SubtitleTimelineTrack,
+} from "@/components/editor/subtitleTimeline";
 
 interface UseEditorTimelineProperties {
   duration: number;
@@ -35,12 +49,21 @@ interface UseEditorTimelineProperties {
   sessionId: string;
   updateClipRange: (start: number, end: number) => void;
   onClipRangeCommit?: (start: number, end: number) => void;
+  subtitleTimelineTrack?: SubtitleTimelineTrack | null;
+  updateSubtitleCueTimings?: (
+    updates: readonly SubtitleCueTimingUpdate[],
+    duration: number,
+  ) => void;
 }
 
 interface TimelineZoomAnchorOptions {
   anchorClientX?: number;
   anchorTime?: number;
 }
+
+const SUBTITLE_TIMELINE_OVERSCAN_SECONDS = 120;
+const SUBTITLE_TIMELINE_SNAP_PIXELS = 8;
+const SUBTITLE_TIMELINE_MAX_SNAP_SECONDS = 0.25;
 
 function getTimelineRangeScrollLeft({
   start,
@@ -96,6 +119,8 @@ export function useEditorTimeline({
   sessionId,
   updateClipRange,
   onClipRangeCommit,
+  subtitleTimelineTrack,
+  updateSubtitleCueTimings,
 }: UseEditorTimelineProperties) {
   const timelineReference = useRef<TimelineState>(null);
   const timelineWheelRegionReference = useRef<HTMLDivElement>(null);
@@ -113,6 +138,7 @@ export function useEditorTimeline({
     () => ({
       source: { id: "source", name: "Source" },
       clip: { id: "clip", name: "Clip" },
+      subtitle: { id: "subtitle", name: "Subtitle" },
     }),
     [],
   );
@@ -176,6 +202,15 @@ export function useEditorTimeline({
       ),
     [duration, activeTimelineScale.scale],
   );
+  const subtitleTimelineSnapThresholdSeconds = useMemo(
+    () =>
+      Math.min(
+        SUBTITLE_TIMELINE_MAX_SNAP_SECONDS,
+        (SUBTITLE_TIMELINE_SNAP_PIXELS / activeTimelineScale.scaleWidth) *
+          activeTimelineScale.scale,
+      ),
+    [activeTimelineScale.scale, activeTimelineScale.scaleWidth],
+  );
 
   const timelineData = useMemo<ClipTimelineData>(() => {
     const clipLength = hasDuration
@@ -195,10 +230,41 @@ export function useEditorTimeline({
         )
       : MIN_CLIP_SECONDS;
 
+    const subtitleTimelineCues = subtitleTimelineTrack
+      ? subtitleCuesInTimelineWindow({
+          cues: subtitleTimelineTrack.cues,
+          startTime: Math.max(
+            0,
+            safeStart - SUBTITLE_TIMELINE_OVERSCAN_SECONDS,
+          ),
+          endTime: Math.min(
+            safeDuration,
+            safeEnd + SUBTITLE_TIMELINE_OVERSCAN_SECONDS,
+          ),
+        })
+      : [];
+    const subtitleRows =
+      subtitleTimelineTrack && subtitleTimelineCues.length > 0
+        ? assignSubtitleCueLanes(subtitleTimelineCues).map((lane) => ({
+            id: `${subtitleTimelineTrack.id}:lane:${lane.index}`,
+            rowHeight: SUBTITLE_TIMELINE_ROW_HEIGHT,
+            actions: lane.cues.map((cue) => ({
+              id: subtitleTimelineActionId(cue.id),
+              start: roundTimelineTime(cue.startTime),
+              end: roundTimelineTime(cue.endTime),
+              effectId: "subtitle",
+              flexible: hasDuration,
+              movable: hasDuration,
+              minStart: 0,
+              maxEnd: safeDuration,
+            })),
+          }))
+        : [];
+
     return [
       {
         id: "source-media",
-        rowHeight: 32,
+        rowHeight: SOURCE_TIMELINE_ROW_HEIGHT,
         actions: [
           {
             id: "full-video",
@@ -214,7 +280,7 @@ export function useEditorTimeline({
       },
       {
         id: "clip-range",
-        rowHeight: 44,
+        rowHeight: CLIP_TIMELINE_ROW_HEIGHT,
         selected: true,
         actions: [
           {
@@ -230,8 +296,20 @@ export function useEditorTimeline({
           },
         ],
       },
+      ...subtitleRows,
     ];
-  }, [duration, endTime, hasDuration, startTime]);
+  }, [duration, endTime, hasDuration, startTime, subtitleTimelineTrack]);
+
+  const timelineSubtitleActionLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const cue of subtitleTimelineTrack?.cues ?? []) {
+      labels.set(
+        subtitleTimelineActionId(cue.id),
+        subtitleCueTimelineLabel(cue),
+      );
+    }
+    return labels;
+  }, [subtitleTimelineTrack]);
 
   useEffect(() => {
     timelineZoomIndexReference.current = timelineZoomIndex;
@@ -501,25 +579,59 @@ export function useEditorTimeline({
     };
   }, [handleTimelineWheel]);
 
-  const handleTimelineChange = useCallback(
-    (nextData: ClipTimelineData) => {
-      const nextAction = nextData
-        .flatMap((row) => row.actions)
-        .find((action) => action.id === "selected-clip");
-      if (!nextAction) {
-        return false;
-      }
-
-      updateClipRange(nextAction.start, nextAction.end);
-    },
-    [updateClipRange],
-  );
+  const handleTimelineChange = useCallback(() => false, []);
 
   const commitClipRange = useCallback(
     (start: number, end: number) => {
-      onClipRangeCommit?.(roundTimelineTime(start), roundTimelineTime(end));
+      const nextStart = roundTimelineTime(start);
+      const nextEnd = roundTimelineTime(end);
+
+      updateClipRange(nextStart, nextEnd);
+      onClipRangeCommit?.(nextStart, nextEnd);
     },
-    [onClipRangeCommit],
+    [onClipRangeCommit, updateClipRange],
+  );
+
+  const commitSubtitleCueTiming = useCallback(
+    ({
+      action,
+      start,
+      end,
+      mode,
+    }: {
+      action: { id: string };
+      start: number;
+      end: number;
+      mode: SubtitleCueTimingUpdateMode;
+    }) => {
+      const cueId = subtitleCueIdFromActionId(action.id);
+      if (!cueId) {
+        return;
+      }
+
+      updateSubtitleCueTimings?.(
+        [
+          snapSubtitleCueTimingUpdateToAdjacentCue({
+            track: subtitleTimelineTrack,
+            duration,
+            thresholdSeconds: subtitleTimelineSnapThresholdSeconds,
+            mode,
+            update: {
+              cueId,
+              startTime: start,
+              endTime: end,
+            },
+          }),
+        ],
+        duration,
+      );
+    },
+    [
+      duration,
+      subtitleTimelineSnapThresholdSeconds,
+      subtitleTimelineTrack,
+      updateSubtitleCueTimings,
+    ],
   );
 
   const handleTimelineActionMoveEnd = useCallback(
@@ -533,12 +645,13 @@ export function useEditorTimeline({
       end: number;
     }) => {
       if (action.id !== "selected-clip") {
+        commitSubtitleCueTiming({ action, start, end, mode: "move" });
         return;
       }
 
       commitClipRange(start, end);
     },
-    [commitClipRange],
+    [commitClipRange, commitSubtitleCueTiming],
   );
 
   const handleTimelineActionResizeEnd = useCallback(
@@ -546,18 +659,26 @@ export function useEditorTimeline({
       action,
       start,
       end,
+      dir,
     }: {
       action: { id: string };
       start: number;
       end: number;
+      dir?: "right" | "left";
     }) => {
       if (action.id !== "selected-clip") {
+        commitSubtitleCueTiming({
+          action,
+          start,
+          end,
+          mode: dir === "left" ? "resize-left" : "resize-right",
+        });
         return;
       }
 
       commitClipRange(start, end);
     },
-    [commitClipRange],
+    [commitClipRange, commitSubtitleCueTiming],
   );
 
   return {
@@ -565,6 +686,7 @@ export function useEditorTimeline({
     timelineWheelRegionRef: timelineWheelRegionReference,
     timelineData,
     timelineEffects,
+    timelineSubtitleActionLabels,
     activeTimelineScale,
     timelineScaleCount,
     timelineViewportWidth,

--- a/apps/frontend/src/components/editor/useSubtitleCues.ts
+++ b/apps/frontend/src/components/editor/useSubtitleCues.ts
@@ -7,6 +7,7 @@ import {
 } from "@cliparr/shared/logging";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
+  subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
   subtitleTrackUnavailableMessage,
 } from "@/lib/selectPreferredSubtitleTrack";
@@ -91,11 +92,15 @@ export function useSubtitleCues({
   const [subtitleCues, setSubtitleCues] = useState<SubtitleCue[]>([]);
   const [subtitleLoading, setSubtitleLoading] = useState(false);
   const [subtitleError, setSubtitleError] = useState<string | null>(null);
+  const [loadedSubtitleTrackKey, setLoadedSubtitleTrackKey] = useState<
+    string | null
+  >(null);
 
   const resetSubtitleCues = useCallback(() => {
     setSubtitleCues([]);
     setSubtitleLoading(false);
     setSubtitleError(null);
+    setLoadedSubtitleTrackKey(null);
   }, []);
 
   const clearSubtitleError = useCallback(() => {
@@ -119,6 +124,7 @@ export function useSubtitleCues({
       if (!subtitleTrackSupportsBurnIn(selectedSubtitleTrack) || !contentUrl) {
         setSubtitleLoading(false);
         setSubtitleCues([]);
+        setLoadedSubtitleTrackKey(null);
         setSubtitleError(
           subtitleTrackUnavailableMessage(selectedSubtitleTrack, providerId) ??
             "This subtitle track is not supported.",
@@ -127,6 +133,7 @@ export function useSubtitleCues({
       }
 
       setSubtitleCues([]);
+      setLoadedSubtitleTrackKey(null);
       setSubtitleLoading(true);
       setSubtitleError(null);
 
@@ -159,6 +166,7 @@ export function useSubtitleCues({
 
         const parsedSubtitleCues = downloadResult.cues;
         setSubtitleCues(parsedSubtitleCues);
+        setLoadedSubtitleTrackKey(subtitleTrackKey(selectedSubtitleTrack));
         setSubtitleError(
           parsedSubtitleCues.length === 0
             ? "No subtitles found in this track."
@@ -174,6 +182,7 @@ export function useSubtitleCues({
         if (cancelled || abortController.signal.aborted) {
           if (!cancelled) {
             setSubtitleCues([]);
+            setLoadedSubtitleTrackKey(null);
             setSubtitleError("Subtitles timed out. Try again.");
             setSubtitleLoading(false);
             logger.warn("Subtitle cue load timed out.", {
@@ -195,6 +204,7 @@ export function useSubtitleCues({
           "subtitle.timeout": false,
         });
         setSubtitleCues([]);
+        setLoadedSubtitleTrackKey(null);
         setSubtitleError(
           error instanceof Error ? error.message : "Could not load subtitles.",
         );
@@ -218,6 +228,7 @@ export function useSubtitleCues({
     subtitleCues,
     subtitleLoading,
     subtitleError,
+    loadedSubtitleTrackKey,
     resetSubtitleCues,
     clearSubtitleError,
   };

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -651,7 +651,7 @@
 
 .cliparr-timeline .timeline-editor-edit-area .ReactVirtualized__Grid {
   overflow-x: scroll !important;
-  overflow-y: hidden !important;
+  overflow-y: auto !important;
   scrollbar-color: var(--editor-scrollbar) transparent;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
@@ -734,6 +734,22 @@
   height: 34px !important;
 }
 
+.cliparr-timeline .timeline-editor-action-effect-subtitle {
+  top: 4px !important;
+  height: 26px !important;
+  border-color: color-mix(
+    in oklch,
+    var(--editor-accent) 46%,
+    var(--editor-border)
+  );
+  background: color-mix(
+    in oklch,
+    var(--editor-accent) 18%,
+    var(--editor-panel)
+  );
+  color: var(--foreground);
+}
+
 .cliparr-timeline .timeline-editor-action .timeline-editor-action-left-stretch,
 .cliparr-timeline
   .timeline-editor-action
@@ -804,6 +820,13 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-overflow: ellipsis;
+}
+
+.cliparr-timeline
+  .timeline-editor-action-effect-subtitle
+  .cliparr-timeline-action-label {
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .cliparr-timeline-action-time {

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -148,8 +148,8 @@ function createRuntime(overrides: Partial<ExportRuntime> = {}) {
         },
       }) as unknown as ReturnType<ExportRuntime["createGifCanvas"]>,
     loadGifEncodingRuntime: async () => createMockGifRuntime(),
-    getActiveSubtitleCue: () => {},
-    renderSubtitleCue: () => {},
+    getActiveSubtitleCues: () => [],
+    renderSubtitleCues: () => {},
     initConversion: async () =>
       createConversion({
         target,
@@ -768,15 +768,15 @@ void test("renders subtitles when burning cues into GIF frames", async () => {
           }),
         },
       }) as unknown as ReturnType<ExportRuntime["createGifCanvas"]>,
-    getActiveSubtitleCue: (cues, timestamp) => {
+    getActiveSubtitleCues: (cues, timestamp) => {
       activeSubtitleTimestamp = timestamp;
-      return cues[0];
+      return [...cues];
     },
-    renderSubtitleCue: (_context, cue, _styleSettings, width, height) => {
-      assert.equal(cue.text, "Hello");
+    renderSubtitleCues: (_context, cues, _styleSettings, width, height) => {
+      assert.equal(cues[0]?.text, "Hello");
       assert.equal(width, 4);
       assert.equal(height, 4);
-      renderedSubtitleCount += 1;
+      renderedSubtitleCount += cues.length;
     },
   });
 

--- a/apps/frontend/src/lib/exportClip.ts
+++ b/apps/frontend/src/lib/exportClip.ts
@@ -55,8 +55,8 @@ import type {
   GifFrameEncoder,
   GifFrameEncoderOptions,
 } from "#/lib/gifFrameEncoder";
-import { getActiveSubtitleCue } from "#/lib/subtitles/getActiveSubtitleCue";
-import { renderSubtitleCue } from "#/lib/subtitles/renderSubtitleCue";
+import { getActiveSubtitleCues } from "#/lib/subtitles/getActiveSubtitleCue";
+import { renderSubtitleCues } from "#/lib/subtitles/renderSubtitleCue";
 import { trimSubtitleCues } from "#/lib/subtitles/trimSubtitleCues";
 import type { SubtitleCue, SubtitleStyleSettings } from "#/lib/subtitles/types";
 
@@ -98,8 +98,8 @@ interface ExportClipRuntime {
   ) => CanvasSink;
   createGifCanvas: typeof createGifCanvas;
   loadGifEncodingRuntime: () => Promise<GifEncodingRuntime>;
-  getActiveSubtitleCue: typeof getActiveSubtitleCue;
-  renderSubtitleCue: typeof renderSubtitleCue;
+  getActiveSubtitleCues: typeof getActiveSubtitleCues;
+  renderSubtitleCues: typeof renderSubtitleCues;
   initConversion: typeof Conversion.init;
   buildSubtitleBurnInProcessor: typeof buildSubtitleBurnInProcessor;
 }
@@ -295,9 +295,9 @@ function buildSubtitleBurnInProcessor(
     context.clearRect(0, 0, width, height);
     sample.draw(context, 0, 0, width, height);
 
-    const activeCue = getActiveSubtitleCue(cues, sample.timestamp);
-    if (activeCue) {
-      renderSubtitleCue(context, activeCue, styleSettings, width, height);
+    const activeCues = getActiveSubtitleCues(cues, sample.timestamp);
+    if (activeCues.length > 0) {
+      renderSubtitleCues(context, activeCues, styleSettings, width, height);
     }
 
     return canvas;
@@ -358,8 +358,8 @@ const defaultExportClipRuntime: ExportClipRuntime = {
   createCanvasSink: (track, options) => new CanvasSink(track, options),
   createGifCanvas,
   loadGifEncodingRuntime,
-  getActiveSubtitleCue,
-  renderSubtitleCue,
+  getActiveSubtitleCues,
+  renderSubtitleCues,
   initConversion: (options) => Conversion.init(options),
   buildSubtitleBurnInProcessor,
 };
@@ -710,15 +710,15 @@ async function exportGifClipWithRuntime(
       );
 
       if (shouldBurnSubtitles && subtitleStyleSettings) {
-        const activeCue = runtime.getActiveSubtitleCue(
+        const activeCues = runtime.getActiveSubtitleCues(
           clippedSubtitleCues,
           displayTimestamp - startTime,
         );
 
-        if (activeCue) {
-          runtime.renderSubtitleCue(
+        if (activeCues.length > 0) {
+          runtime.renderSubtitleCues(
             context,
-            activeCue,
+            activeCues,
             subtitleStyleSettings,
             outputDimensions.width,
             outputDimensions.height,

--- a/apps/frontend/src/lib/subtitleTrackLabels.test.ts
+++ b/apps/frontend/src/lib/subtitleTrackLabels.test.ts
@@ -1,0 +1,67 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatSubtitleTrackLabel,
+  formatSubtitleTrackTechnicalSummary,
+} from "@/lib/subtitleTrackLabels";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+
+void test("formats subtitle track labels for selector summary and timeline surfaces", () => {
+  const track = {
+    title: " English SDH ",
+    languageCode: " en ",
+    codec: " srt ",
+    isText: true,
+    contentUrl: "/api/media/subtitles/en.srt",
+    isForced: true,
+    isHearingImpaired: true,
+    isDefault: true,
+    isExternal: true,
+  } satisfies PlaybackSubtitleTrack;
+
+  assert.equal(
+    formatSubtitleTrackLabel(track, { variant: "selector" }),
+    "English SDH (EN | SRT | Forced · SDH · Default · External)",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel(track, { variant: "summary" }),
+    "English SDH",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel(track, { variant: "timeline" }),
+    "English SDH / EN",
+  );
+  assert.equal(
+    formatSubtitleTrackTechnicalSummary(track),
+    "SRT · EN · Forced · SDH",
+  );
+});
+
+void test("formats fallback subtitle track labels consistently", () => {
+  assert.equal(
+    formatSubtitleTrackLabel({ languageCode: "es" }, { variant: "selector" }),
+    "ES (Unsupported)",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel({ languageCode: "es" }, { variant: "summary" }),
+    "ES",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel({ languageCode: "es" }, { variant: "timeline" }),
+    "ES",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel({}, { variant: "selector" }),
+    "Unnamed subtitle track (Unsupported)",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel({}, { variant: "summary" }),
+    "Selected subtitle track",
+  );
+  assert.equal(
+    formatSubtitleTrackLabel({}, { variant: "timeline" }),
+    "Subtitle track",
+  );
+});

--- a/apps/frontend/src/lib/subtitleTrackLabels.ts
+++ b/apps/frontend/src/lib/subtitleTrackLabels.ts
@@ -1,0 +1,85 @@
+import { subtitleTrackSupportsBurnIn } from "@/lib/selectPreferredSubtitleTrack";
+import type { PlaybackSubtitleTrack } from "@/providers/types";
+
+type SubtitleTrackLabelVariant = "selector" | "summary" | "timeline";
+
+interface SubtitleTrackLabelOptions {
+  variant?: SubtitleTrackLabelVariant;
+}
+
+interface SubtitleTrackLabelParts {
+  title?: string;
+  language?: string;
+  codec?: string;
+  flags: string[];
+}
+
+function isPresent(value: string | null | undefined): value is string {
+  return Boolean(value);
+}
+
+function trimmedText(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function subtitleTrackLabelParts(
+  track: PlaybackSubtitleTrack,
+): SubtitleTrackLabelParts {
+  return {
+    title: trimmedText(track.title),
+    language: trimmedText(track.languageCode)?.toUpperCase(),
+    codec: trimmedText(track.codec)?.toUpperCase(),
+    flags: [
+      track.isForced ? "Forced" : null,
+      track.isHearingImpaired ? "SDH" : null,
+      track.isDefault ? "Default" : null,
+      track.isExternal ? "External" : null,
+      subtitleTrackSupportsBurnIn(track) ? null : "Unsupported",
+    ].filter(isPresent),
+  };
+}
+
+export function formatSubtitleTrackLabel(
+  track: PlaybackSubtitleTrack,
+  { variant = "summary" }: SubtitleTrackLabelOptions = {},
+) {
+  const parts = subtitleTrackLabelParts(track);
+
+  if (variant === "selector") {
+    const baseLabel = parts.title ?? parts.language ?? "Unnamed subtitle track";
+    const detailParts = [
+      parts.title && parts.language ? parts.language : null,
+      parts.codec,
+      parts.flags.join(" · ") || null,
+    ].filter(isPresent);
+
+    return detailParts.length > 0
+      ? `${baseLabel} (${detailParts.join(" | ")})`
+      : baseLabel;
+  }
+
+  if (variant === "timeline") {
+    return (
+      [parts.title, parts.language].filter(isPresent).join(" / ") ||
+      "Subtitle track"
+    );
+  }
+
+  return parts.title ?? parts.language ?? "Selected subtitle track";
+}
+
+export function formatSubtitleTrackTechnicalSummary(
+  track: PlaybackSubtitleTrack,
+) {
+  const parts = subtitleTrackLabelParts(track);
+
+  return [
+    parts.codec ?? "Unknown codec",
+    parts.language,
+    track.isForced ? "Forced" : null,
+    track.isHearingImpaired ? "SDH" : null,
+  ]
+    .filter(isPresent)
+    .join(" · ");
+}

--- a/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getActiveSubtitleCue,
+  getActiveSubtitleCues,
+} from "@/lib/subtitles/getActiveSubtitleCue";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+
+const cues: SubtitleCue[] = [
+  {
+    id: "cue-1",
+    startTime: 0,
+    endTime: 3,
+    text: "Top line",
+    lines: ["Top line"],
+  },
+  {
+    id: "cue-2",
+    startTime: 1,
+    endTime: 4,
+    text: "Bottom line",
+    lines: ["Bottom line"],
+  },
+  {
+    id: "cue-3",
+    startTime: 4,
+    endTime: 5,
+    text: "Next",
+    lines: ["Next"],
+  },
+];
+
+void test("returns all overlapping active subtitle cues", () => {
+  assert.deepEqual(
+    getActiveSubtitleCues(cues, 2).map((cue) => cue.id),
+    ["cue-1", "cue-2"],
+  );
+});
+
+void test("returns the first active subtitle cue for singular callers", () => {
+  assert.deepEqual(getActiveSubtitleCue(cues, 2), cues[0]);
+});
+
+void test("keeps adjacent subtitle cues from overlapping", () => {
+  assert.deepEqual(
+    getActiveSubtitleCues(cues, 4).map((cue) => cue.id),
+    ["cue-3"],
+  );
+});

--- a/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/getActiveSubtitleCue.ts
@@ -1,31 +1,30 @@
 import type { SubtitleCue } from "@/lib/subtitles/types";
 
+export function getActiveSubtitleCues(
+  cues: readonly SubtitleCue[],
+  time: number,
+) {
+  if (!Number.isFinite(time)) {
+    return [];
+  }
+
+  const activeCues: SubtitleCue[] = [];
+  for (const cue of cues) {
+    if (cue.startTime > time) {
+      break;
+    }
+
+    if (time >= cue.startTime && time < cue.endTime) {
+      activeCues.push(cue);
+    }
+  }
+
+  return activeCues;
+}
+
 export function getActiveSubtitleCue(
   cues: readonly SubtitleCue[],
   time: number,
 ) {
-  let low = 0;
-  let high = cues.length - 1;
-
-  while (low <= high) {
-    const mid = Math.floor((low + high) / 2);
-    const cue = cues[mid];
-    if (!cue) {
-      break;
-    }
-
-    if (time < cue.startTime) {
-      high = mid - 1;
-      continue;
-    }
-
-    if (time >= cue.endTime) {
-      low = mid + 1;
-      continue;
-    }
-
-    return cue;
-  }
-
-  return;
+  return getActiveSubtitleCues(cues, time)[0];
 }

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   renderSubtitleCue,
+  renderSubtitleCues,
   resolveSubtitleLayerBounds,
 } from "@/lib/subtitles/renderSubtitleCue";
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
@@ -16,6 +17,12 @@ interface FakeCanvas {
 
 interface FakeCanvasContext {
   canvas: { ownerDocument: { createElement: () => FakeCanvas } };
+  drawImageCalls: Array<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>;
   fillStyle: string;
   font: string;
   imageSmoothingEnabled: boolean;
@@ -33,7 +40,7 @@ interface FakeCanvasContext {
   save: () => void;
   restore: () => void;
   measureText: (text: string) => { width: number };
-  drawImage: () => undefined;
+  drawImage: (...parameters: unknown[]) => undefined;
   fillText: () => undefined;
   strokeText: () => undefined;
 }
@@ -44,6 +51,7 @@ function createFakeCanvasContext(ownerDocument: {
   const stateStack: string[] = [];
   const context: FakeCanvasContext = {
     canvas: { ownerDocument },
+    drawImageCalls: [],
     fillStyle: "",
     font: "10px initial",
     imageSmoothingEnabled: false,
@@ -70,7 +78,16 @@ function createFakeCanvasContext(ownerDocument: {
     measureText(text) {
       return { width: text.length * 12 };
     },
-    drawImage() {
+    drawImage(...parameters) {
+      const [, x, y, width, height] = parameters;
+      if (
+        typeof x === "number" &&
+        typeof y === "number" &&
+        typeof width === "number" &&
+        typeof height === "number"
+      ) {
+        context.drawImageCalls.push({ x, y, width, height });
+      }
       return;
     },
     fillText() {
@@ -179,4 +196,37 @@ void test("rendering subtitles preserves the caller canvas font", () => {
   );
 
   assert.equal(context.font, "16px caller");
+});
+
+void test("rendering multiple subtitle cues composites separate cue layers at the same anchor", () => {
+  const ownerDocument = {
+    createElement: () => createFakeCanvas(ownerDocument),
+  };
+  const context = createFakeCanvasContext(ownerDocument);
+
+  renderSubtitleCues(
+    context as unknown as CanvasRenderingContext2D,
+    [
+      {
+        id: "overlap-cue-1",
+        startTime: 0,
+        endTime: 2,
+        text: "Bottom cue",
+        lines: ["Bottom cue"],
+      },
+      {
+        id: "overlap-cue-2",
+        startTime: 0,
+        endTime: 2,
+        text: "Top cue",
+        lines: ["Top cue"],
+      },
+    ],
+    subtitleStyle,
+    1920,
+    1080,
+  );
+
+  assert.equal(context.drawImageCalls.length, 2);
+  assert.equal(context.drawImageCalls[0]!.y, context.drawImageCalls[1]!.y);
 });

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -20,6 +20,15 @@ interface SubtitleLayer {
   bounds: SubtitleLayerBounds;
 }
 
+interface SubtitleCueRenderMetrics {
+  fontSize: number;
+  strokeWidth: number;
+  shadowBlur: number;
+  shadowOffsetY: number;
+  bottomMargin: number;
+  layout: SubtitleLayout;
+}
+
 const subtitleLayoutCache = new Map<string, SubtitleLayout>();
 const SUBTITLE_LAYOUT_CACHE_LIMIT = 120;
 const subtitleLayerCache = new Map<string, SubtitleLayer>();
@@ -419,13 +428,19 @@ function drawDirectSubtitleText({
   }
 }
 
-export function renderSubtitleCue(
-  context: CanvasRenderingContext2D,
-  cue: SubtitleCue,
-  style: SubtitleStyleSettings,
-  canvasWidth: number,
-  canvasHeight: number,
-) {
+function resolveSubtitleCueRenderMetrics({
+  context,
+  cue,
+  style,
+  canvasWidth,
+  canvasHeight,
+}: {
+  context: CanvasRenderingContext2D;
+  cue: SubtitleCue;
+  style: SubtitleStyleSettings;
+  canvasWidth: number;
+  canvasHeight: number;
+}): SubtitleCueRenderMetrics {
   const fontSize = Math.max(12, scaledValue(style.fontSize, canvasHeight));
   const strokeWidth = Math.max(0, scaledValue(style.strokeWidth, canvasHeight));
   const shadowBlur = Math.max(0, scaledValue(style.shadowBlur, canvasHeight));
@@ -435,15 +450,42 @@ export function renderSubtitleCue(
     scaledValue(style.bottomMargin, canvasHeight),
   );
   const maxWidth = canvasWidth * 0.84;
-  const layout = cachedSubtitleLayout(
-    context,
-    cue,
-    style,
-    canvasWidth,
-    canvasHeight,
+
+  return {
     fontSize,
-    maxWidth,
-  );
+    strokeWidth,
+    shadowBlur,
+    shadowOffsetY,
+    bottomMargin,
+    layout: cachedSubtitleLayout(
+      context,
+      cue,
+      style,
+      canvasWidth,
+      canvasHeight,
+      fontSize,
+      maxWidth,
+    ),
+  };
+}
+
+function renderSubtitleCueWithMetrics({
+  context,
+  cue,
+  style,
+  canvasWidth,
+  canvasHeight,
+  metrics,
+}: {
+  context: CanvasRenderingContext2D;
+  cue: SubtitleCue;
+  style: SubtitleStyleSettings;
+  canvasWidth: number;
+  canvasHeight: number;
+  metrics: SubtitleCueRenderMetrics;
+}) {
+  const { strokeWidth, shadowBlur, shadowOffsetY, bottomMargin, layout } =
+    metrics;
 
   context.save();
   context.font = layout.font;
@@ -486,4 +528,40 @@ export function renderSubtitleCue(
   }
 
   context.restore();
+}
+
+export function renderSubtitleCue(
+  context: CanvasRenderingContext2D,
+  cue: SubtitleCue,
+  style: SubtitleStyleSettings,
+  canvasWidth: number,
+  canvasHeight: number,
+) {
+  const metrics = resolveSubtitleCueRenderMetrics({
+    context,
+    cue,
+    style,
+    canvasWidth,
+    canvasHeight,
+  });
+  renderSubtitleCueWithMetrics({
+    context,
+    cue,
+    style,
+    canvasWidth,
+    canvasHeight,
+    metrics,
+  });
+}
+
+export function renderSubtitleCues(
+  context: CanvasRenderingContext2D,
+  cues: readonly SubtitleCue[],
+  style: SubtitleStyleSettings,
+  canvasWidth: number,
+  canvasHeight: number,
+) {
+  for (const cue of cues) {
+    renderSubtitleCue(context, cue, style, canvasWidth, canvasHeight);
+  }
 }


### PR DESCRIPTION
## Summary
- Add a canonical editable subtitle cue model for the selected supported subtitle track
- Render subtitle cue lanes below the clip row with drag/resize timing updates and adjacency snapping
- Render concurrent active subtitle cues separately in preview and export burn-in

<img width="3816" height="1908" alt="Screenshot 2026-06-24 at 14-17-46" src="https://github.com/user-attachments/assets/9afd2567-e85e-4c4b-852b-fdc950fa47f0" />


## Validation
- pnpm preflight