### PR TITLE
fix(server): prefer fresh Plex account token during dedupe

### DIFF
--- a/apps/server/src/db/plexSourceDeduplication.ts
+++ b/apps/server/src/db/plexSourceDeduplication.ts
@@ -471,13 +471,17 @@ function reassignMediaSourcesForProviderAccount(
 function updateMergedProviderAccount(
   canonicalAccountId: string,
   accounts: ProviderAccount[],
+  newlyAuthenticatedAccountId?: string,
 ) {
   const canonicalAccount = getProviderAccount(canonicalAccountId);
   if (!canonicalAccount) {
     return;
   }
 
-  const latestAccount = latestUpdatedAccount(accounts) ?? canonicalAccount;
+  const latestAccount =
+    accounts.find((account) => account.id === newlyAuthenticatedAccountId) ??
+    latestUpdatedAccount(accounts) ??
+    canonicalAccount;
   updateProviderAccount(canonicalAccountId, {
     label: canonicalAccount.label,
     accessToken: latestAccount.accessToken,
@@ -570,7 +574,11 @@ function cleanupDuplicatePlexSourcesInTransaction(
   }
 
   for (const [canonicalAccountId, accounts] of componentAccountsByCanonicalId) {
-    updateMergedProviderAccount(canonicalAccountId, accounts);
+    updateMergedProviderAccount(
+      canonicalAccountId,
+      accounts,
+      options.newlyAuthenticatedAccountId,
+    );
   }
 
   const providerAccountId = resolveCanonicalAccountId(


### PR DESCRIPTION
## Summary
- Prefer the newly authenticated Plex account token when duplicate Plex provider accounts are merged during source dedupe.
- Keep the existing latest-updated fallback for non-auth cleanup paths.

## Validation
- pnpm --filter @cliparr/server test -- src/db/providerPersistence.test.ts
- pnpm preflight