### PR TITLE
feat(frontend): add collapsible subtitle properties

### DIFF
--- a/apps/frontend/src/components/editor/EditorPropertyControls.tsx
+++ b/apps/frontend/src/components/editor/EditorPropertyControls.tsx
@@ -1,4 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
+import { Accordion } from "@base-ui/react/accordion";
+import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utilities";
 
 export function editorPropertyLabelClassName() {
@@ -26,6 +28,54 @@ export function EditorPropertySection({
       </div>
       <div className="mt-2.5 space-y-2.5">{children}</div>
     </section>
+  );
+}
+
+export function EditorPropertyAccordion<Value extends string>({
+  value,
+  onValueChange,
+  children,
+}: {
+  value: readonly Value[];
+  onValueChange: (value: Value[]) => void;
+  children: ReactNode;
+}) {
+  return (
+    <Accordion.Root
+      multiple
+      value={[...value]}
+      onValueChange={onValueChange}
+      className="flex min-h-0 flex-col"
+    >
+      {children}
+    </Accordion.Root>
+  );
+}
+
+export function EditorPropertyAccordionItem<Value extends string>({
+  value,
+  title,
+  action,
+  children,
+}: {
+  value: Value;
+  title: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <Accordion.Item value={value} className="border-b border-editor-border/80">
+      <Accordion.Header className="m-0 flex min-h-10 items-center gap-2 border-b border-editor-border/70 bg-editor-panel-muted/55 px-3 py-2">
+        <Accordion.Trigger className="group flex min-w-0 flex-1 items-center gap-2 bg-transparent text-left text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-sidebar-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none">
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 ease-out group-data-[panel-open]:rotate-90" />
+          <span className="min-w-0 truncate">{title}</span>
+        </Accordion.Trigger>
+        {action ? <span className="shrink-0">{action}</span> : null}
+      </Accordion.Header>
+      <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden transition-[height] duration-150 ease-out data-ending-style:h-0 data-starting-style:h-0">
+        <div>{children}</div>
+      </Accordion.Panel>
+    </Accordion.Item>
   );
 }
 

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -45,6 +45,10 @@ import {
 import { useEditorFramegrab } from "@/components/editor/useEditorFramegrab";
 import { useEditorSubtitles } from "@/components/editor/useEditorSubtitles";
 import {
+  loadEditorPropertiesOpenSections,
+  saveEditorPropertiesOpenSections,
+} from "@/components/editor/editorSidebarPreferences";
+import {
   isValidSubtitleTimelineActionRange,
   subtitleCueIdFromActionId,
 } from "@/components/editor/subtitleTimeline";
@@ -76,6 +80,8 @@ export default function EditorScreen({ session, onBack }: Properties) {
   const [startTime, setStartTime] = useState(() => initialClipRange.startTime);
   const [endTime, setEndTime] = useState(() => initialClipRange.endTime);
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
+  const [editorPropertiesOpenSections, setEditorPropertiesOpenSections] =
+    useState(loadEditorPropertiesOpenSections);
   const [exportDialogMounted, setExportDialogMounted] = useState(false);
   const playbackTimeUpdateReference = useRef<
     ((seconds: number) => void) | null
@@ -150,6 +156,10 @@ export default function EditorScreen({ session, onBack }: Properties) {
     subtitleStyleSettings,
     onPlaybackTimeUpdate: handlePlaybackTimeUpdate,
   });
+
+  useEffect(() => {
+    saveEditorPropertiesOpenSections(editorPropertiesOpenSections);
+  }, [editorPropertiesOpenSections]);
   const {
     resolution,
     exportFormat,
@@ -609,6 +619,8 @@ export default function EditorScreen({ session, onBack }: Properties) {
           subtitleLoading={subtitleLoading}
           subtitleError={subtitleError}
           selectedSubtitleTrack={selectedSubtitleTrack}
+          editorPropertiesOpenSections={editorPropertiesOpenSections}
+          onEditorPropertiesOpenSectionsChange={setEditorPropertiesOpenSections}
         />
       </div>
     );

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -28,6 +28,8 @@ import {
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
 import {
+  EditorPropertyAccordion,
+  EditorPropertyAccordionItem,
   EditorColorControl,
   EditorPropertyRow,
   EditorPropertySection,
@@ -35,6 +37,11 @@ import {
   editorPropertyLabelClassName,
   editorPropertySelectTriggerClassName,
 } from "@/components/editor/EditorPropertyControls";
+import {
+  EDITOR_PROPERTIES_SECTION_ID,
+  type EditorPropertiesOpenSections,
+  type EditorPropertiesSectionId,
+} from "@/components/editor/editorSidebarPreferences";
 import { useSubtitleFontOptions } from "@/components/editor/useSubtitleFontOptions";
 
 interface EditorSubtitlePanelProperties {
@@ -51,6 +58,10 @@ interface EditorSubtitlePanelProperties {
   subtitleLoading: boolean;
   subtitleError: string | null;
   selectedSubtitleTrack: PlaybackSubtitleTrack | null;
+  editorPropertiesOpenSections: EditorPropertiesOpenSections;
+  onEditorPropertiesOpenSectionsChange: (
+    openSections: EditorPropertiesOpenSections,
+  ) => void;
 }
 
 export function EditorSubtitlePanel({
@@ -65,6 +76,8 @@ export function EditorSubtitlePanel({
   subtitleLoading,
   subtitleError,
   selectedSubtitleTrack,
+  editorPropertiesOpenSections,
+  onEditorPropertiesOpenSectionsChange,
 }: EditorSubtitlePanelProperties) {
   const canEnableBurnIn = subtitleTrackSupportsBurnIn(selectedSubtitleTrack);
   const styleControlsDisabled = !subtitlesEnabled || !canEnableBurnIn;
@@ -115,7 +128,7 @@ export function EditorSubtitlePanel({
     />
   );
   const subtitleAction = (
-    <div className="flex items-center gap-2">
+    <span className="flex items-center gap-2">
       <span className="relative h-3.5 w-3.5 shrink-0 text-muted-foreground">
         <LoaderCircle
           aria-hidden={!subtitleLoading}
@@ -129,247 +142,263 @@ export function EditorSubtitlePanel({
         </span>
       </span>
       {subtitleToggle}
-    </div>
+    </span>
   );
 
   return (
     <div className="cliparr-editor-scrollbar min-h-0 flex-1 overflow-y-auto bg-editor-panel text-sidebar-foreground">
-      <EditorPropertySection
-        title="Subtitles"
-        action={
-          subtitleToggleTooltip ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex" tabIndex={0}>
-                  {subtitleAction}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                {subtitleToggleTooltip}
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            subtitleAction
-          )
-        }
+      <EditorPropertyAccordion<EditorPropertiesSectionId>
+        value={editorPropertiesOpenSections}
+        onValueChange={onEditorPropertiesOpenSectionsChange}
       >
-        <EditorPropertyRow label="Track">
-          <Select
-            value={selectedSubtitleTrackKey}
-            onValueChange={onSelectedSubtitleTrackKeyChange}
-          >
-            <SelectTrigger
-              size="sm"
-              className={editorPropertySelectTriggerClassName()}
-            >
-              <SelectValue placeholder="Select subtitle track" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectLabel>Subtitle Tracks</SelectLabel>
-                <SelectItem value="none">No subtitles</SelectItem>
-                {subtitleTracks.map((track) => {
-                  const trackKey = subtitleTrackKey(track);
-
-                  return (
-                    <SelectItem key={trackKey} value={trackKey}>
-                      {formatSubtitleTrackLabel(track, { variant: "selector" })}
-                    </SelectItem>
-                  );
-                })}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </EditorPropertyRow>
-
-        {!canEnableBurnIn && (
-          <div className="border border-editor-border bg-editor-warning px-2.5 py-2 text-xs text-editor-warning-foreground">
-            <div className="flex items-start gap-2">
-              <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <div className="space-y-1">
-                <p>{subtitleWarning}</p>
-                {selectedSubtitleTrack && (
-                  <p className="text-ui-label text-muted-foreground">
-                    {formatSubtitleTrackTechnicalSummary(selectedSubtitleTrack)}
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {subtitleError && (
-          <div className="border border-destructive/35 bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
-            {subtitleError}
-          </div>
-        )}
-      </EditorPropertySection>
-
-      <div
-        aria-disabled={styleControlsDisabled}
-        className={cn(
-          "transition-opacity",
-          styleControlsDisabled && "opacity-60",
-        )}
-      >
-        <EditorPropertySection
-          title="Text"
+        <EditorPropertyAccordionItem<EditorPropertiesSectionId>
+          value={EDITOR_PROPERTIES_SECTION_ID.globalSubtitles}
+          title="Global Subtitles"
           action={
-            styleTooltip ? (
+            subtitleToggleTooltip ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className={editorPropertyLabelClassName()}>Locked</span>
+                  <span className="inline-flex" tabIndex={0}>
+                    {subtitleAction}
+                  </span>
                 </TooltipTrigger>
-                <TooltipContent side="top" align="end">
-                  {styleTooltip}
+                <TooltipContent side="left">
+                  {subtitleToggleTooltip}
                 </TooltipContent>
               </Tooltip>
-            ) : null
+            ) : (
+              subtitleAction
+            )
           }
         >
-          <EditorPropertyRow label="Font">
-            <Select
-              value={subtitleStyleSettings.fontFamily}
-              onValueChange={(value) => updateStyleSetting("fontFamily", value)}
-              onOpenChange={(open) => {
-                if (open && !styleControlsDisabled) {
-                  requestLocalFonts();
-                }
-              }}
-              disabled={styleControlsDisabled}
-            >
-              <SelectTrigger
-                size="sm"
-                className={editorPropertySelectTriggerClassName()}
+          <EditorPropertySection title="Track">
+            <EditorPropertyRow label="Track">
+              <Select
+                value={selectedSubtitleTrackKey}
+                onValueChange={onSelectedSubtitleTrackKeyChange}
               >
-                <SelectValue placeholder="Select font" />
-              </SelectTrigger>
-              <SelectContent>
-                {currentFontOption && (
+                <SelectTrigger
+                  size="sm"
+                  className={editorPropertySelectTriggerClassName()}
+                >
+                  <SelectValue placeholder="Select subtitle track" />
+                </SelectTrigger>
+                <SelectContent>
                   <SelectGroup>
-                    <SelectLabel>Current Font</SelectLabel>
-                    <SelectItem value={currentFontOption.value}>
-                      {currentFontOption.label}
-                    </SelectItem>
+                    <SelectLabel>Subtitle Tracks</SelectLabel>
+                    <SelectItem value="none">No subtitles</SelectItem>
+                    {subtitleTracks.map((track) => {
+                      const trackKey = subtitleTrackKey(track);
+
+                      return (
+                        <SelectItem key={trackKey} value={trackKey}>
+                          {formatSubtitleTrackLabel(track, {
+                            variant: "selector",
+                          })}
+                        </SelectItem>
+                      );
+                    })}
                   </SelectGroup>
-                )}
-                <SelectGroup>
-                  <SelectLabel>Included Fonts</SelectLabel>
-                  {bundledFontOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-                {localFontOptions.length > 0 && (
-                  <SelectGroup>
-                    <SelectLabel>Installed Fonts</SelectLabel>
-                    {localFontOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                )}
-                {loadingLocalFonts && (
-                  <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
-                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                    Loading installed fonts...
+                </SelectContent>
+              </Select>
+            </EditorPropertyRow>
+
+            {!canEnableBurnIn && (
+              <div className="border border-editor-border bg-editor-warning px-2.5 py-2 text-xs text-editor-warning-foreground">
+                <div className="flex items-start gap-2">
+                  <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <div className="space-y-1">
+                    <p>{subtitleWarning}</p>
+                    {selectedSubtitleTrack && (
+                      <p className="text-ui-label text-muted-foreground">
+                        {formatSubtitleTrackTechnicalSummary(
+                          selectedSubtitleTrack,
+                        )}
+                      </p>
+                    )}
                   </div>
-                )}
-              </SelectContent>
-            </Select>
-          </EditorPropertyRow>
+                </div>
+              </div>
+            )}
 
-          <EditorColorControl
-            label="Color"
-            value={subtitleStyleSettings.fontColor}
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("fontColor", value)}
-          />
-          <EditorRangeControl
-            label="Size"
-            value={subtitleStyleSettings.fontSize}
-            min={16}
-            max={150}
-            step={1}
-            unit="px"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("fontSize", value)}
-          />
-        </EditorPropertySection>
+            {subtitleError && (
+              <div className="border border-destructive/35 bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
+                {subtitleError}
+              </div>
+            )}
+          </EditorPropertySection>
 
-        <EditorPropertySection title="Shadow">
-          <EditorColorControl
-            label="Color"
-            value={subtitleStyleSettings.shadowColor}
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("shadowColor", value)}
-          />
-          <EditorRangeControl
-            label="Blur"
-            value={subtitleStyleSettings.shadowBlur}
-            min={0}
-            max={24}
-            step={1}
-            unit="px"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("shadowBlur", value)}
-          />
-          <EditorRangeControl
-            label="Offset"
-            value={subtitleStyleSettings.shadowOffsetY}
-            min={-16}
-            max={24}
-            step={1}
-            unit="px"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("shadowOffsetY", value)}
-          />
-        </EditorPropertySection>
+          <div
+            aria-disabled={styleControlsDisabled}
+            className={cn(
+              "transition-opacity",
+              styleControlsDisabled && "opacity-60",
+            )}
+          >
+            <EditorPropertySection
+              title="Text"
+              action={
+                styleTooltip ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className={editorPropertyLabelClassName()}>
+                        Locked
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" align="end">
+                      {styleTooltip}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null
+              }
+            >
+              <EditorPropertyRow label="Font">
+                <Select
+                  value={subtitleStyleSettings.fontFamily}
+                  onValueChange={(value) =>
+                    updateStyleSetting("fontFamily", value)
+                  }
+                  onOpenChange={(open) => {
+                    if (open && !styleControlsDisabled) {
+                      requestLocalFonts();
+                    }
+                  }}
+                  disabled={styleControlsDisabled}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className={editorPropertySelectTriggerClassName()}
+                  >
+                    <SelectValue placeholder="Select font" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {currentFontOption && (
+                      <SelectGroup>
+                        <SelectLabel>Current Font</SelectLabel>
+                        <SelectItem value={currentFontOption.value}>
+                          {currentFontOption.label}
+                        </SelectItem>
+                      </SelectGroup>
+                    )}
+                    <SelectGroup>
+                      <SelectLabel>Included Fonts</SelectLabel>
+                      {bundledFontOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                    {localFontOptions.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>Installed Fonts</SelectLabel>
+                        {localFontOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    )}
+                    {loadingLocalFonts && (
+                      <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                        Loading installed fonts...
+                      </div>
+                    )}
+                  </SelectContent>
+                </Select>
+              </EditorPropertyRow>
 
-        <EditorPropertySection title="Stroke">
-          <EditorColorControl
-            label="Color"
-            value={subtitleStyleSettings.strokeColor}
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("strokeColor", value)}
-          />
-          <EditorRangeControl
-            label="Width"
-            value={subtitleStyleSettings.strokeWidth}
-            min={0}
-            max={32}
-            step={0.5}
-            unit="px"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("strokeWidth", value)}
-          />
-        </EditorPropertySection>
+              <EditorColorControl
+                label="Color"
+                value={subtitleStyleSettings.fontColor}
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("fontColor", value)}
+              />
+              <EditorRangeControl
+                label="Size"
+                value={subtitleStyleSettings.fontSize}
+                min={16}
+                max={150}
+                step={1}
+                unit="px"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("fontSize", value)}
+              />
+            </EditorPropertySection>
 
-        <EditorPropertySection title="Position">
-          <EditorRangeControl
-            label="X"
-            value={subtitleStyleSettings.positionX}
-            min={0}
-            max={100}
-            step={1}
-            unit="%"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("positionX", value)}
-          />
-          <EditorRangeControl
-            label="Y"
-            value={subtitleStyleSettings.positionY}
-            min={0}
-            max={100}
-            step={1}
-            unit="%"
-            disabled={styleControlsDisabled}
-            onChange={(value) => updateStyleSetting("positionY", value)}
-          />
-        </EditorPropertySection>
-      </div>
+            <EditorPropertySection title="Shadow">
+              <EditorColorControl
+                label="Color"
+                value={subtitleStyleSettings.shadowColor}
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("shadowColor", value)}
+              />
+              <EditorRangeControl
+                label="Blur"
+                value={subtitleStyleSettings.shadowBlur}
+                min={0}
+                max={24}
+                step={1}
+                unit="px"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("shadowBlur", value)}
+              />
+              <EditorRangeControl
+                label="Offset"
+                value={subtitleStyleSettings.shadowOffsetY}
+                min={-16}
+                max={24}
+                step={1}
+                unit="px"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("shadowOffsetY", value)}
+              />
+            </EditorPropertySection>
+
+            <EditorPropertySection title="Stroke">
+              <EditorColorControl
+                label="Color"
+                value={subtitleStyleSettings.strokeColor}
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("strokeColor", value)}
+              />
+              <EditorRangeControl
+                label="Width"
+                value={subtitleStyleSettings.strokeWidth}
+                min={0}
+                max={32}
+                step={0.5}
+                unit="px"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("strokeWidth", value)}
+              />
+            </EditorPropertySection>
+
+            <EditorPropertySection title="Position">
+              <EditorRangeControl
+                label="X"
+                value={subtitleStyleSettings.positionX}
+                min={0}
+                max={100}
+                step={1}
+                unit="%"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("positionX", value)}
+              />
+              <EditorRangeControl
+                label="Y"
+                value={subtitleStyleSettings.positionY}
+                min={0}
+                max={100}
+                step={1}
+                unit="%"
+                disabled={styleControlsDisabled}
+                onChange={(value) => updateStyleSetting("positionY", value)}
+              />
+            </EditorPropertySection>
+          </div>
+        </EditorPropertyAccordionItem>
+      </EditorPropertyAccordion>
     </div>
   );
 }

--- a/apps/frontend/src/components/editor/editorSidebarPreferences.test.ts
+++ b/apps/frontend/src/components/editor/editorSidebarPreferences.test.ts
@@ -1,0 +1,183 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+  EDITOR_PROPERTIES_SECTION_ID,
+  loadEditorPropertiesOpenSections,
+  saveEditorPropertiesOpenSections,
+} from "@/components/editor/editorSidebarPreferences";
+
+const editorPropertiesAccordionStorageKey =
+  "cliparr.editor.properties.accordion.v1";
+
+function withStorage<T>(
+  initialValues: Record<string, string>,
+  callback: (storage: Map<string, string>) => T,
+) {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  );
+  const storage = new Map(Object.entries(initialValues));
+  const localStorage = {
+    getItem(key: string) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      storage.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+  });
+
+  try {
+    return callback(storage);
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  }
+}
+
+void test("defaults editor properties accordion sections without storage", () => {
+  withStorage({}, () => {
+    assert.deepEqual(
+      loadEditorPropertiesOpenSections(),
+      DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+    );
+  });
+});
+
+void test("loads saved open editor properties accordion sections", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: [EDITOR_PROPERTIES_SECTION_ID.globalSubtitles],
+      }),
+    },
+    () => {
+      assert.deepEqual(
+        loadEditorPropertiesOpenSections(),
+        DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+      );
+    },
+  );
+});
+
+void test("loads saved closed editor properties accordion sections", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: [],
+      }),
+    },
+    () => {
+      assert.deepEqual(loadEditorPropertiesOpenSections(), []);
+    },
+  );
+});
+
+void test("filters unknown editor properties accordion section ids", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: [
+          "preview-source",
+          EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+          "export",
+        ],
+      }),
+    },
+    () => {
+      assert.deepEqual(
+        loadEditorPropertiesOpenSections(),
+        DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+      );
+    },
+  );
+});
+
+void test("deduplicates editor properties accordion section ids", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: [
+          EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+          EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+        ],
+      }),
+    },
+    () => {
+      assert.deepEqual(
+        loadEditorPropertiesOpenSections(),
+        DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+      );
+    },
+  );
+});
+
+void test("falls back to default editor properties accordion sections for invalid storage", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: "nope",
+    },
+    () => {
+      assert.deepEqual(
+        loadEditorPropertiesOpenSections(),
+        DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+      );
+    },
+  );
+
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: true,
+      }),
+    },
+    () => {
+      assert.deepEqual(
+        loadEditorPropertiesOpenSections(),
+        DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
+      );
+    },
+  );
+});
+
+void test("saves editor properties accordion sections", () => {
+  withStorage({}, (storage) => {
+    saveEditorPropertiesOpenSections([]);
+
+    assert.equal(
+      storage.get(editorPropertiesAccordionStorageKey),
+      JSON.stringify({ openSections: [] }),
+    );
+
+    saveEditorPropertiesOpenSections(DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS);
+
+    assert.equal(
+      storage.get(editorPropertiesAccordionStorageKey),
+      JSON.stringify({
+        openSections: [EDITOR_PROPERTIES_SECTION_ID.globalSubtitles],
+      }),
+    );
+  });
+});

--- a/apps/frontend/src/components/editor/editorSidebarPreferences.ts
+++ b/apps/frontend/src/components/editor/editorSidebarPreferences.ts
@@ -1,0 +1,111 @@
+export const EDITOR_PROPERTIES_SECTION_ID = {
+  globalSubtitles: "global-subtitles",
+} as const;
+
+const EDITOR_PROPERTIES_SECTION_IDS = [
+  EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+] as const;
+
+export type EditorPropertiesSectionId =
+  (typeof EDITOR_PROPERTIES_SECTION_IDS)[number];
+
+export type EditorPropertiesOpenSections = readonly EditorPropertiesSectionId[];
+
+export const DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS = [
+  EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+] as const satisfies EditorPropertiesOpenSections;
+
+const EDITOR_PROPERTIES_ACCORDION_STORAGE_KEY =
+  "cliparr.editor.properties.accordion.v1";
+
+interface EditorPropertiesAccordionPreferences {
+  openSections: EditorPropertiesOpenSections;
+}
+
+const editorPropertiesSectionIdSet = new Set<string>(
+  EDITOR_PROPERTIES_SECTION_IDS,
+);
+
+function defaultEditorPropertiesOpenSections(): EditorPropertiesOpenSections {
+  return [...DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEditorPropertiesSectionId(
+  value: unknown,
+): value is EditorPropertiesSectionId {
+  return typeof value === "string" && editorPropertiesSectionIdSet.has(value);
+}
+
+function normalizeEditorPropertiesOpenSections(
+  value: unknown,
+): EditorPropertiesOpenSections | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const openSections: EditorPropertiesSectionId[] = [];
+  for (const sectionId of value) {
+    if (
+      isEditorPropertiesSectionId(sectionId) &&
+      !openSections.includes(sectionId)
+    ) {
+      openSections.push(sectionId);
+    }
+  }
+
+  return openSections;
+}
+
+export function loadEditorPropertiesOpenSections(): EditorPropertiesOpenSections {
+  if (globalThis.window === undefined) {
+    return defaultEditorPropertiesOpenSections();
+  }
+
+  try {
+    const raw = globalThis.localStorage.getItem(
+      EDITOR_PROPERTIES_ACCORDION_STORAGE_KEY,
+    );
+    if (!raw) {
+      return defaultEditorPropertiesOpenSections();
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return defaultEditorPropertiesOpenSections();
+    }
+
+    return (
+      normalizeEditorPropertiesOpenSections(parsed.openSections) ??
+      defaultEditorPropertiesOpenSections()
+    );
+  } catch {
+    return defaultEditorPropertiesOpenSections();
+  }
+}
+
+export function saveEditorPropertiesOpenSections(
+  openSections: EditorPropertiesOpenSections,
+) {
+  if (globalThis.window === undefined) {
+    return;
+  }
+
+  try {
+    const preferences = {
+      openSections:
+        normalizeEditorPropertiesOpenSections(openSections) ??
+        defaultEditorPropertiesOpenSections(),
+    } satisfies EditorPropertiesAccordionPreferences;
+
+    globalThis.localStorage.setItem(
+      EDITOR_PROPERTIES_ACCORDION_STORAGE_KEY,
+      JSON.stringify(preferences),
+    );
+  } catch {
+    // Best-effort persistence only.
+  }
+}


### PR DESCRIPTION
## Summary

- Adds editor-styled accordion primitives for Properties sidebar sections.
- Wraps the existing subtitle controls in a remembered "Global Subtitles" accordion on desktop and mobile.
- Stores open Properties sections as a typed, validated JSON preference for future accordion sections.

## Validation

- `pnpm preflight`
