### PR TITLE
fix(www): remove deprecated media query listeners

### DIFF
--- a/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
+++ b/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
@@ -45,15 +45,16 @@ function addMediaQueryChangeListener(query: string, onChange: () => void) {
   }
 
   const mediaQuery = globalThis.matchMedia(query);
-  const listener = () => onChange();
-
-  if (typeof mediaQuery.addEventListener === "function") {
-    mediaQuery.addEventListener("change", listener);
-    return () => mediaQuery.removeEventListener("change", listener);
+  if (
+    typeof mediaQuery.addEventListener !== "function" ||
+    typeof mediaQuery.removeEventListener !== "function"
+  ) {
+    return () => {};
   }
 
-  mediaQuery.addListener(listener);
-  return () => mediaQuery.removeListener(listener);
+  const listener = () => onChange();
+  mediaQuery.addEventListener("change", listener);
+  return () => mediaQuery.removeEventListener("change", listener);
 }
 
 function getCurrentConvertPwaInstallState(


### PR DESCRIPTION
## Summary

- remove deprecated `MediaQueryList.addListener/removeListener` usage from the www Convert PWA install prompt
- keep the listener helper on the modern `change` event API and no-op in environments without it

## Validation

- `pnpm lint`
- `pnpm preflight`
