### PR TITLE
feat(frontend): simplify export settings

### DIFF
--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -158,19 +158,27 @@ export function EditorExportDialog({
             includeAudio={includeAudio}
             onIncludeAudioChange={onIncludeAudioChange}
             audioDisabledReason={audioDisabledReason}
+            showSourcePreference={hasHlsSource && hasDirectSource}
             hasHlsSource={hasHlsSource}
             hasDirectSource={hasDirectSource}
             directSourceLabel={directSourceLabel}
             hlsSourceLabel={hlsSourceLabel}
           />
 
-          <EditorFilenameTemplateSection
-            editingTemplateKind={editingTemplateKind}
-            onEditingTemplateKindChange={onEditingTemplateKindChange}
-            fileNameTemplates={fileNameTemplates}
-            onFileNameTemplateChange={onFileNameTemplateChange}
-            onResetFileNameTemplate={onResetFileNameTemplate}
-          />
+          <details className="rounded-md border border-border bg-card">
+            <summary className="cursor-pointer rounded-md px-3 py-3 text-sm font-medium focus-visible:ring-2 focus-visible:ring-ring">
+              Advanced filename settings
+            </summary>
+            <div className="px-3 pb-3">
+              <EditorFilenameTemplateSection
+                editingTemplateKind={editingTemplateKind}
+                onEditingTemplateKindChange={onEditingTemplateKindChange}
+                fileNameTemplates={fileNameTemplates}
+                onFileNameTemplateChange={onFileNameTemplateChange}
+                onResetFileNameTemplate={onResetFileNameTemplate}
+              />
+            </div>
+          </details>
         </div>
 
         <EditorExportSummaryPanel


### PR DESCRIPTION
Keep the primary export choices and live output summary visible, collapse filename templates under Advanced filename settings, and show source selection only when both direct media and HLS are available.

Validation: `pnpm preflight`, frontend production build, and desktop/mobile browser checks for a local-file export, including expanding and collapsing template controls.
