### PR TITLE
feat(frontend): clarify video onboarding and empty states

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -11,6 +11,7 @@ import {
   Video,
 } from "lucide-react";
 import { cliparrClient, type CliparrVersionInfo } from "@/api/cliparrClient";
+import { compactSecondaryButtonClasses } from "@/components/ui/control-styles";
 import { cn } from "@/lib/utilities";
 import { EDITOR_THUMBNAIL_VIEW_TRANSITION_NAME } from "@/lib/viewTransitions";
 import {
@@ -298,6 +299,10 @@ function DashboardPlaybackMotionRegion({
   activeViewTransitionSessionId,
   onSelectSession,
   onClearViewerFilter,
+  onOpenLocalVideo,
+  onOpenSources,
+  onRefresh,
+  refreshing,
 }: {
   loading: boolean;
   error: string;
@@ -308,6 +313,10 @@ function DashboardPlaybackMotionRegion({
   activeViewTransitionSessionId?: string | null;
   onSelectSession: (session: CurrentlyPlayingItem) => void;
   onClearViewerFilter: () => void;
+  onOpenLocalVideo: () => void;
+  onOpenSources: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
 }) {
   const reduceMotion = useReducedMotion();
   const hasPlaybackCards = playbackCards.length > 0;
@@ -438,6 +447,37 @@ function DashboardPlaybackMotionRegion({
                 <p className="mx-auto max-w-sm text-sm text-muted-foreground">
                   {emptyMessage}
                 </p>
+                <p className="mx-auto mt-2 max-w-sm text-sm text-muted-foreground">
+                  Start a video in Plex or Jellyfin, then refresh. If your
+                  server is missing, check your connected sources.
+                </p>
+                <div className="mt-5 flex flex-wrap justify-center gap-2">
+                  <button
+                    type="button"
+                    onClick={onRefresh}
+                    disabled={refreshing}
+                    className={compactSecondaryButtonClasses}
+                  >
+                    <RefreshCw className="h-4 w-4" />
+                    {refreshing ? "Refreshing…" : "Refresh sessions"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onOpenSources}
+                    className={compactSecondaryButtonClasses}
+                  >
+                    <Settings2 className="h-4 w-4" />
+                    Manage sources
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onOpenLocalVideo}
+                    className={compactSecondaryButtonClasses}
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                    Open Video
+                  </button>
+                </div>
               </>
             )}
           </motion.div>
@@ -907,6 +947,10 @@ export default function DashboardScreen({
             activeViewTransitionSessionId={activeViewTransitionSessionId}
             onSelectSession={onSelectSession}
             onClearViewerFilter={clearViewerFilter}
+            onOpenLocalVideo={onOpenLocalVideo}
+            onOpenSources={onOpenSources}
+            onRefresh={() => void fetchSessions()}
+            refreshing={refreshing}
           />
         </div>
       </div>

--- a/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
@@ -1,6 +1,6 @@
 import { FolderOpen } from "lucide-react";
 import ProviderConnectFlow from "@/components/provider-connect/ProviderConnectFlow";
-import { secondaryButtonClasses } from "@/components/ui/control-styles";
+import { primaryButtonClasses } from "@/components/ui/control-styles";
 import type { ProviderSession } from "@/providers/types";
 
 interface Properties {
@@ -33,25 +33,41 @@ export default function ProviderConnectScreen({
             />
           </div>
           <h1 className="text-center text-3xl font-semibold tracking-tight">
-            Connect A Provider
+            Start a clip
           </h1>
           <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-6 text-muted-foreground">
-            Choose a provider to get started.
+            Open a video from your device or connect your media library.
           </p>
-          <div className="mt-5 flex justify-center">
+        </div>
+
+        <div className="relative grid gap-6 px-6 py-6 sm:px-8 lg:grid-cols-2">
+          <section className="rounded-2xl border border-border bg-background/60 p-5">
+            <FolderOpen
+              className="mb-3 h-6 w-6 text-primary"
+              aria-hidden="true"
+            />
+            <h2 className="text-lg font-semibold">Open a file</h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Choose a video on this device and start trimming. Local files need
+              no account or provider connection.
+            </p>
             <button
               type="button"
               onClick={onOpenLocalVideo}
-              className={secondaryButtonClasses}
+              className={`${primaryButtonClasses} mt-5`}
             >
               <FolderOpen className="h-4 w-4" />
               Open Video
             </button>
-          </div>
-        </div>
-
-        <div className="relative px-6 py-6 sm:px-8">
-          <ProviderConnectFlow variant="screen" onConnected={onConnected} />
+          </section>
+          <section className="min-w-0 rounded-2xl border border-border bg-background/60 p-5">
+            <h2 className="text-lg font-semibold">Connect a provider</h2>
+            <p className="mt-2 mb-5 text-sm leading-6 text-muted-foreground">
+              Connect Plex or Jellyfin, then play a video there to find it in
+              Cliparr and create a clip.
+            </p>
+            <ProviderConnectFlow variant="screen" onConnected={onConnected} />
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Present local files and provider connections as two clear starting paths, explaining that local videos need no account. Give the empty dashboard playback instructions and working Refresh sessions, Manage sources, and Open Video actions.

Validation: `pnpm preflight`, frontend production build, and mobile browser checks covering unauthenticated local-file editing and empty-dashboard actions with mocked provider responses. Live provider authentication was not exercised.
