### PR TITLE
feat(frontend): add timeline item selection properties

### DIFF
--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -3,6 +3,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -49,9 +50,18 @@ import {
   saveEditorPropertiesOpenSections,
 } from "@/components/editor/editorSidebarPreferences";
 import {
+  buildSubtitleCueTimingPropertyUpdate,
   isValidSubtitleTimelineActionRange,
   subtitleCueIdFromActionId,
+  type SubtitleTimelineCue,
 } from "@/components/editor/subtitleTimeline";
+import {
+  defaultEditorTimelineSelection,
+  editorTimelineSelectionsEqual,
+  normalizeEditorTimelineSelection,
+  resolveSelectedSubtitleCue,
+  type EditorTimelineSelection,
+} from "@/components/editor/editorTimelineSelection";
 import { sourceDisplayLabel, type EditorSession } from "@/lib/editorMedia";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 
@@ -82,6 +92,8 @@ export default function EditorScreen({ session, onBack }: Properties) {
   const [playbackSidebarOpen, setPlaybackSidebarOpen] = useState(true);
   const [editorPropertiesOpenSections, setEditorPropertiesOpenSections] =
     useState(loadEditorPropertiesOpenSections);
+  const [timelineSelection, setTimelineSelection] =
+    useState<EditorTimelineSelection>(defaultEditorTimelineSelection);
   const [exportDialogMounted, setExportDialogMounted] = useState(false);
   const playbackTimeUpdateReference = useRef<
     ((seconds: number) => void) | null
@@ -111,6 +123,22 @@ export default function EditorScreen({ session, onBack }: Properties) {
     startTime,
     endTime,
   });
+  const normalizedTimelineSelection = useMemo(
+    () =>
+      normalizeEditorTimelineSelection({
+        selection: timelineSelection,
+        subtitleTimelineTrack,
+      }),
+    [subtitleTimelineTrack, timelineSelection],
+  );
+  const selectedSubtitleCue = useMemo(
+    () =>
+      resolveSelectedSubtitleCue(
+        subtitleTimelineTrack,
+        normalizedTimelineSelection,
+      ),
+    [normalizedTimelineSelection, subtitleTimelineTrack],
+  );
   const posterImageUrl = session.thumbUrl;
 
   const {
@@ -160,6 +188,19 @@ export default function EditorScreen({ session, onBack }: Properties) {
   useEffect(() => {
     saveEditorPropertiesOpenSections(editorPropertiesOpenSections);
   }, [editorPropertiesOpenSections]);
+  useEffect(() => {
+    setTimelineSelection(defaultEditorTimelineSelection());
+  }, [session.id]);
+  useEffect(() => {
+    if (
+      !editorTimelineSelectionsEqual(
+        timelineSelection,
+        normalizedTimelineSelection,
+      )
+    ) {
+      setTimelineSelection(normalizedTimelineSelection);
+    }
+  }, [normalizedTimelineSelection, timelineSelection]);
   const {
     resolution,
     exportFormat,
@@ -328,6 +369,42 @@ export default function EditorScreen({ session, onBack }: Properties) {
     },
     [duration, startTime, updateClipRange, warmClipSelection],
   );
+  const handleClipDurationCommit = useCallback(
+    (nextDuration: number) => {
+      if (!duration || duration <= 0) {
+        return;
+      }
+
+      const nextEnd = clampClipEndTime(
+        startTime + nextDuration,
+        startTime,
+        duration,
+      );
+      updateClipRange(startTime, nextEnd);
+      void warmClipSelection(startTime, nextEnd);
+    },
+    [duration, startTime, updateClipRange, warmClipSelection],
+  );
+  const handleSubtitleCueTimingPropertyCommit = useCallback(
+    (
+      cue: SubtitleTimelineCue,
+      property: "start" | "end" | "duration",
+      value: number,
+    ) => {
+      const update = buildSubtitleCueTimingPropertyUpdate({
+        cue,
+        property,
+        value,
+        duration,
+      });
+      if (!update) {
+        return;
+      }
+
+      updateSubtitleCueTimings([update], duration);
+    },
+    [duration, updateSubtitleCueTimings],
+  );
   const handleMarkInShortcut = useCallback(() => {
     if (!duration || duration <= 0) {
       return;
@@ -414,6 +491,7 @@ export default function EditorScreen({ session, onBack }: Properties) {
     handleTimelineChange,
     handleTimelineActionMoveEnd,
     handleTimelineActionResizeEnd,
+    selectTimelineAction,
     setTimelineCurrentTime,
     hasDuration,
   } = useEditorTimeline({
@@ -427,6 +505,8 @@ export default function EditorScreen({ session, onBack }: Properties) {
       void warmClipSelection(nextStart, nextEnd);
     },
     subtitleTimelineTrack,
+    timelineSelection: normalizedTimelineSelection,
+    onTimelineSelectionChange: setTimelineSelection,
     updateSubtitleCueTimings,
   });
 
@@ -570,6 +650,7 @@ export default function EditorScreen({ session, onBack }: Properties) {
       handleTimelineChange={handleTimelineChange}
       handleTimelineActionMoveEnd={handleTimelineActionMoveEnd}
       handleTimelineActionResizeEnd={handleTimelineActionResizeEnd}
+      selectTimelineAction={selectTimelineAction}
       isValidTimelineActionRange={isValidTimelineActionRange}
       seekToTime={seekToTime}
       onCursorDragStart={() => {
@@ -601,13 +682,27 @@ export default function EditorScreen({ session, onBack }: Properties) {
   );
 
   function renderSubtitlePanel(className: string) {
-    if (session.local) {
-      return null;
-    }
-
     return (
       <div className={className}>
         <EditorSubtitlePanel
+          showGlobalSubtitles={!session.local}
+          timelineSelection={normalizedTimelineSelection}
+          selectedSubtitleCue={selectedSubtitleCue}
+          clipStartTime={startTime}
+          clipEndTime={endTime}
+          duration={duration}
+          onClipStartTimeCommit={handleStartTimeCommit}
+          onClipEndTimeCommit={handleEndTimeCommit}
+          onClipDurationCommit={handleClipDurationCommit}
+          onSubtitleCueStartTimeCommit={(cue, seconds) =>
+            handleSubtitleCueTimingPropertyCommit(cue, "start", seconds)
+          }
+          onSubtitleCueEndTimeCommit={(cue, seconds) =>
+            handleSubtitleCueTimingPropertyCommit(cue, "end", seconds)
+          }
+          onSubtitleCueDurationCommit={(cue, seconds) =>
+            handleSubtitleCueTimingPropertyCommit(cue, "duration", seconds)
+          }
           providerId={session.source.providerId}
           subtitleTracks={subtitleTracks}
           selectedSubtitleTrackKey={selectedSubtitleTrackKey}

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import { LoaderCircle, Sparkles } from "lucide-react";
+import { EditorEditableTimecode } from "@/components/editor/EditorEditableTimecode";
 import {
   Select,
   SelectContent,
@@ -16,6 +17,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utilities";
+import { formatTime } from "@/components/editor/editorUtilities";
 import {
   subtitleTrackKey,
   subtitleTrackSupportsBurnIn,
@@ -27,6 +29,8 @@ import {
 } from "@/lib/subtitleTrackLabels";
 import type { SubtitleStyleSettings } from "@/lib/subtitles/types";
 import type { PlaybackSubtitleTrack } from "@/providers/types";
+import type { SubtitleTimelineCue } from "@/components/editor/subtitleTimeline";
+import type { EditorTimelineSelection } from "@/components/editor/editorTimelineSelection";
 import {
   EditorPropertyAccordion,
   EditorPropertyAccordionItem,
@@ -45,6 +49,27 @@ import {
 import { useSubtitleFontOptions } from "@/components/editor/useSubtitleFontOptions";
 
 interface EditorSubtitlePanelProperties {
+  showGlobalSubtitles: boolean;
+  timelineSelection: EditorTimelineSelection;
+  selectedSubtitleCue: SubtitleTimelineCue | null;
+  clipStartTime: number;
+  clipEndTime: number;
+  duration: number;
+  onClipStartTimeCommit: (seconds: number) => void;
+  onClipEndTimeCommit: (seconds: number) => void;
+  onClipDurationCommit: (seconds: number) => void;
+  onSubtitleCueStartTimeCommit: (
+    cue: SubtitleTimelineCue,
+    seconds: number,
+  ) => void;
+  onSubtitleCueEndTimeCommit: (
+    cue: SubtitleTimelineCue,
+    seconds: number,
+  ) => void;
+  onSubtitleCueDurationCommit: (
+    cue: SubtitleTimelineCue,
+    seconds: number,
+  ) => void;
   providerId?: string;
   subtitleTracks: readonly PlaybackSubtitleTrack[];
   selectedSubtitleTrackKey: string;
@@ -65,6 +90,18 @@ interface EditorSubtitlePanelProperties {
 }
 
 export function EditorSubtitlePanel({
+  showGlobalSubtitles,
+  timelineSelection,
+  selectedSubtitleCue,
+  clipStartTime,
+  clipEndTime,
+  duration,
+  onClipStartTimeCommit,
+  onClipEndTimeCommit,
+  onClipDurationCommit,
+  onSubtitleCueStartTimeCommit,
+  onSubtitleCueEndTimeCommit,
+  onSubtitleCueDurationCommit,
   providerId,
   subtitleTracks,
   selectedSubtitleTrackKey,
@@ -144,6 +181,57 @@ export function EditorSubtitlePanel({
       {subtitleToggle}
     </span>
   );
+  const selectedClip = timelineSelection.kind === "clip";
+  const selectedItemTitle = selectedClip ? "Clip" : "Subtitle";
+  const selectedStartTime = selectedSubtitleCue?.startTime ?? clipStartTime;
+  const selectedEndTime = selectedSubtitleCue?.endTime ?? clipEndTime;
+  const selectedDuration = Math.max(0, selectedEndTime - selectedStartTime);
+  const timingDisabled =
+    duration <= 0 ||
+    (timelineSelection.kind === "subtitle-cue" && !selectedSubtitleCue);
+  const timingRows = (
+    <>
+      <SelectionTimecodeRow
+        label="Start"
+        value={selectedStartTime}
+        disabled={timingDisabled}
+        onCommit={(seconds) => {
+          if (selectedSubtitleCue) {
+            onSubtitleCueStartTimeCommit(selectedSubtitleCue, seconds);
+            return;
+          }
+
+          onClipStartTimeCommit(seconds);
+        }}
+      />
+      <SelectionTimecodeRow
+        label="End"
+        value={selectedEndTime}
+        disabled={timingDisabled}
+        onCommit={(seconds) => {
+          if (selectedSubtitleCue) {
+            onSubtitleCueEndTimeCommit(selectedSubtitleCue, seconds);
+            return;
+          }
+
+          onClipEndTimeCommit(seconds);
+        }}
+      />
+      <SelectionTimecodeRow
+        label="Duration"
+        value={selectedDuration}
+        disabled={timingDisabled}
+        onCommit={(seconds) => {
+          if (selectedSubtitleCue) {
+            onSubtitleCueDurationCommit(selectedSubtitleCue, seconds);
+            return;
+          }
+
+          onClipDurationCommit(seconds);
+        }}
+      />
+    </>
+  );
 
   return (
     <div className="cliparr-editor-scrollbar min-h-0 flex-1 overflow-y-auto bg-editor-panel text-sidebar-foreground">
@@ -152,253 +240,302 @@ export function EditorSubtitlePanel({
         onValueChange={onEditorPropertiesOpenSectionsChange}
       >
         <EditorPropertyAccordionItem<EditorPropertiesSectionId>
-          value={EDITOR_PROPERTIES_SECTION_ID.globalSubtitles}
-          title="Global Subtitles"
-          action={
-            subtitleToggleTooltip ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex" tabIndex={0}>
-                    {subtitleAction}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  {subtitleToggleTooltip}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              subtitleAction
-            )
-          }
+          value={EDITOR_PROPERTIES_SECTION_ID.selection}
+          title="Selection"
         >
-          <EditorPropertySection title="Track">
-            <EditorPropertyRow label="Track">
-              <Select
-                value={selectedSubtitleTrackKey}
-                onValueChange={onSelectedSubtitleTrackKeyChange}
-              >
-                <SelectTrigger
-                  size="sm"
-                  className={editorPropertySelectTriggerClassName()}
-                >
-                  <SelectValue placeholder="Select subtitle track" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>Subtitle Tracks</SelectLabel>
-                    <SelectItem value="none">No subtitles</SelectItem>
-                    {subtitleTracks.map((track) => {
-                      const trackKey = subtitleTrackKey(track);
-
-                      return (
-                        <SelectItem key={trackKey} value={trackKey}>
-                          {formatSubtitleTrackLabel(track, {
-                            variant: "selector",
-                          })}
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </EditorPropertyRow>
-
-            {!canEnableBurnIn && (
-              <div className="border border-editor-border bg-editor-warning px-2.5 py-2 text-xs text-editor-warning-foreground">
-                <div className="flex items-start gap-2">
-                  <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <div className="space-y-1">
-                    <p>{subtitleWarning}</p>
-                    {selectedSubtitleTrack && (
-                      <p className="text-ui-label text-muted-foreground">
-                        {formatSubtitleTrackTechnicalSummary(
-                          selectedSubtitleTrack,
-                        )}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {subtitleError && (
-              <div className="border border-destructive/35 bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
-                {subtitleError}
-              </div>
-            )}
+          <EditorPropertySection title={selectedItemTitle}>
+            {selectedSubtitleCue ? (
+              <EditorPropertyRow label="Text" align="start">
+                <span className="block max-h-24 overflow-y-auto whitespace-pre-wrap rounded-[var(--radius-control)] border border-editor-border bg-editor-control px-2.5 py-2 text-xs leading-relaxed text-sidebar-foreground">
+                  {selectedSubtitleCue.lines.join("\n")}
+                </span>
+              </EditorPropertyRow>
+            ) : null}
+            {timingRows}
           </EditorPropertySection>
+        </EditorPropertyAccordionItem>
 
-          <div
-            aria-disabled={styleControlsDisabled}
-            className={cn(
-              "transition-opacity",
-              styleControlsDisabled && "opacity-60",
-            )}
+        {showGlobalSubtitles ? (
+          <EditorPropertyAccordionItem<EditorPropertiesSectionId>
+            value={EDITOR_PROPERTIES_SECTION_ID.globalSubtitles}
+            title="Global Subtitles"
+            action={
+              subtitleToggleTooltip ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex" tabIndex={0}>
+                      {subtitleAction}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="left">
+                    {subtitleToggleTooltip}
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                subtitleAction
+              )
+            }
           >
-            <EditorPropertySection
-              title="Text"
-              action={
-                styleTooltip ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className={editorPropertyLabelClassName()}>
-                        Locked
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" align="end">
-                      {styleTooltip}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : null
-              }
-            >
-              <EditorPropertyRow label="Font">
+            <EditorPropertySection title="Track">
+              <EditorPropertyRow label="Track">
                 <Select
-                  value={subtitleStyleSettings.fontFamily}
-                  onValueChange={(value) =>
-                    updateStyleSetting("fontFamily", value)
-                  }
-                  onOpenChange={(open) => {
-                    if (open && !styleControlsDisabled) {
-                      requestLocalFonts();
-                    }
-                  }}
-                  disabled={styleControlsDisabled}
+                  value={selectedSubtitleTrackKey}
+                  onValueChange={onSelectedSubtitleTrackKeyChange}
                 >
                   <SelectTrigger
                     size="sm"
                     className={editorPropertySelectTriggerClassName()}
                   >
-                    <SelectValue placeholder="Select font" />
+                    <SelectValue placeholder="Select subtitle track" />
                   </SelectTrigger>
                   <SelectContent>
-                    {currentFontOption && (
-                      <SelectGroup>
-                        <SelectLabel>Current Font</SelectLabel>
-                        <SelectItem value={currentFontOption.value}>
-                          {currentFontOption.label}
-                        </SelectItem>
-                      </SelectGroup>
-                    )}
                     <SelectGroup>
-                      <SelectLabel>Included Fonts</SelectLabel>
-                      {bundledFontOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
+                      <SelectLabel>Subtitle Tracks</SelectLabel>
+                      <SelectItem value="none">No subtitles</SelectItem>
+                      {subtitleTracks.map((track) => {
+                        const trackKey = subtitleTrackKey(track);
+
+                        return (
+                          <SelectItem key={trackKey} value={trackKey}>
+                            {formatSubtitleTrackLabel(track, {
+                              variant: "selector",
+                            })}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectGroup>
-                    {localFontOptions.length > 0 && (
+                  </SelectContent>
+                </Select>
+              </EditorPropertyRow>
+
+              {!canEnableBurnIn && (
+                <div className="border border-editor-border bg-editor-warning px-2.5 py-2 text-xs text-editor-warning-foreground">
+                  <div className="flex items-start gap-2">
+                    <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <div className="space-y-1">
+                      <p>{subtitleWarning}</p>
+                      {selectedSubtitleTrack && (
+                        <p className="text-ui-label text-muted-foreground">
+                          {formatSubtitleTrackTechnicalSummary(
+                            selectedSubtitleTrack,
+                          )}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {subtitleError && (
+                <div className="border border-destructive/35 bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
+                  {subtitleError}
+                </div>
+              )}
+            </EditorPropertySection>
+
+            <div
+              aria-disabled={styleControlsDisabled}
+              className={cn(
+                "transition-opacity",
+                styleControlsDisabled && "opacity-60",
+              )}
+            >
+              <EditorPropertySection
+                title="Text"
+                action={
+                  styleTooltip ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className={editorPropertyLabelClassName()}>
+                          Locked
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" align="end">
+                        {styleTooltip}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null
+                }
+              >
+                <EditorPropertyRow label="Font">
+                  <Select
+                    value={subtitleStyleSettings.fontFamily}
+                    onValueChange={(value) =>
+                      updateStyleSetting("fontFamily", value)
+                    }
+                    onOpenChange={(open) => {
+                      if (open && !styleControlsDisabled) {
+                        requestLocalFonts();
+                      }
+                    }}
+                    disabled={styleControlsDisabled}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className={editorPropertySelectTriggerClassName()}
+                    >
+                      <SelectValue placeholder="Select font" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {currentFontOption && (
+                        <SelectGroup>
+                          <SelectLabel>Current Font</SelectLabel>
+                          <SelectItem value={currentFontOption.value}>
+                            {currentFontOption.label}
+                          </SelectItem>
+                        </SelectGroup>
+                      )}
                       <SelectGroup>
-                        <SelectLabel>Installed Fonts</SelectLabel>
-                        {localFontOptions.map((option) => (
+                        <SelectLabel>Included Fonts</SelectLabel>
+                        {bundledFontOptions.map((option) => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
                           </SelectItem>
                         ))}
                       </SelectGroup>
-                    )}
-                    {loadingLocalFonts && (
-                      <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
-                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                        Loading installed fonts...
-                      </div>
-                    )}
-                  </SelectContent>
-                </Select>
-              </EditorPropertyRow>
+                      {localFontOptions.length > 0 && (
+                        <SelectGroup>
+                          <SelectLabel>Installed Fonts</SelectLabel>
+                          {localFontOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                      {loadingLocalFonts && (
+                        <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                          Loading installed fonts...
+                        </div>
+                      )}
+                    </SelectContent>
+                  </Select>
+                </EditorPropertyRow>
 
-              <EditorColorControl
-                label="Color"
-                value={subtitleStyleSettings.fontColor}
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("fontColor", value)}
-              />
-              <EditorRangeControl
-                label="Size"
-                value={subtitleStyleSettings.fontSize}
-                min={16}
-                max={150}
-                step={1}
-                unit="px"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("fontSize", value)}
-              />
-            </EditorPropertySection>
+                <EditorColorControl
+                  label="Color"
+                  value={subtitleStyleSettings.fontColor}
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("fontColor", value)}
+                />
+                <EditorRangeControl
+                  label="Size"
+                  value={subtitleStyleSettings.fontSize}
+                  min={16}
+                  max={150}
+                  step={1}
+                  unit="px"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("fontSize", value)}
+                />
+              </EditorPropertySection>
 
-            <EditorPropertySection title="Shadow">
-              <EditorColorControl
-                label="Color"
-                value={subtitleStyleSettings.shadowColor}
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("shadowColor", value)}
-              />
-              <EditorRangeControl
-                label="Blur"
-                value={subtitleStyleSettings.shadowBlur}
-                min={0}
-                max={24}
-                step={1}
-                unit="px"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("shadowBlur", value)}
-              />
-              <EditorRangeControl
-                label="Offset"
-                value={subtitleStyleSettings.shadowOffsetY}
-                min={-16}
-                max={24}
-                step={1}
-                unit="px"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("shadowOffsetY", value)}
-              />
-            </EditorPropertySection>
+              <EditorPropertySection title="Shadow">
+                <EditorColorControl
+                  label="Color"
+                  value={subtitleStyleSettings.shadowColor}
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("shadowColor", value)}
+                />
+                <EditorRangeControl
+                  label="Blur"
+                  value={subtitleStyleSettings.shadowBlur}
+                  min={0}
+                  max={24}
+                  step={1}
+                  unit="px"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("shadowBlur", value)}
+                />
+                <EditorRangeControl
+                  label="Offset"
+                  value={subtitleStyleSettings.shadowOffsetY}
+                  min={-16}
+                  max={24}
+                  step={1}
+                  unit="px"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) =>
+                    updateStyleSetting("shadowOffsetY", value)
+                  }
+                />
+              </EditorPropertySection>
 
-            <EditorPropertySection title="Stroke">
-              <EditorColorControl
-                label="Color"
-                value={subtitleStyleSettings.strokeColor}
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("strokeColor", value)}
-              />
-              <EditorRangeControl
-                label="Width"
-                value={subtitleStyleSettings.strokeWidth}
-                min={0}
-                max={32}
-                step={0.5}
-                unit="px"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("strokeWidth", value)}
-              />
-            </EditorPropertySection>
+              <EditorPropertySection title="Stroke">
+                <EditorColorControl
+                  label="Color"
+                  value={subtitleStyleSettings.strokeColor}
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("strokeColor", value)}
+                />
+                <EditorRangeControl
+                  label="Width"
+                  value={subtitleStyleSettings.strokeWidth}
+                  min={0}
+                  max={32}
+                  step={0.5}
+                  unit="px"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("strokeWidth", value)}
+                />
+              </EditorPropertySection>
 
-            <EditorPropertySection title="Position">
-              <EditorRangeControl
-                label="X"
-                value={subtitleStyleSettings.positionX}
-                min={0}
-                max={100}
-                step={1}
-                unit="%"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("positionX", value)}
-              />
-              <EditorRangeControl
-                label="Y"
-                value={subtitleStyleSettings.positionY}
-                min={0}
-                max={100}
-                step={1}
-                unit="%"
-                disabled={styleControlsDisabled}
-                onChange={(value) => updateStyleSetting("positionY", value)}
-              />
-            </EditorPropertySection>
-          </div>
-        </EditorPropertyAccordionItem>
+              <EditorPropertySection title="Position">
+                <EditorRangeControl
+                  label="X"
+                  value={subtitleStyleSettings.positionX}
+                  min={0}
+                  max={100}
+                  step={1}
+                  unit="%"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("positionX", value)}
+                />
+                <EditorRangeControl
+                  label="Y"
+                  value={subtitleStyleSettings.positionY}
+                  min={0}
+                  max={100}
+                  step={1}
+                  unit="%"
+                  disabled={styleControlsDisabled}
+                  onChange={(value) => updateStyleSetting("positionY", value)}
+                />
+              </EditorPropertySection>
+            </div>
+          </EditorPropertyAccordionItem>
+        ) : null}
       </EditorPropertyAccordion>
     </div>
+  );
+}
+
+function SelectionTimecodeRow({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  disabled: boolean;
+  onCommit: (seconds: number) => void;
+}) {
+  return (
+    <EditorPropertyRow label={label}>
+      <EditorEditableTimecode
+        ariaLabel={`${label.toLowerCase()} time`}
+        buttonClassName="h-8 w-full justify-end rounded-[var(--radius-control)] border border-editor-border bg-editor-control px-2.5 font-mono text-xs font-semibold tabular-nums text-sidebar-foreground hover:bg-editor-control-hover focus-visible:ring-editor-accent/35"
+        className="w-full justify-end"
+        disabled={disabled}
+        inputClassName="w-full text-right text-xs"
+        inputWidth="100%"
+        onCommit={onCommit}
+        value={value}
+      >
+        <span className="block w-full text-right">{formatTime(value)}</span>
+      </EditorEditableTimecode>
+    </EditorPropertyRow>
   );
 }

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -40,6 +40,7 @@ interface EditorTimelineProperties {
     end: number;
     dir?: "right" | "left";
   }) => void;
+  selectTimelineAction: (action: { id: string }) => void;
   isValidTimelineActionRange: (params: {
     action: { id: string };
     start: number;
@@ -65,6 +66,7 @@ export function EditorTimeline({
   handleTimelineChange,
   handleTimelineActionMoveEnd,
   handleTimelineActionResizeEnd,
+  selectTimelineAction,
   isValidTimelineActionRange,
   seekToTime,
   onCursorDragStart,
@@ -115,7 +117,10 @@ export function EditorTimeline({
       const actionLabel = isSource ? "Source" : (subtitleLabel ?? "Selection");
 
       return (
-        <div className="cliparr-timeline-action-content">
+        <div
+          className="cliparr-timeline-action-content"
+          data-selected={action.selected ? "true" : undefined}
+        >
           {readyFillStyle && playbackReadyRange && (
             <span
               className="cliparr-timeline-action-ready-fill"
@@ -179,7 +184,8 @@ export function EditorTimeline({
 
           void seekToTime(time);
         }}
-        onClickActionOnly={(_, { time }) => {
+        onClickActionOnly={(_, { action, time }) => {
+          selectTimelineAction(action);
           void seekToTime(time);
         }}
         onCursorDragStart={onCursorDragStart}

--- a/apps/frontend/src/components/editor/editorSidebarPreferences.test.ts
+++ b/apps/frontend/src/components/editor/editorSidebarPreferences.test.ts
@@ -70,7 +70,10 @@ void test("loads saved open editor properties accordion sections", () => {
   withStorage(
     {
       [editorPropertiesAccordionStorageKey]: JSON.stringify({
-        openSections: [EDITOR_PROPERTIES_SECTION_ID.globalSubtitles],
+        openSections: [
+          EDITOR_PROPERTIES_SECTION_ID.selection,
+          EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+        ],
       }),
     },
     () => {
@@ -78,6 +81,21 @@ void test("loads saved open editor properties accordion sections", () => {
         loadEditorPropertiesOpenSections(),
         DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS,
       );
+    },
+  );
+});
+
+void test("loads saved single editor properties accordion section", () => {
+  withStorage(
+    {
+      [editorPropertiesAccordionStorageKey]: JSON.stringify({
+        openSections: [EDITOR_PROPERTIES_SECTION_ID.globalSubtitles],
+      }),
+    },
+    () => {
+      assert.deepEqual(loadEditorPropertiesOpenSections(), [
+        EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+      ]);
     },
   );
 });
@@ -101,6 +119,7 @@ void test("filters unknown editor properties accordion section ids", () => {
       [editorPropertiesAccordionStorageKey]: JSON.stringify({
         openSections: [
           "preview-source",
+          EDITOR_PROPERTIES_SECTION_ID.selection,
           EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
           "export",
         ],
@@ -120,7 +139,9 @@ void test("deduplicates editor properties accordion section ids", () => {
     {
       [editorPropertiesAccordionStorageKey]: JSON.stringify({
         openSections: [
+          EDITOR_PROPERTIES_SECTION_ID.selection,
           EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+          EDITOR_PROPERTIES_SECTION_ID.selection,
           EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
         ],
       }),
@@ -176,7 +197,10 @@ void test("saves editor properties accordion sections", () => {
     assert.equal(
       storage.get(editorPropertiesAccordionStorageKey),
       JSON.stringify({
-        openSections: [EDITOR_PROPERTIES_SECTION_ID.globalSubtitles],
+        openSections: [
+          EDITOR_PROPERTIES_SECTION_ID.selection,
+          EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
+        ],
       }),
     );
   });

--- a/apps/frontend/src/components/editor/editorSidebarPreferences.ts
+++ b/apps/frontend/src/components/editor/editorSidebarPreferences.ts
@@ -1,8 +1,10 @@
 export const EDITOR_PROPERTIES_SECTION_ID = {
+  selection: "selection",
   globalSubtitles: "global-subtitles",
 } as const;
 
 const EDITOR_PROPERTIES_SECTION_IDS = [
+  EDITOR_PROPERTIES_SECTION_ID.selection,
   EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
 ] as const;
 
@@ -12,6 +14,7 @@ export type EditorPropertiesSectionId =
 export type EditorPropertiesOpenSections = readonly EditorPropertiesSectionId[];
 
 export const DEFAULT_EDITOR_PROPERTIES_OPEN_SECTIONS = [
+  EDITOR_PROPERTIES_SECTION_ID.selection,
   EDITOR_PROPERTIES_SECTION_ID.globalSubtitles,
 ] as const satisfies EditorPropertiesOpenSections;
 

--- a/apps/frontend/src/components/editor/editorTimelineSelection.test.ts
+++ b/apps/frontend/src/components/editor/editorTimelineSelection.test.ts
@@ -1,0 +1,86 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defaultEditorTimelineSelection,
+  editorTimelineSelectionForActionId,
+  normalizeEditorTimelineSelection,
+  resolveSelectedSubtitleCue,
+} from "@/components/editor/editorTimelineSelection";
+import {
+  buildSubtitleTimelineTrack,
+  subtitleTimelineActionId,
+} from "@/components/editor/subtitleTimeline";
+
+const track = buildSubtitleTimelineTrack({
+  trackKey: "stream:1",
+  label: "English",
+  cues: [
+    {
+      startTime: 0,
+      endTime: 1,
+      text: "First",
+      lines: ["First"],
+    },
+    {
+      startTime: 2,
+      endTime: 3,
+      text: "Second",
+      lines: ["Second"],
+    },
+  ],
+});
+
+void test("defaults timeline selection to the clip", () => {
+  assert.deepEqual(defaultEditorTimelineSelection(), { kind: "clip" });
+});
+
+void test("resolves timeline selection from selectable action ids", () => {
+  assert.deepEqual(editorTimelineSelectionForActionId("selected-clip"), {
+    kind: "clip",
+  });
+  assert.deepEqual(
+    editorTimelineSelectionForActionId(
+      subtitleTimelineActionId("stream:1:cue:0"),
+    ),
+    {
+      kind: "subtitle-cue",
+      cueId: "stream:1:cue:0",
+    },
+  );
+  assert.equal(editorTimelineSelectionForActionId("full-video"), null);
+});
+
+void test("preserves selected subtitle cues while present", () => {
+  const selection = { kind: "subtitle-cue" as const, cueId: "stream:1:cue:1" };
+
+  assert.deepEqual(
+    normalizeEditorTimelineSelection({
+      selection,
+      subtitleTimelineTrack: track,
+    }),
+    selection,
+  );
+  assert.equal(resolveSelectedSubtitleCue(track, selection)?.text, "Second");
+});
+
+void test("falls back to clip when selected subtitle cue is missing", () => {
+  assert.deepEqual(
+    normalizeEditorTimelineSelection({
+      selection: { kind: "subtitle-cue", cueId: "missing" },
+      subtitleTimelineTrack: track,
+    }),
+    { kind: "clip" },
+  );
+});
+
+void test("falls back to clip when subtitle track is unavailable", () => {
+  assert.deepEqual(
+    normalizeEditorTimelineSelection({
+      selection: { kind: "subtitle-cue", cueId: "stream:1:cue:0" },
+      subtitleTimelineTrack: null,
+    }),
+    { kind: "clip" },
+  );
+});

--- a/apps/frontend/src/components/editor/editorTimelineSelection.ts
+++ b/apps/frontend/src/components/editor/editorTimelineSelection.ts
@@ -1,0 +1,66 @@
+import {
+  subtitleCueIdFromActionId,
+  type SubtitleTimelineTrack,
+  type SubtitleTimelineCue,
+} from "@/components/editor/subtitleTimeline";
+
+export type EditorTimelineSelection =
+  | { kind: "clip" }
+  | { kind: "subtitle-cue"; cueId: string };
+
+export function defaultEditorTimelineSelection(): EditorTimelineSelection {
+  return { kind: "clip" };
+}
+
+export function editorTimelineSelectionsEqual(
+  left: EditorTimelineSelection,
+  right: EditorTimelineSelection,
+) {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+
+  if (left.kind === "clip") {
+    return true;
+  }
+
+  return right.kind === "subtitle-cue" && left.cueId === right.cueId;
+}
+
+export function editorTimelineSelectionForActionId(
+  actionId: string,
+): EditorTimelineSelection | null {
+  if (actionId === "selected-clip") {
+    return { kind: "clip" };
+  }
+
+  const cueId = subtitleCueIdFromActionId(actionId);
+  return cueId ? { kind: "subtitle-cue", cueId } : null;
+}
+
+export function resolveSelectedSubtitleCue(
+  track: SubtitleTimelineTrack | null | undefined,
+  selection: EditorTimelineSelection,
+): SubtitleTimelineCue | null {
+  if (selection.kind !== "subtitle-cue") {
+    return null;
+  }
+
+  return track?.cues.find((cue) => cue.id === selection.cueId) ?? null;
+}
+
+export function normalizeEditorTimelineSelection({
+  selection,
+  subtitleTimelineTrack,
+}: {
+  selection: EditorTimelineSelection;
+  subtitleTimelineTrack: SubtitleTimelineTrack | null | undefined;
+}): EditorTimelineSelection {
+  if (selection.kind === "clip") {
+    return selection;
+  }
+
+  return resolveSelectedSubtitleCue(subtitleTimelineTrack, selection)
+    ? selection
+    : defaultEditorTimelineSelection();
+}

--- a/apps/frontend/src/components/editor/subtitleTimeline.test.ts
+++ b/apps/frontend/src/components/editor/subtitleTimeline.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   applySubtitleCueTimingUpdates,
   assignSubtitleCueLanes,
+  buildSubtitleCueTimingPropertyUpdate,
   buildSubtitleTimelineTrack,
   isValidSubtitleCueRange,
   isValidSubtitleTimelineActionRange,
@@ -316,6 +317,82 @@ void test("rejects invalid subtitle cue timing updates", () => {
       updates: [{ cueId: "stream:1:cue:0", startTime: 1, endTime: 11 }],
     }),
     track,
+  );
+});
+
+void test("builds subtitle cue timing updates from property edits", () => {
+  const item = cue("cue-1", 1, 3);
+
+  assert.deepEqual(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "start",
+      value: 1.234,
+      duration: 10,
+    }),
+    {
+      cueId: "cue-1",
+      startTime: 1.23,
+      endTime: 3,
+    },
+  );
+  assert.deepEqual(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "end",
+      value: 4.567,
+      duration: 10,
+    }),
+    {
+      cueId: "cue-1",
+      startTime: 1,
+      endTime: 4.57,
+    },
+  );
+  assert.deepEqual(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "duration",
+      value: 2.345,
+      duration: 10,
+    }),
+    {
+      cueId: "cue-1",
+      startTime: 1,
+      endTime: 3.35,
+    },
+  );
+});
+
+void test("rejects invalid subtitle cue timing property edits", () => {
+  const item = cue("cue-1", 1, 3);
+
+  assert.equal(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "start",
+      value: 3,
+      duration: 10,
+    }),
+    null,
+  );
+  assert.equal(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "end",
+      value: 1,
+      duration: 10,
+    }),
+    null,
+  );
+  assert.equal(
+    buildSubtitleCueTimingPropertyUpdate({
+      cue: item,
+      property: "duration",
+      value: 20,
+      duration: 10,
+    }),
+    null,
   );
 });
 

--- a/apps/frontend/src/components/editor/subtitleTimeline.ts
+++ b/apps/frontend/src/components/editor/subtitleTimeline.ts
@@ -34,6 +34,8 @@ export type SubtitleCueTimingUpdateMode =
   | "resize-left"
   | "resize-right";
 
+export type SubtitleCueTimingProperty = "start" | "end" | "duration";
+
 const subtitleActionPrefix = "subtitle-cue:";
 
 export function subtitleTimelineActionId(cueId: string) {
@@ -197,6 +199,53 @@ export function roundSubtitleCueTimingUpdate(
     startTime: roundTimelineTime(update.startTime),
     endTime: roundTimelineTime(update.endTime),
   };
+}
+
+export function buildSubtitleCueTimingPropertyUpdate({
+  cue,
+  property,
+  value,
+  duration,
+}: {
+  cue: SubtitleTimelineCue;
+  property: SubtitleCueTimingProperty;
+  value: number;
+  duration: number;
+}): SubtitleCueTimingUpdate | null {
+  const roundedValue = roundTimelineTime(value);
+  let update: SubtitleCueTimingUpdate;
+
+  if (property === "start") {
+    update = {
+      cueId: cue.id,
+      startTime: roundedValue,
+      endTime: cue.endTime,
+    };
+  } else if (property === "end") {
+    update = {
+      cueId: cue.id,
+      startTime: cue.startTime,
+      endTime: roundedValue,
+    };
+  } else {
+    update = {
+      cueId: cue.id,
+      startTime: cue.startTime,
+      endTime: roundTimelineTime(cue.startTime + roundedValue),
+    };
+  }
+
+  if (
+    !isValidSubtitleCueRange({
+      startTime: update.startTime,
+      endTime: update.endTime,
+      duration,
+    })
+  ) {
+    return null;
+  }
+
+  return roundSubtitleCueTimingUpdate(update);
 }
 
 export function snapSubtitleCueTimingUpdateToAdjacentCue({

--- a/apps/frontend/src/components/editor/useEditorTimeline.ts
+++ b/apps/frontend/src/components/editor/useEditorTimeline.ts
@@ -40,6 +40,10 @@ import {
   type SubtitleCueTimingUpdateMode,
   type SubtitleTimelineTrack,
 } from "@/components/editor/subtitleTimeline";
+import {
+  editorTimelineSelectionForActionId,
+  type EditorTimelineSelection,
+} from "@/components/editor/editorTimelineSelection";
 
 interface UseEditorTimelineProperties {
   duration: number;
@@ -50,6 +54,8 @@ interface UseEditorTimelineProperties {
   updateClipRange: (start: number, end: number) => void;
   onClipRangeCommit?: (start: number, end: number) => void;
   subtitleTimelineTrack?: SubtitleTimelineTrack | null;
+  timelineSelection: EditorTimelineSelection;
+  onTimelineSelectionChange: (selection: EditorTimelineSelection) => void;
   updateSubtitleCueTimings?: (
     updates: readonly SubtitleCueTimingUpdate[],
     duration: number,
@@ -120,6 +126,8 @@ export function useEditorTimeline({
   updateClipRange,
   onClipRangeCommit,
   subtitleTimelineTrack,
+  timelineSelection,
+  onTimelineSelectionChange,
   updateSubtitleCueTimings,
 }: UseEditorTimelineProperties) {
   const timelineReference = useRef<TimelineState>(null);
@@ -247,12 +255,18 @@ export function useEditorTimeline({
       subtitleTimelineTrack && subtitleTimelineCues.length > 0
         ? assignSubtitleCueLanes(subtitleTimelineCues).map((lane) => ({
             id: `${subtitleTimelineTrack.id}:lane:${lane.index}`,
+            selected:
+              timelineSelection.kind === "subtitle-cue" &&
+              lane.cues.some((cue) => cue.id === timelineSelection.cueId),
             rowHeight: SUBTITLE_TIMELINE_ROW_HEIGHT,
             actions: lane.cues.map((cue) => ({
               id: subtitleTimelineActionId(cue.id),
               start: roundTimelineTime(cue.startTime),
               end: roundTimelineTime(cue.endTime),
               effectId: "subtitle",
+              selected:
+                timelineSelection.kind === "subtitle-cue" &&
+                timelineSelection.cueId === cue.id,
               flexible: hasDuration,
               movable: hasDuration,
               minStart: 0,
@@ -281,14 +295,14 @@ export function useEditorTimeline({
       {
         id: "clip-range",
         rowHeight: CLIP_TIMELINE_ROW_HEIGHT,
-        selected: true,
+        selected: timelineSelection.kind === "clip",
         actions: [
           {
             id: "selected-clip",
             start: safeStart,
             end: safeEnd,
             effectId: "clip",
-            selected: true,
+            selected: timelineSelection.kind === "clip",
             flexible: hasDuration,
             movable: hasDuration,
             minStart: 0,
@@ -298,7 +312,14 @@ export function useEditorTimeline({
       },
       ...subtitleRows,
     ];
-  }, [duration, endTime, hasDuration, startTime, subtitleTimelineTrack]);
+  }, [
+    duration,
+    endTime,
+    hasDuration,
+    startTime,
+    subtitleTimelineTrack,
+    timelineSelection,
+  ]);
 
   const timelineSubtitleActionLabels = useMemo(() => {
     const labels = new Map<string, string>();
@@ -634,6 +655,16 @@ export function useEditorTimeline({
     ],
   );
 
+  const selectTimelineAction = useCallback(
+    (action: { id: string }) => {
+      const selection = editorTimelineSelectionForActionId(action.id);
+      if (selection) {
+        onTimelineSelectionChange(selection);
+      }
+    },
+    [onTimelineSelectionChange],
+  );
+
   const handleTimelineActionMoveEnd = useCallback(
     ({
       action,
@@ -644,6 +675,7 @@ export function useEditorTimeline({
       start: number;
       end: number;
     }) => {
+      selectTimelineAction(action);
       if (action.id !== "selected-clip") {
         commitSubtitleCueTiming({ action, start, end, mode: "move" });
         return;
@@ -651,7 +683,7 @@ export function useEditorTimeline({
 
       commitClipRange(start, end);
     },
-    [commitClipRange, commitSubtitleCueTiming],
+    [commitClipRange, commitSubtitleCueTiming, selectTimelineAction],
   );
 
   const handleTimelineActionResizeEnd = useCallback(
@@ -666,6 +698,7 @@ export function useEditorTimeline({
       end: number;
       dir?: "right" | "left";
     }) => {
+      selectTimelineAction(action);
       if (action.id !== "selected-clip") {
         commitSubtitleCueTiming({
           action,
@@ -678,7 +711,7 @@ export function useEditorTimeline({
 
       commitClipRange(start, end);
     },
-    [commitClipRange, commitSubtitleCueTiming],
+    [commitClipRange, commitSubtitleCueTiming, selectTimelineAction],
   );
 
   return {
@@ -699,6 +732,7 @@ export function useEditorTimeline({
     handleTimelineChange,
     handleTimelineActionMoveEnd,
     handleTimelineActionResizeEnd,
+    selectTimelineAction,
     setTimelineCurrentTime,
     hasDuration,
   };

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -784,6 +784,18 @@
   -webkit-user-select: none;
 }
 
+.cliparr-timeline-action-content[data-selected="true"]::after {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border: 2px solid var(--editor-accent);
+  border-radius: 1px;
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklch, var(--editor-workspace) 70%, transparent);
+  content: "";
+  pointer-events: none;
+}
+
 .cliparr-timeline-action-ready-fill {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- add first-class timeline selection state for clip and subtitle cue actions
- add a Selection properties accordion for editing selected clip/cue timing
- preserve global subtitle settings behavior while making clip selection properties available for local media

## Validation
- pnpm preflight
