### PR TITLE
feat(frontend): add editor history and shortcut guidance

### DIFF
--- a/apps/frontend/src/components/editor/EditorEditingTools.tsx
+++ b/apps/frontend/src/components/editor/EditorEditingTools.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Keyboard, Redo2, Undo2 } from "lucide-react";
+import { DialogWindow } from "@/components/ui/dialog";
+import { compactSecondaryButtonClasses } from "@/components/ui/control-styles";
+import type { useEditorHistory } from "@/components/editor/useEditorHistory";
+
+const shortcuts = [
+  ["Play / pause", "Space"],
+  ["Set In / Out at the playhead", "I / O (or [ / ])"],
+  ["Jump to In / Out", "Shift + I / O"],
+  ["Seek 30 seconds", "← / →"],
+  ["Seek 5 seconds", "Shift + ← / →"],
+  ["Previous / next frame", "Page Up / Page Down (or hold K + J / L)"],
+  ["Zoom out / in", "− / +"],
+  ["Undo", "Ctrl / ⌘ + Z"],
+  ["Redo", "Ctrl / ⌘ + Shift + Z (or Ctrl + Y)"],
+] as const;
+
+export function EditorEditingTools({
+  history,
+}: {
+  history: ReturnType<typeof useEditorHistory>;
+}) {
+  const [helpOpen, setHelpOpen] = useState(false);
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-editor-border bg-editor-panel px-3 py-2">
+      <button
+        type="button"
+        onClick={history.undo}
+        disabled={!history.canUndo}
+        className={compactSecondaryButtonClasses}
+      >
+        <Undo2 className="h-4 w-4" /> Undo
+      </button>
+      <button
+        type="button"
+        onClick={history.redo}
+        disabled={!history.canRedo}
+        className={compactSecondaryButtonClasses}
+      >
+        <Redo2 className="h-4 w-4" /> Redo
+      </button>
+      <button
+        type="button"
+        onClick={() => setHelpOpen(true)}
+        className={`${compactSecondaryButtonClasses} ml-auto`}
+      >
+        <Keyboard className="h-4 w-4" /> Shortcuts
+      </button>
+      <DialogWindow
+        open={helpOpen}
+        onClose={() => setHelpOpen(false)}
+        title="Editor shortcuts"
+        description="Use these keys while the editor is focused. Text fields keep their own editing shortcuts."
+        closeLabel="Close shortcut help"
+      >
+        <dl className="space-y-3 overflow-y-auto p-4">
+          {shortcuts.map(([action, keys]) => (
+            <div
+              key={action}
+              className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 text-sm"
+            >
+              <dt>{action}</dt>
+              <dd className="font-mono text-xs text-muted-foreground">
+                {keys}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </DialogWindow>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -33,6 +33,8 @@ import {
   createEditorTimelineEngine,
   synchronizeEditorTimelineSession,
 } from "@/components/editor/editorTimelineEngine";
+import { useEditorHistory } from "@/components/editor/useEditorHistory";
+import { EditorEditingTools } from "@/components/editor/EditorEditingTools";
 import { EditorHeader } from "@/components/editor/EditorHeader";
 import { EditorPreview } from "@/components/editor/EditorPreview";
 import { EditorSubtitlePreview } from "@/components/editor/EditorSubtitlePreview";
@@ -147,6 +149,10 @@ function EditorScreenContent({
     duration,
     mediaReady: timelineMedia.metadataReady,
   });
+  const editHistory = useEditorHistory(
+    engine,
+    timelineMedia.metadataReady && !subtitleLoading,
+  );
   const posterImageUrl = session.thumbUrl;
 
   const {
@@ -368,6 +374,8 @@ function EditorScreenContent({
     [duration, frameStepSeconds, getPlaybackTime, pausePlayback, seekToTime],
   );
   useEditorKeyboardShortcuts({
+    undo: editHistory.undo,
+    redo: editHistory.redo,
     togglePlay: () => void togglePlay(),
     markIn: handleMarkInShortcut,
     markOut: handleMarkOutShortcut,
@@ -551,6 +559,8 @@ function EditorScreenContent({
         exportDisabledReason={headerExportDisabledReason}
         onExportClick={handleOpenExportDialog}
       />
+
+      <EditorEditingTools history={editHistory} />
 
       <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-2.5 sm:p-3 lg:overflow-hidden">
         {isDesktopLayout ? (

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -33,8 +33,8 @@ function TrackHeaderColumn({ muted, onMutedChange }: EditorTimelineProperties) {
                 <button
                   type="button"
                   onClick={() => onMutedChange(!muted)}
-                  title={muted ? "Unmute Source" : "Mute Source"}
-                  aria-label={muted ? "Unmute Source" : "Mute Source"}
+                  title={muted ? "Unmute preview" : "Mute preview"}
+                  aria-label={muted ? "Unmute preview" : "Mute preview"}
                   aria-pressed={muted}
                   className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
                 >

--- a/apps/frontend/src/components/editor/editorHistory.test.ts
+++ b/apps/frontend/src/components/editor/editorHistory.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  TimelineEngine,
+  fromSeconds,
+  toSeconds,
+} from "@techsquidtv/canvas-timeline";
+import { createEditorHistory } from "@/components/editor/editorHistory";
+import {
+  subtitleCuesFromTimeline,
+  synchronizeEditorTimelineSubtitles,
+} from "@/components/editor/editorTimelineEngine";
+import { resolveEditorShortcutCommand } from "@/components/editor/editorShortcutCommands";
+
+function createEngine() {
+  const engine = new TimelineEngine({
+    tracks: [],
+    duration: fromSeconds(60),
+    inPoint: fromSeconds(0),
+    outPoint: fromSeconds(10),
+  });
+  synchronizeEditorTimelineSubtitles(engine, {
+    cues: [
+      {
+        id: "cue-1",
+        startTime: 1,
+        endTime: 2,
+        text: "Original",
+        lines: ["Original"],
+      },
+    ],
+  });
+  return engine;
+}
+
+void test("undoes range and subtitle edits in chronological order", () => {
+  const engine = createEngine();
+  const history = createEditorHistory(engine);
+  engine.setInPoint(fromSeconds(5));
+  const clip = engine.getState().tracks[0]?.clips[0];
+  assert.ok(clip);
+  engine.updateClipProperties(clip.id, { label: "Edited" });
+  history.undo();
+  assert.equal(
+    subtitleCuesFromTimeline(engine.getState().tracks)[0]?.text,
+    "Original",
+  );
+  assert.equal(toSeconds(engine.getState().inPoint!), 5);
+  history.undo();
+  assert.equal(toSeconds(engine.getState().inPoint!), 0);
+  assert.equal(history.getSnapshot().canUndo, false);
+  history.redo();
+  history.redo();
+  assert.equal(toSeconds(engine.getState().inPoint!), 5);
+  assert.equal(
+    subtitleCuesFromTimeline(engine.getState().tracks)[0]?.text,
+    "Edited",
+  );
+  assert.equal(history.getSnapshot().canRedo, false);
+  history.dispose();
+});
+
+void test("groups a range drag and clears redo after a new edit", () => {
+  const engine = createEngine();
+  const history = createEditorHistory(engine);
+  history.beginRangeGesture();
+  for (const value of [1, 2, 3, 4]) {
+    engine.setInPoint(fromSeconds(value));
+  }
+  history.endRangeGesture();
+  history.undo();
+  assert.equal(toSeconds(engine.getState().inPoint!), 0);
+  assert.equal(history.getSnapshot().canUndo, false);
+  engine.setOutPoint(fromSeconds(20));
+  assert.equal(history.getSnapshot().canRedo, false);
+  history.undo();
+  assert.equal(toSeconds(engine.getState().outPoint!), 10);
+  history.dispose();
+});
+
+void test("playback and zoom do not become undoable edits", () => {
+  const engine = createEngine();
+  const history = createEditorHistory(engine);
+  engine.setTime(fromSeconds(3));
+  engine.setZoomScale(100);
+  assert.equal(history.getSnapshot().canUndo, false);
+  history.dispose();
+  engine.setInPoint(fromSeconds(2));
+  assert.equal(history.getSnapshot().canUndo, false);
+});
+
+void test("resolves platform undo and redo without consuming unrelated modifiers", () => {
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyZ", ctrlKey: true }),
+    "undo",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({
+      code: "KeyZ",
+      metaKey: true,
+      shiftKey: true,
+    }),
+    "redo",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyY", ctrlKey: true }),
+    "redo",
+  );
+  assert.equal(
+    resolveEditorShortcutCommand({ code: "KeyZ", ctrlKey: true, altKey: true }),
+    null,
+  );
+});

--- a/apps/frontend/src/components/editor/editorHistory.ts
+++ b/apps/frontend/src/components/editor/editorHistory.ts
@@ -1,0 +1,148 @@
+import {
+  toSeconds,
+  type TimelineEngine,
+  type TimelineStateSnapshot,
+} from "@techsquidtv/canvas-timeline";
+
+type ClipRange = Pick<TimelineStateSnapshot, "inPoint" | "outPoint">;
+type RangeEdit = { kind: "range"; before: ClipRange; after: ClipRange };
+type Edit = RangeEdit | { kind: "timeline" };
+
+function readRange(engine: TimelineEngine): ClipRange {
+  const { inPoint, outPoint } = engine.getState();
+  return { inPoint, outPoint };
+}
+
+function rangesEqual(left: ClipRange, right: ClipRange) {
+  return ["inPoint", "outPoint"].every((key) => {
+    const boundary = key as keyof ClipRange;
+    const a = left[boundary];
+    const b = right[boundary];
+    return a && b ? toSeconds(a) === toSeconds(b) : a === b;
+  });
+}
+
+// Canvas Timeline owns document history. Its history excludes In/Out, so this
+// adapter orders range edits alongside native undo/redo without copying tracks.
+export function createEditorHistory(engine: TimelineEngine) {
+  engine.snapshot();
+  const past: Edit[] = [];
+  const future: Edit[] = [];
+  const listeners = new Set<() => void>();
+  let range = readRange(engine);
+  let replaying = false;
+  let rangeGesture = false;
+  let groupedRange: RangeEdit | null = null;
+  let snapshot = { canUndo: false, canRedo: false };
+
+  const notify = () => {
+    const previous = past.at(-1);
+    const next = future.at(-1);
+    snapshot = {
+      canUndo: Boolean(
+        previous && (previous.kind === "range" || engine.canUndo),
+      ),
+      canRedo: Boolean(next && (next.kind === "range" || engine.canRedo)),
+    };
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const push = (edit: Edit) => {
+    past.push(edit);
+    if (past.length > 75) {
+      past.shift();
+    }
+    future.length = 0;
+    notify();
+  };
+  const unsubscribeRange = engine.on("state:inOut", () => {
+    const next = readRange(engine);
+    if (!replaying && !rangesEqual(range, next)) {
+      if (groupedRange && past.at(-1) === groupedRange) {
+        groupedRange.after = next;
+        notify();
+      } else {
+        groupedRange = { kind: "range", before: range, after: next };
+        push(groupedRange);
+      }
+      if (!rangeGesture) {
+        queueMicrotask(() => {
+          groupedRange = null;
+        });
+      }
+    }
+    range = next;
+  });
+  const unsubscribeTimeline = engine.on("history:change", () => {
+    if (!replaying) {
+      groupedRange = null;
+      push({ kind: "timeline" });
+    }
+  });
+
+  function restoreRange(next: ClipRange) {
+    if (next.inPoint && next.outPoint) {
+      engine.setInOutRange(next.inPoint, next.outPoint);
+    } else {
+      engine.clearInOutPoints();
+      if (next.inPoint) {
+        engine.setInPoint(next.inPoint);
+      }
+      if (next.outPoint) {
+        engine.setOutPoint(next.outPoint);
+      }
+    }
+  }
+  function move(direction: "undo" | "redo") {
+    if (!(direction === "undo" ? snapshot.canUndo : snapshot.canRedo)) {
+      return;
+    }
+    const source = direction === "undo" ? past : future;
+    const destination = direction === "undo" ? future : past;
+    const edit = source.pop();
+    if (!edit) {
+      return;
+    }
+    groupedRange = null;
+    replaying = true;
+    try {
+      if (edit.kind === "range") {
+        restoreRange(direction === "undo" ? edit.before : edit.after);
+      } else if (direction === "undo") {
+        engine.undo();
+      } else {
+        engine.redo();
+      }
+      destination.push(edit);
+    } finally {
+      replaying = false;
+      range = readRange(engine);
+      notify();
+    }
+  }
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    undo: () => move("undo"),
+    redo: () => move("redo"),
+    beginRangeGesture: () => {
+      rangeGesture = true;
+      groupedRange = null;
+    },
+    endRangeGesture: () => {
+      rangeGesture = false;
+      groupedRange = null;
+    },
+    dispose: () => {
+      unsubscribeRange();
+      unsubscribeTimeline();
+      listeners.clear();
+    },
+  };
+}

--- a/apps/frontend/src/components/editor/editorShortcutCommands.ts
+++ b/apps/frontend/src/components/editor/editorShortcutCommands.ts
@@ -3,6 +3,8 @@ export const EDITOR_SMALL_SEEK_SECONDS = 5;
 export const DEFAULT_EDITOR_FRAME_STEP_SECONDS = 1 / 30;
 
 export type EditorShortcutCommand =
+  | "undo"
+  | "redo"
   | "toggle-play"
   | "mark-in"
   | "mark-out"
@@ -36,6 +38,14 @@ export function resolveEditorShortcutCommand({
   metaKey = false,
   pressedCodes,
 }: EditorShortcutEvent): EditorShortcutCommand | null {
+  if (!altKey && (ctrlKey || metaKey) && !repeat) {
+    if (code === "KeyZ") {
+      return shiftKey ? "redo" : "undo";
+    }
+    if (code === "KeyY" && ctrlKey && !metaKey && !shiftKey) {
+      return "redo";
+    }
+  }
   if (altKey || ctrlKey || metaKey) {
     return null;
   }

--- a/apps/frontend/src/components/editor/useEditorHistory.ts
+++ b/apps/frontend/src/components/editor/useEditorHistory.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+import type { TimelineEngine } from "@techsquidtv/canvas-timeline";
+import { createEditorHistory } from "@/components/editor/editorHistory";
+
+const emptyHistory = { canUndo: false, canRedo: false };
+const getEmptyHistory = () => emptyHistory;
+const unsubscribeEmptyHistory = () => {};
+const subscribeEmptyHistory = () => unsubscribeEmptyHistory;
+
+export function useEditorHistory(engine: TimelineEngine, ready: boolean) {
+  const [history, setHistory] = useState<ReturnType<
+    typeof createEditorHistory
+  > | null>(null);
+  useEffect(() => {
+    if (!ready) {
+      setHistory(null);
+      return;
+    }
+    const next = createEditorHistory(engine);
+    setHistory(next);
+    window.addEventListener("pointerdown", next.beginRangeGesture, {
+      capture: true,
+    });
+    window.addEventListener("pointerup", next.endRangeGesture, {
+      capture: true,
+    });
+    window.addEventListener("pointercancel", next.endRangeGesture, {
+      capture: true,
+    });
+    window.addEventListener("blur", next.endRangeGesture);
+    return () => {
+      next.dispose();
+      window.removeEventListener("pointerdown", next.beginRangeGesture, true);
+      window.removeEventListener("pointerup", next.endRangeGesture, true);
+      window.removeEventListener("pointercancel", next.endRangeGesture, true);
+      window.removeEventListener("blur", next.endRangeGesture);
+    };
+  }, [engine, ready]);
+  const state = useSyncExternalStore(
+    history?.subscribe ?? subscribeEmptyHistory,
+    history?.getSnapshot ?? getEmptyHistory,
+    getEmptyHistory,
+  );
+  return {
+    canUndo: ready && state.canUndo,
+    canRedo: ready && state.canRedo,
+    undo: () => {
+      if (ready) {
+        history?.undo();
+      }
+    },
+    redo: () => {
+      if (ready) {
+        history?.redo();
+      }
+    },
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
+++ b/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
@@ -5,6 +5,8 @@ import {
 } from "@/components/editor/editorShortcutCommands";
 
 interface UseEditorKeyboardShortcutsProperties {
+  undo?: () => void;
+  redo?: () => void;
   togglePlay: () => void;
   markIn?: () => void;
   markOut?: () => void;
@@ -22,6 +24,8 @@ interface UseEditorKeyboardShortcutsProperties {
 
 export function useEditorKeyboardShortcuts({
   togglePlay,
+  undo,
+  redo,
   markIn,
   markOut,
   jumpToIn,
@@ -41,6 +45,8 @@ export function useEditorKeyboardShortcuts({
 
   useEffect(() => {
     commandHandlersReference.current = {
+      undo,
+      redo,
       "toggle-play": togglePlay,
       "mark-in": markIn,
       "mark-out": markOut,
@@ -61,11 +67,10 @@ export function useEditorKeyboardShortcuts({
     const pressedCodes = new Set<string>();
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (isInteractiveKeyboardTarget(event.target) || isModalDialogOpen()) {
+      if (isEditorDialogOpen()) {
         return;
       }
 
-      pressedCodes.add(event.code);
       const command = resolveEditorShortcutCommand({
         code: event.code,
         repeat: event.repeat,
@@ -75,6 +80,15 @@ export function useEditorKeyboardShortcuts({
         metaKey: event.metaKey,
         pressedCodes,
       });
+      if (
+        isInteractiveKeyboardTarget(
+          event.target,
+          command === "undo" || command === "redo",
+        )
+      ) {
+        return;
+      }
+      pressedCodes.add(event.code);
       const handler = command
         ? commandHandlersReference.current[command]
         : undefined;
@@ -108,7 +122,10 @@ export function useEditorKeyboardShortcuts({
   }, []);
 }
 
-function isInteractiveKeyboardTarget(target: EventTarget | null) {
+function isInteractiveKeyboardTarget(
+  target: EventTarget | null,
+  historyCommand: boolean,
+) {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
@@ -117,21 +134,24 @@ function isInteractiveKeyboardTarget(target: EventTarget | null) {
     return true;
   }
 
-  return Boolean(
-    target.closest(
-      'input, textarea, select, button, [contenteditable="true"], [role="slider"], [role="dialog"], [role="alertdialog"], dialog',
-    ),
+  return (
+    (!historyCommand && Boolean(target.closest("button"))) ||
+    Boolean(
+      target.closest(
+        'input, textarea, select, [contenteditable="true"], [role="slider"], [role="dialog"], [role="alertdialog"], dialog',
+      ),
+    )
   );
 }
 
-function isModalDialogOpen() {
+function isEditorDialogOpen() {
   if (typeof document === "undefined") {
     return false;
   }
 
-  return Boolean(
-    document.querySelector(
-      '[role="dialog"][aria-modal="true"], [role="alertdialog"][aria-modal="true"], dialog[open]',
+  return [
+    ...document.querySelectorAll<HTMLElement>(
+      '[role="dialog"], [role="alertdialog"], dialog[open]',
     ),
-  );
+  ].some((dialog) => dialog.getClientRects().length > 0);
 }


### PR DESCRIPTION
Add visible Undo/Redo controls and keyboard shortcuts for range and subtitle edits, plus an editor shortcut reference on desktop and mobile. Range gestures undo as one action; playback and zoom do not enter edit history. Reuse Canvas Timeline document history for subtitle changes and keep range actions in chronological order.

Unify preview mute labels and block editor shortcuts in visible dialogs while preserving native text-field editing.

Validation: `pnpm preflight` (383 tests), frontend production build, four history regression tests, and desktop/mobile browser checks for keyboard undo, button redo, text-field/dialog isolation, and mobile layout.
