### PR TITLE
feat(frontend): add subtitle position controls

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -364,9 +364,8 @@ flowchart TD
   after timing changes.
 - Preview and export consume adjusted subtitle cues from the timeline model, not
   the original parsed cue list.
-- Concurrent active cues render as separate composited cues at the same default
-  subtitle anchor. They are not merged into one cue and are not auto-stacked;
-  positioning controls are future work.
+- Concurrent active cues render as separate composited cues at the same global
+  subtitle position. They are not merged into one cue and are not auto-stacked.
 - Text editing, add/remove, provider-side subtitle writes, lazy cue loading, and
   sidecar export/persistence are outside the v1 timeline scope.
 

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -349,14 +349,14 @@ export function EditorSubtitlePanel({
 
         <EditorPropertySection title="Position">
           <EditorRangeControl
-            label="Bottom"
-            value={subtitleStyleSettings.bottomMargin}
+            label="Y"
+            value={subtitleStyleSettings.positionY}
             min={0}
-            max={180}
+            max={100}
             step={1}
-            unit="px"
+            unit="%"
             disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("bottomMargin", value)}
+            onChange={(value) => updateStyleSetting("positionY", value)}
           />
         </EditorPropertySection>
       </div>

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -349,6 +349,16 @@ export function EditorSubtitlePanel({
 
         <EditorPropertySection title="Position">
           <EditorRangeControl
+            label="X"
+            value={subtitleStyleSettings.positionX}
+            min={0}
+            max={100}
+            step={1}
+            unit="%"
+            disabled={styleControlsDisabled}
+            onChange={(value) => updateStyleSetting("positionX", value)}
+          />
+          <EditorRangeControl
             label="Y"
             value={subtitleStyleSettings.positionY}
             min={0}

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -53,6 +53,7 @@ const subtitleStyle = {
   shadowOffsetY: 2,
   strokeColor: "#000000",
   strokeWidth: 2,
+  positionX: 50,
   positionY: 10,
   lineHeight: 1.2,
 } satisfies SubtitleStyleSettings;

--- a/apps/frontend/src/lib/exportClip.test.ts
+++ b/apps/frontend/src/lib/exportClip.test.ts
@@ -53,7 +53,7 @@ const subtitleStyle = {
   shadowOffsetY: 2,
   strokeColor: "#000000",
   strokeWidth: 2,
-  bottomMargin: 48,
+  positionY: 10,
   lineHeight: 1.2,
 } satisfies SubtitleStyleSettings;
 

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   renderSubtitleCue,
   renderSubtitleCues,
+  resolveSubtitleCenterX,
   resolveSubtitleLayerBounds,
   resolveSubtitleStartY,
 } from "@/lib/subtitles/renderSubtitleCue";
@@ -128,6 +129,7 @@ const subtitleStyle: SubtitleStyleSettings = {
   shadowBlur: 8,
   shadowColor: "rgba(0, 0, 0, 0.7)",
   shadowOffsetY: 4,
+  positionX: 50,
   positionY: 10,
 };
 
@@ -172,6 +174,58 @@ void test("clamps subtitle supersampling bounds to the target canvas", () => {
       width: 640,
       height: 46,
     },
+  );
+});
+
+void test("resolves subtitle horizontal center from the center position", () => {
+  assert.equal(
+    resolveSubtitleCenterX({
+      canvasWidth: 1920,
+      positionX: 50,
+      maxLineWidth: 480,
+    }),
+    960,
+  );
+});
+
+void test("clamps subtitle horizontal center to the left edge", () => {
+  assert.equal(
+    resolveSubtitleCenterX({
+      canvasWidth: 1920,
+      positionX: 0,
+      maxLineWidth: 480,
+    }),
+    240,
+  );
+});
+
+void test("clamps subtitle horizontal center to the right edge", () => {
+  assert.equal(
+    resolveSubtitleCenterX({
+      canvasWidth: 1920,
+      positionX: 100,
+      maxLineWidth: 480,
+    }),
+    1680,
+  );
+});
+
+void test("keeps oversized subtitle lines centered horizontally", () => {
+  assert.equal(
+    resolveSubtitleCenterX({
+      canvasWidth: 1920,
+      positionX: 0,
+      maxLineWidth: 2400,
+    }),
+    960,
+  );
+  assert.equal(
+    resolveSubtitleCenterX({
+      canvasWidth: 1920,
+      positionX: 100,
+      maxLineWidth: 2400,
+    }),
+    960,
   );
 });
 

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.test.ts
@@ -6,6 +6,7 @@ import {
   renderSubtitleCue,
   renderSubtitleCues,
   resolveSubtitleLayerBounds,
+  resolveSubtitleStartY,
 } from "@/lib/subtitles/renderSubtitleCue";
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 
@@ -127,7 +128,7 @@ const subtitleStyle: SubtitleStyleSettings = {
   shadowBlur: 8,
   shadowColor: "rgba(0, 0, 0, 0.7)",
   shadowOffsetY: 4,
-  bottomMargin: 96,
+  positionY: 10,
 };
 
 void test("resolves subtitle supersampling bounds with stroke and shadow padding", () => {
@@ -171,6 +172,58 @@ void test("clamps subtitle supersampling bounds to the target canvas", () => {
       width: 640,
       height: 46,
     },
+  );
+});
+
+void test("resolves subtitle vertical start from the center position", () => {
+  assert.equal(
+    resolveSubtitleStartY({
+      canvasHeight: 1080,
+      positionY: 50,
+      totalHeight: 120,
+    }),
+    480,
+  );
+});
+
+void test("clamps subtitle vertical start to the top edge", () => {
+  assert.equal(
+    resolveSubtitleStartY({
+      canvasHeight: 1080,
+      positionY: 100,
+      totalHeight: 120,
+    }),
+    0,
+  );
+});
+
+void test("clamps subtitle vertical start to the bottom edge", () => {
+  assert.equal(
+    resolveSubtitleStartY({
+      canvasHeight: 1080,
+      positionY: 0,
+      totalHeight: 120,
+    }),
+    960,
+  );
+});
+
+void test("keeps tall multiline subtitles inside the frame bounds", () => {
+  assert.equal(
+    resolveSubtitleStartY({
+      canvasHeight: 1080,
+      positionY: 100,
+      totalHeight: 900,
+    }),
+    0,
+  );
+  assert.equal(
+    resolveSubtitleStartY({
+      canvasHeight: 1080,
+      positionY: 0,
+      totalHeight: 900,
+    }),
+    180,
   );
 });
 

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -25,7 +25,7 @@ interface SubtitleCueRenderMetrics {
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
-  bottomMargin: number;
+  positionY: number;
   layout: SubtitleLayout;
 }
 
@@ -37,6 +37,49 @@ const SUBTITLE_SUPERSAMPLE_SCALE = 2;
 
 function scaledValue(value: number, canvasHeight: number) {
   return value * (canvasHeight / 1080);
+}
+
+function clampNumber(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function resolveSubtitleStartY({
+  canvasHeight,
+  positionY,
+  totalHeight,
+}: {
+  canvasHeight: number;
+  positionY: number;
+  totalHeight: number;
+}) {
+  const safeCanvasHeight = Math.max(1, canvasHeight);
+  const safeTotalHeight = Math.max(0, totalHeight);
+  const desiredCenterY = safeCanvasHeight * ((100 - positionY) / 100);
+  const unclampedStartY = desiredCenterY - safeTotalHeight / 2;
+  const maxStartY = Math.max(0, safeCanvasHeight - safeTotalHeight);
+
+  return clampNumber(unclampedStartY, 0, maxStartY);
+}
+
+function resolveSubtitlePlacement({
+  canvasHeight,
+  layout,
+  positionY,
+}: {
+  canvasHeight: number;
+  layout: SubtitleLayout;
+  positionY: number;
+}) {
+  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
+
+  return {
+    startY: resolveSubtitleStartY({
+      canvasHeight,
+      positionY,
+      totalHeight,
+    }),
+    totalHeight,
+  };
 }
 
 function wrapLine(
@@ -202,7 +245,7 @@ function cueLayerKey({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
-  bottomMargin,
+  positionY,
 }: {
   cue: SubtitleCue;
   style: SubtitleStyleSettings;
@@ -212,7 +255,7 @@ function cueLayerKey({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
-  bottomMargin: number;
+  positionY: number;
 }) {
   return JSON.stringify([
     cue.id,
@@ -230,7 +273,7 @@ function cueLayerKey({
     style.shadowColor,
     shadowBlur,
     shadowOffsetY,
-    bottomMargin,
+    positionY,
     SUBTITLE_SUPERSAMPLE_SCALE,
   ]);
 }
@@ -255,7 +298,7 @@ function renderSupersampledSubtitleLayer({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
-  bottomMargin,
+  positionY,
 }: {
   context: CanvasRenderingContext2D;
   cue: SubtitleCue;
@@ -266,7 +309,7 @@ function renderSupersampledSubtitleLayer({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
-  bottomMargin: number;
+  positionY: number;
 }): SubtitleLayer | null {
   const key = cueLayerKey({
     cue,
@@ -277,15 +320,18 @@ function renderSupersampledSubtitleLayer({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
-    bottomMargin,
+    positionY,
   });
   const cached = subtitleLayerCache.get(key);
   if (cached) {
     return cached;
   }
 
-  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
-  const startY = canvasHeight - bottomMargin - totalHeight;
+  const { startY, totalHeight } = resolveSubtitlePlacement({
+    canvasHeight,
+    layout,
+    positionY,
+  });
   const centerX = canvasWidth / 2;
   const maxLineWidth = Math.max(1, ...layout.lineWidths);
   const bounds = resolveSubtitleLayerBounds({
@@ -391,7 +437,7 @@ function drawDirectSubtitleText({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
-  bottomMargin,
+  positionY,
 }: {
   context: CanvasRenderingContext2D;
   layout: SubtitleLayout;
@@ -401,10 +447,13 @@ function drawDirectSubtitleText({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
-  bottomMargin: number;
+  positionY: number;
 }) {
-  const totalHeight = layout.lineHeight * layout.wrappedLines.length;
-  const startY = canvasHeight - bottomMargin - totalHeight;
+  const { startY } = resolveSubtitlePlacement({
+    canvasHeight,
+    layout,
+    positionY,
+  });
   const x = canvasWidth / 2;
 
   if (strokeWidth > 0) {
@@ -445,10 +494,7 @@ function resolveSubtitleCueRenderMetrics({
   const strokeWidth = Math.max(0, scaledValue(style.strokeWidth, canvasHeight));
   const shadowBlur = Math.max(0, scaledValue(style.shadowBlur, canvasHeight));
   const shadowOffsetY = scaledValue(style.shadowOffsetY, canvasHeight);
-  const bottomMargin = Math.max(
-    0,
-    scaledValue(style.bottomMargin, canvasHeight),
-  );
+  const positionY = clampNumber(style.positionY, 0, 100);
   const maxWidth = canvasWidth * 0.84;
 
   return {
@@ -456,7 +502,7 @@ function resolveSubtitleCueRenderMetrics({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
-    bottomMargin,
+    positionY,
     layout: cachedSubtitleLayout(
       context,
       cue,
@@ -484,8 +530,7 @@ function renderSubtitleCueWithMetrics({
   canvasHeight: number;
   metrics: SubtitleCueRenderMetrics;
 }) {
-  const { strokeWidth, shadowBlur, shadowOffsetY, bottomMargin, layout } =
-    metrics;
+  const { strokeWidth, shadowBlur, shadowOffsetY, positionY, layout } = metrics;
 
   context.save();
   context.font = layout.font;
@@ -509,7 +554,7 @@ function renderSubtitleCueWithMetrics({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
-    bottomMargin,
+    positionY,
   });
   if (layer) {
     drawSubtitleLayer(context, layer);
@@ -523,7 +568,7 @@ function renderSubtitleCueWithMetrics({
       strokeWidth,
       shadowBlur,
       shadowOffsetY,
-      bottomMargin,
+      positionY,
     });
   }
 

--- a/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
+++ b/apps/frontend/src/lib/subtitles/renderSubtitleCue.ts
@@ -25,6 +25,7 @@ interface SubtitleCueRenderMetrics {
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
+  positionX: number;
   positionY: number;
   layout: SubtitleLayout;
 }
@@ -61,18 +62,46 @@ export function resolveSubtitleStartY({
   return clampNumber(unclampedStartY, 0, maxStartY);
 }
 
+export function resolveSubtitleCenterX({
+  canvasWidth,
+  positionX,
+  maxLineWidth,
+}: {
+  canvasWidth: number;
+  positionX: number;
+  maxLineWidth: number;
+}) {
+  const safeCanvasWidth = Math.max(1, canvasWidth);
+  const safeMaxLineWidth = Math.max(1, maxLineWidth);
+  const desiredCenterX = safeCanvasWidth * (positionX / 100);
+  const halfWidth = Math.min(safeCanvasWidth, safeMaxLineWidth) / 2;
+
+  return clampNumber(desiredCenterX, halfWidth, safeCanvasWidth - halfWidth);
+}
+
 function resolveSubtitlePlacement({
+  canvasWidth,
   canvasHeight,
   layout,
+  positionX,
   positionY,
 }: {
+  canvasWidth: number;
   canvasHeight: number;
   layout: SubtitleLayout;
+  positionX: number;
   positionY: number;
 }) {
   const totalHeight = layout.lineHeight * layout.wrappedLines.length;
+  const maxLineWidth = Math.max(1, ...layout.lineWidths);
 
   return {
+    centerX: resolveSubtitleCenterX({
+      canvasWidth,
+      positionX,
+      maxLineWidth,
+    }),
+    maxLineWidth,
     startY: resolveSubtitleStartY({
       canvasHeight,
       positionY,
@@ -245,6 +274,7 @@ function cueLayerKey({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
+  positionX,
   positionY,
 }: {
   cue: SubtitleCue;
@@ -255,6 +285,7 @@ function cueLayerKey({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
+  positionX: number;
   positionY: number;
 }) {
   return JSON.stringify([
@@ -273,6 +304,7 @@ function cueLayerKey({
     style.shadowColor,
     shadowBlur,
     shadowOffsetY,
+    positionX,
     positionY,
     SUBTITLE_SUPERSAMPLE_SCALE,
   ]);
@@ -298,6 +330,7 @@ function renderSupersampledSubtitleLayer({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
+  positionX,
   positionY,
 }: {
   context: CanvasRenderingContext2D;
@@ -309,6 +342,7 @@ function renderSupersampledSubtitleLayer({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
+  positionX: number;
   positionY: number;
 }): SubtitleLayer | null {
   const key = cueLayerKey({
@@ -320,6 +354,7 @@ function renderSupersampledSubtitleLayer({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
+    positionX,
     positionY,
   });
   const cached = subtitleLayerCache.get(key);
@@ -327,13 +362,14 @@ function renderSupersampledSubtitleLayer({
     return cached;
   }
 
-  const { startY, totalHeight } = resolveSubtitlePlacement({
-    canvasHeight,
-    layout,
-    positionY,
-  });
-  const centerX = canvasWidth / 2;
-  const maxLineWidth = Math.max(1, ...layout.lineWidths);
+  const { centerX, maxLineWidth, startY, totalHeight } =
+    resolveSubtitlePlacement({
+      canvasWidth,
+      canvasHeight,
+      layout,
+      positionX,
+      positionY,
+    });
   const bounds = resolveSubtitleLayerBounds({
     canvasWidth,
     canvasHeight,
@@ -437,6 +473,7 @@ function drawDirectSubtitleText({
   strokeWidth,
   shadowBlur,
   shadowOffsetY,
+  positionX,
   positionY,
 }: {
   context: CanvasRenderingContext2D;
@@ -447,14 +484,16 @@ function drawDirectSubtitleText({
   strokeWidth: number;
   shadowBlur: number;
   shadowOffsetY: number;
+  positionX: number;
   positionY: number;
 }) {
-  const { startY } = resolveSubtitlePlacement({
+  const { centerX, startY } = resolveSubtitlePlacement({
+    canvasWidth,
     canvasHeight,
     layout,
+    positionX,
     positionY,
   });
-  const x = canvasWidth / 2;
 
   if (strokeWidth > 0) {
     context.strokeStyle = style.strokeColor;
@@ -462,7 +501,7 @@ function drawDirectSubtitleText({
     context.shadowColor = "transparent";
 
     for (const [index, line] of layout.wrappedLines.entries()) {
-      context.strokeText(line, x, startY + layout.lineHeight * index);
+      context.strokeText(line, centerX, startY + layout.lineHeight * index);
     }
   }
 
@@ -473,7 +512,7 @@ function drawDirectSubtitleText({
   context.shadowOffsetY = shadowOffsetY;
 
   for (const [index, line] of layout.wrappedLines.entries()) {
-    context.fillText(line, x, startY + layout.lineHeight * index);
+    context.fillText(line, centerX, startY + layout.lineHeight * index);
   }
 }
 
@@ -494,6 +533,7 @@ function resolveSubtitleCueRenderMetrics({
   const strokeWidth = Math.max(0, scaledValue(style.strokeWidth, canvasHeight));
   const shadowBlur = Math.max(0, scaledValue(style.shadowBlur, canvasHeight));
   const shadowOffsetY = scaledValue(style.shadowOffsetY, canvasHeight);
+  const positionX = clampNumber(style.positionX, 0, 100);
   const positionY = clampNumber(style.positionY, 0, 100);
   const maxWidth = canvasWidth * 0.84;
 
@@ -502,6 +542,7 @@ function resolveSubtitleCueRenderMetrics({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
+    positionX,
     positionY,
     layout: cachedSubtitleLayout(
       context,
@@ -530,7 +571,14 @@ function renderSubtitleCueWithMetrics({
   canvasHeight: number;
   metrics: SubtitleCueRenderMetrics;
 }) {
-  const { strokeWidth, shadowBlur, shadowOffsetY, positionY, layout } = metrics;
+  const {
+    strokeWidth,
+    shadowBlur,
+    shadowOffsetY,
+    positionX,
+    positionY,
+    layout,
+  } = metrics;
 
   context.save();
   context.font = layout.font;
@@ -554,6 +602,7 @@ function renderSubtitleCueWithMetrics({
     strokeWidth,
     shadowBlur,
     shadowOffsetY,
+    positionX,
     positionY,
   });
   if (layer) {
@@ -568,6 +617,7 @@ function renderSubtitleCueWithMetrics({
       strokeWidth,
       shadowBlur,
       shadowOffsetY,
+      positionX,
       positionY,
     });
   }

--- a/apps/frontend/src/lib/subtitles/settings.test.ts
+++ b/apps/frontend/src/lib/subtitles/settings.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadSubtitleStyleSettings } from "@/lib/subtitles/settings";
+
+const subtitleStyleSettingsStorageKey = "cliparr.subtitle.style-settings.v3";
+const legacySubtitleStyleSettingsStorageKey =
+  "cliparr.subtitle.style-settings.v1";
+const unflippedSubtitleStyleSettingsStorageKey =
+  "cliparr.subtitle.style-settings.v2";
+
+function withStorage<T>(
+  initialValues: Record<string, string>,
+  callback: (storage: Map<string, string>) => T,
+) {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  );
+  const storage = new Map(Object.entries(initialValues));
+  const localStorage = {
+    getItem(key: string) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      storage.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+  });
+
+  try {
+    return callback(storage);
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  }
+}
+
+void test("loads and clamps subtitle vertical position from v3 settings", () => {
+  withStorage(
+    {
+      [subtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionY: 175,
+      }),
+    },
+    () => {
+      assert.equal(loadSubtitleStyleSettings().positionY, 100);
+    },
+  );
+
+  withStorage(
+    {
+      [subtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionY: -25,
+      }),
+    },
+    () => {
+      assert.equal(loadSubtitleStyleSettings().positionY, 0);
+    },
+  );
+});
+
+void test("ignores legacy subtitle position settings", () => {
+  withStorage(
+    {
+      [legacySubtitleStyleSettingsStorageKey]: JSON.stringify({
+        bottomMargin: 240,
+      }),
+      [unflippedSubtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionY: 90,
+      }),
+    },
+    () => {
+      assert.equal(loadSubtitleStyleSettings().positionY, 10);
+    },
+  );
+});

--- a/apps/frontend/src/lib/subtitles/settings.test.ts
+++ b/apps/frontend/src/lib/subtitles/settings.test.ts
@@ -55,26 +55,47 @@ function withStorage<T>(
   }
 }
 
-void test("loads and clamps subtitle vertical position from v3 settings", () => {
+void test("loads and clamps subtitle position from v3 settings", () => {
   withStorage(
     {
       [subtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionX: 150,
         positionY: 175,
       }),
     },
     () => {
-      assert.equal(loadSubtitleStyleSettings().positionY, 100);
+      const settings = loadSubtitleStyleSettings();
+      assert.equal(settings.positionX, 100);
+      assert.equal(settings.positionY, 100);
     },
   );
 
   withStorage(
     {
       [subtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionX: -25,
         positionY: -25,
       }),
     },
     () => {
-      assert.equal(loadSubtitleStyleSettings().positionY, 0);
+      const settings = loadSubtitleStyleSettings();
+      assert.equal(settings.positionX, 0);
+      assert.equal(settings.positionY, 0);
+    },
+  );
+});
+
+void test("defaults missing subtitle horizontal position to center", () => {
+  withStorage(
+    {
+      [subtitleStyleSettingsStorageKey]: JSON.stringify({
+        positionY: 20,
+      }),
+    },
+    () => {
+      const settings = loadSubtitleStyleSettings();
+      assert.equal(settings.positionX, 50);
+      assert.equal(settings.positionY, 20);
     },
   );
 });
@@ -90,7 +111,9 @@ void test("ignores legacy subtitle position settings", () => {
       }),
     },
     () => {
-      assert.equal(loadSubtitleStyleSettings().positionY, 10);
+      const settings = loadSubtitleStyleSettings();
+      assert.equal(settings.positionX, 50);
+      assert.equal(settings.positionY, 10);
     },
   );
 });

--- a/apps/frontend/src/lib/subtitles/settings.ts
+++ b/apps/frontend/src/lib/subtitles/settings.ts
@@ -166,6 +166,7 @@ function defaultSubtitleStyleSettings(): SubtitleStyleSettings {
     shadowOffsetY: 2,
     strokeColor: "#000000",
     strokeWidth: 4,
+    positionX: 50,
     positionY: 10,
     lineHeight: 1.2,
   };
@@ -225,6 +226,7 @@ export function loadSubtitleStyleSettings(): SubtitleStyleSettings {
       ),
       strokeColor: colorValue(parsed.strokeColor, defaults.strokeColor),
       strokeWidth: clampNumber(parsed.strokeWidth, defaults.strokeWidth, 0, 32),
+      positionX: clampNumber(parsed.positionX, defaults.positionX, 0, 100),
       positionY: clampNumber(parsed.positionY, defaults.positionY, 0, 100),
       lineHeight: clampNumber(parsed.lineHeight, defaults.lineHeight, 1, 2),
     };

--- a/apps/frontend/src/lib/subtitles/settings.ts
+++ b/apps/frontend/src/lib/subtitles/settings.ts
@@ -1,7 +1,7 @@
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 
 const SUBTITLE_STYLE_SETTINGS_STORAGE_KEY =
-  "cliparr.subtitle.style-settings.v1";
+  "cliparr.subtitle.style-settings.v3";
 
 type SubtitleFontOptionSource = "bundled" | "local" | "saved";
 
@@ -166,7 +166,7 @@ function defaultSubtitleStyleSettings(): SubtitleStyleSettings {
     shadowOffsetY: 2,
     strokeColor: "#000000",
     strokeWidth: 4,
-    bottomMargin: 72,
+    positionY: 10,
     lineHeight: 1.2,
   };
 }
@@ -225,12 +225,7 @@ export function loadSubtitleStyleSettings(): SubtitleStyleSettings {
       ),
       strokeColor: colorValue(parsed.strokeColor, defaults.strokeColor),
       strokeWidth: clampNumber(parsed.strokeWidth, defaults.strokeWidth, 0, 32),
-      bottomMargin: clampNumber(
-        parsed.bottomMargin,
-        defaults.bottomMargin,
-        0,
-        240,
-      ),
+      positionY: clampNumber(parsed.positionY, defaults.positionY, 0, 100),
       lineHeight: clampNumber(parsed.lineHeight, defaults.lineHeight, 1, 2),
     };
   } catch {

--- a/apps/frontend/src/lib/subtitles/types.ts
+++ b/apps/frontend/src/lib/subtitles/types.ts
@@ -15,6 +15,7 @@ export interface SubtitleStyleSettings {
   shadowOffsetY: number;
   strokeColor: string;
   strokeWidth: number;
+  positionX: number;
   positionY: number;
   lineHeight: number;
 }

--- a/apps/frontend/src/lib/subtitles/types.ts
+++ b/apps/frontend/src/lib/subtitles/types.ts
@@ -15,6 +15,6 @@ export interface SubtitleStyleSettings {
   shadowOffsetY: number;
   strokeColor: string;
   strokeWidth: number;
-  bottomMargin: number;
+  positionY: number;
   lineHeight: number;
 }


### PR DESCRIPTION
## Summary
- replace bottom-margin subtitle placement with global center-point positioning
- add X and flipped Y percentage controls in the subtitle sidebar
- keep preview/export burn-in aligned through the shared subtitle renderer

## Validation
- pnpm preflight