### PR TITLE
feat(frontend): recover saved editor drafts

### DIFF
--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -33,6 +33,12 @@ import {
   createEditorTimelineEngine,
   synchronizeEditorTimelineSession,
 } from "@/components/editor/editorTimelineEngine";
+import {
+  editorDraftIdentity,
+  editorDrafts,
+  type EditorDraft,
+} from "@/components/editor/editorDrafts";
+import { useEditorDraft } from "@/components/editor/useEditorDraft";
 import { EditorHeader } from "@/components/editor/EditorHeader";
 import { EditorPreview } from "@/components/editor/EditorPreview";
 import { EditorSubtitlePreview } from "@/components/editor/EditorSubtitlePreview";
@@ -74,12 +80,23 @@ interface Properties {
 }
 
 export default function EditorScreen({ session, onBack }: Properties) {
+  const [draftRevision, setDraftRevision] = useState(0);
   return (
-    <EditorSessionScreen key={session.id} session={session} onBack={onBack} />
+    <EditorSessionScreen
+      key={`${editorDraftIdentity(session)}:${draftRevision}`}
+      session={session}
+      onBack={onBack}
+      onReset={() => setDraftRevision((revision) => revision + 1)}
+    />
   );
 }
 
-function EditorSessionScreen({ session, onBack }: Properties) {
+function EditorSessionScreen({
+  session,
+  onBack,
+  onReset,
+}: Properties & { onReset: () => void }) {
+  const [initialDraft] = useState(() => editorDrafts.read(session));
   const [engine] = useState(() => createEditorTimelineEngine(session));
   const previousSessionReference = useRef(session);
 
@@ -95,7 +112,13 @@ function EditorSessionScreen({ session, onBack }: Properties) {
 
   return (
     <TimelineProvider engine={engine}>
-      <EditorScreenContent session={session} onBack={onBack} engine={engine} />
+      <EditorScreenContent
+        session={session}
+        onBack={onBack}
+        engine={engine}
+        initialDraft={initialDraft}
+        onReset={onReset}
+      />
     </TimelineProvider>
   );
 }
@@ -104,7 +127,13 @@ function EditorScreenContent({
   session,
   onBack,
   engine,
-}: Properties & { engine: TimelineEngine }) {
+  initialDraft,
+  onReset,
+}: Properties & {
+  engine: TimelineEngine;
+  initialDraft: EditorDraft | null;
+  onReset: () => void;
+}) {
   const { inPoint, outPoint, setInPoint, setOutPoint, clearInOutPoints } =
     useTimelinePlayback();
   const timelineMedia = useEditorTimelineMedia(session, engine);
@@ -122,6 +151,8 @@ function EditorScreenContent({
     subtitleEnabled,
     subtitleOutputEnabled,
     subtitleCuesReady,
+    importedSubtitleTrackKey,
+    subtitleTrackVisible,
     setSubtitleEnabled,
     subtitleStyleSettings,
     setSubtitleStyleSettings,
@@ -140,12 +171,30 @@ function EditorScreenContent({
     handleSelectNextSubtitle,
     handleSeekToSelectedSubtitle,
   } = useEditorSubtitles({
+    initialDraft,
     engine,
     session,
     startTime,
     endTime,
     duration,
     mediaReady: timelineMedia.metadataReady,
+  });
+  const draft = useEditorDraft({
+    engine,
+    session,
+    initialDraft,
+    onReset,
+    ready: timelineMedia.metadataReady && !subtitleLoading,
+    duration,
+    startTime,
+    endTime,
+    subtitles: {
+      selectedTrackKey: selectedSubtitleTrackKey,
+      importedTrackKey: importedSubtitleTrackKey,
+      enabled: subtitleEnabled,
+      visible: subtitleTrackVisible,
+      cues: subtitleCues,
+    },
   });
   const posterImageUrl = session.thumbUrl;
 
@@ -551,6 +600,28 @@ function EditorScreenContent({
         exportDisabledReason={headerExportDisabledReason}
         onExportClick={handleOpenExportDialog}
       />
+
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-editor-border bg-editor-panel px-3 py-2 text-xs text-muted-foreground">
+        <span role="status">
+          {draft.notice ?? "Drafts save on this device for 14 days."}
+        </span>
+        <button
+          type="button"
+          disabled={exporting}
+          onClick={() => {
+            if (
+              globalThis.confirm(
+                "Reset this draft? This removes the saved clip range and subtitle edits.",
+              )
+            ) {
+              draft.reset();
+            }
+          }}
+          className="rounded px-2 py-1 text-foreground hover:bg-editor-control-hover focus-visible:ring-2 focus-visible:ring-editor-accent"
+        >
+          Reset draft
+        </button>
+      </div>
 
       <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-2.5 sm:p-3 lg:overflow-hidden">
         {isDesktopLayout ? (

--- a/apps/frontend/src/components/editor/editorDrafts.test.ts
+++ b/apps/frontend/src/components/editor/editorDrafts.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  createEditorDraftStore,
+  editorDraftIdentity,
+  type EditorDraft,
+} from "@/components/editor/editorDrafts";
+import { buildLocalEditorSession, type EditorSession } from "@/lib/editorMedia";
+
+function session(name = "clip.mp4", size = 5, lastModified = 1): EditorSession {
+  const file = new File([new Uint8Array(size)], name, { lastModified });
+  return buildLocalEditorSession({
+    id: name,
+    title: name,
+    duration: 30,
+    source: {
+      kind: "file",
+      role: "direct",
+      label: "Local file",
+      file,
+      fileName: file.name,
+    },
+  });
+}
+function draftFor(media: EditorSession): EditorDraft {
+  return {
+    version: 1,
+    identity: editorDraftIdentity(media),
+    sessionId: media.id,
+    updatedAt: Date.now(),
+    duration: 30,
+    startTime: 5,
+    endTime: 20,
+    subtitles: {
+      selectedTrackKey: "stream:1",
+      importedTrackKey: "stream:1",
+      enabled: true,
+      visible: false,
+      cues: [
+        {
+          id: "1",
+          startTime: 6,
+          endTime: 8,
+          text: "Edited caption",
+          lines: ["Edited caption"],
+        },
+      ],
+    },
+  };
+}
+function storage() {
+  let raw: string | null = null;
+  return {
+    getItem: () => raw,
+    setItem: (_key: string, value: string) => {
+      raw = value;
+    },
+  };
+}
+
+void test("restores clip and subtitle edits from storage with a new local registry id", () => {
+  const media = session();
+  const saved = draftFor(media);
+  const persistent = storage();
+  assert.equal(createEditorDraftStore(() => persistent).save(saved), true);
+  const reopened = { ...media, id: "reopened-file" };
+  assert.deepEqual(
+    createEditorDraftStore(() => persistent).read(reopened),
+    saved,
+  );
+});
+
+void test("does not apply drafts to a different or modified file", () => {
+  const store = createEditorDraftStore(() => storage());
+  store.save(draftFor(session()));
+  assert.equal(store.read(session("different.mp4")), null);
+  assert.equal(store.read(session("clip.mp4", 6)), null);
+  assert.equal(store.read(session("clip.mp4", 5, 2)), null);
+});
+
+void test("does not retain provider media credentials in identity or draft storage", () => {
+  const local = session();
+  const media: EditorSession = {
+    ...local,
+    local: false,
+    source: { id: "source", name: "Plex", providerId: "plex" },
+    directSource: {
+      kind: "url",
+      role: "direct",
+      label: "Direct",
+      url: "https://example.com/file?token=private",
+    },
+  };
+  const persistent = storage();
+  createEditorDraftStore(() => persistent).save(draftFor(media));
+  assert.doesNotMatch(persistent.getItem() ?? "", /private|https|token/);
+});
+
+void test("ignores corrupt, malformed, expired, and unsupported draft records", () => {
+  const media = session();
+  for (const raw of [
+    "not json",
+    "null",
+    "{}",
+    "[null]",
+    JSON.stringify([{ ...draftFor(media), version: 2 }]),
+    JSON.stringify([{ ...draftFor(media), subtitles: { cues: [null] } }]),
+    JSON.stringify([
+      { ...draftFor(media), updatedAt: Date.now() - 15 * 86_400_000 },
+    ]),
+  ]) {
+    const persistent = { getItem: () => raw, setItem: () => {} };
+    assert.equal(createEditorDraftStore(() => persistent).read(media), null);
+  }
+});
+
+void test("keeps navigation recovery in memory when storage fails and allows reset", () => {
+  const store = createEditorDraftStore(() => {
+    throw new Error("Storage denied");
+  });
+  const media = session();
+  assert.equal(store.save(draftFor(media)), false);
+  assert.ok(store.read(media));
+  store.remove(media);
+  assert.equal(store.read(media), null);
+});
+
+void test("reset removes persisted drafts and limits retained drafts to twenty", () => {
+  const persistent = storage();
+  const store = createEditorDraftStore(() => persistent);
+  for (let index = 0; index < 22; index += 1) {
+    store.save(draftFor(session(`clip-${index}.mp4`)));
+  }
+  const records = JSON.parse(persistent.getItem() ?? "[]") as EditorDraft[];
+  assert.equal(records.length, 20);
+  const media = session("clip-21.mp4");
+  assert.equal(store.remove(media), true);
+  assert.equal(createEditorDraftStore(() => persistent).read(media), null);
+});
+
+void test("separates different media when a provider reuses its playback session id", () => {
+  const media = { ...session(), local: false };
+  const persistent = storage();
+  const store = createEditorDraftStore(() => persistent);
+  store.save(draftFor(media));
+  assert.equal(store.read({ ...media, title: "Next episode" }), null);
+});

--- a/apps/frontend/src/components/editor/editorDrafts.ts
+++ b/apps/frontend/src/components/editor/editorDrafts.ts
@@ -1,0 +1,207 @@
+import type { EditorSession } from "@/lib/editorMedia";
+import type { SubtitleCue } from "@/lib/subtitles/types";
+
+export interface EditorDraft {
+  version: 1;
+  identity: string;
+  sessionId: string;
+  updatedAt: number;
+  duration: number;
+  startTime: number;
+  endTime: number;
+  subtitles: {
+    selectedTrackKey: string;
+    importedTrackKey: string | null;
+    enabled: boolean;
+    visible: boolean;
+    cues: readonly SubtitleCue[];
+  };
+}
+
+type DraftStorage = Pick<Storage, "getItem" | "setItem">;
+const STORAGE_KEY = "cliparr.editor.drafts.v1";
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const MAX_STORAGE_BYTES = 1_500_000;
+
+export function editorDraftIdentity(session: EditorSession) {
+  const source = session.directSource ?? session.hlsSource;
+  if (session.local && source && source.kind !== "url") {
+    const size = source.kind === "file" ? source.file.size : source.size;
+    const lastModified =
+      source.kind === "file" ? source.file.lastModified : source.lastModified;
+    if (size !== undefined && lastModified !== undefined) {
+      return JSON.stringify(["file", source.fileName, size, lastModified]);
+    }
+  }
+  // Provider session IDs and local registry IDs identify media without retaining
+  // signed media URLs or provider credentials in draft storage.
+  return JSON.stringify([
+    session.source.providerId,
+    session.source.id,
+    session.exportMetadata?.ratingKey ?? session.id,
+    session.title,
+  ]);
+}
+
+function browserStorage(): DraftStorage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isCue(cue: Partial<SubtitleCue> | null): cue is SubtitleCue {
+  return Boolean(
+    cue &&
+    typeof cue === "object" &&
+    (cue.id === undefined || typeof cue.id === "string") &&
+    typeof cue.startTime === "number" &&
+    Number.isFinite(cue.startTime) &&
+    cue.startTime >= 0 &&
+    typeof cue.endTime === "number" &&
+    Number.isFinite(cue.endTime) &&
+    cue.endTime > cue.startTime &&
+    typeof cue.text === "string" &&
+    Array.isArray(cue.lines) &&
+    cue.lines.every((line: string) => typeof line === "string"),
+  );
+}
+
+function isDraft(value: Partial<EditorDraft> | null): value is EditorDraft {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const subtitles = value.subtitles;
+  return (
+    value.version === 1 &&
+    typeof value.identity === "string" &&
+    value.identity.length <= 4096 &&
+    typeof value.sessionId === "string" &&
+    typeof value.updatedAt === "number" &&
+    Number.isFinite(value.updatedAt) &&
+    typeof value.duration === "number" &&
+    Number.isFinite(value.duration) &&
+    value.duration > 0 &&
+    typeof value.startTime === "number" &&
+    Number.isFinite(value.startTime) &&
+    value.startTime >= 0 &&
+    typeof value.endTime === "number" &&
+    Number.isFinite(value.endTime) &&
+    value.endTime > value.startTime &&
+    value.endTime <= value.duration + 0.5 &&
+    Boolean(
+      subtitles &&
+      typeof subtitles === "object" &&
+      typeof subtitles.selectedTrackKey === "string" &&
+      (subtitles.importedTrackKey === null ||
+        typeof subtitles.importedTrackKey === "string") &&
+      typeof subtitles.enabled === "boolean" &&
+      typeof subtitles.visible === "boolean" &&
+      Array.isArray(subtitles.cues) &&
+      subtitles.cues.length <= 20_000 &&
+      subtitles.cues.every(isCue),
+    )
+  );
+}
+
+function mergeDrafts(
+  incoming: readonly EditorDraft[],
+  current: readonly EditorDraft[],
+) {
+  const merged = new Map<string, EditorDraft>();
+  for (const collection of [incoming, current]) {
+    for (const draft of collection) {
+      const previous = merged.get(draft.identity);
+      if (!previous || draft.updatedAt >= previous.updatedAt) {
+        merged.set(draft.identity, draft);
+      }
+    }
+  }
+  return [...merged.values()];
+}
+
+export function createEditorDraftStore(
+  getStorage: () => DraftStorage | null = browserStorage,
+) {
+  let drafts: EditorDraft[] = [];
+  const removed = new Set<string>();
+  const load = () => {
+    try {
+      const raw = getStorage()?.getItem(STORAGE_KEY);
+      if (raw && raw.length * 2 <= MAX_STORAGE_BYTES) {
+        const stored = JSON.parse(raw) as (Partial<EditorDraft> | null)[];
+        if (Array.isArray(stored)) {
+          drafts = mergeDrafts(stored.filter(isDraft), drafts).filter(
+            (draft) => !removed.has(draft.identity),
+          );
+        }
+      }
+    } catch {
+      /* Keep this tab's drafts when storage is unavailable or corrupt. */
+    }
+    drafts = drafts
+      .filter((draft) => Date.now() - draft.updatedAt <= MAX_AGE_MS)
+      .toSorted((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, 20);
+  };
+  const persist = () => {
+    try {
+      const storage = getStorage();
+      if (!storage) {
+        return false;
+      }
+      const retained = [...drafts];
+      while (
+        retained.length > 1 &&
+        JSON.stringify(retained).length * 2 > MAX_STORAGE_BYTES
+      ) {
+        retained.pop();
+      }
+      const serialized = JSON.stringify(retained);
+      if (serialized.length * 2 > MAX_STORAGE_BYTES) {
+        return false;
+      }
+      storage.setItem(STORAGE_KEY, serialized);
+      drafts = retained;
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  return {
+    read: (session: EditorSession) => {
+      load();
+      return (
+        drafts.find(
+          (draft) => draft.identity === editorDraftIdentity(session),
+        ) ?? null
+      );
+    },
+    hasSession: (sessionId: string) => {
+      load();
+      return drafts.some((draft) => draft.sessionId === sessionId);
+    },
+    save: (draft: EditorDraft) => {
+      if (!isDraft(draft)) {
+        return false;
+      }
+      load();
+      removed.delete(draft.identity);
+      drafts = [
+        draft,
+        ...drafts.filter((saved) => saved.identity !== draft.identity),
+      ].slice(0, 20);
+      return persist();
+    },
+    remove: (session: EditorSession) => {
+      load();
+      const identity = editorDraftIdentity(session);
+      removed.add(identity);
+      drafts = drafts.filter((draft) => draft.identity !== identity);
+      return persist();
+    },
+  };
+}
+
+export const editorDrafts = createEditorDraftStore();

--- a/apps/frontend/src/components/editor/useEditorDraft.ts
+++ b/apps/frontend/src/components/editor/useEditorDraft.ts
@@ -1,0 +1,138 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { fromSeconds, type TimelineEngine } from "@techsquidtv/canvas-timeline";
+import type { EditorSession } from "@/lib/editorMedia";
+import {
+  editorDraftIdentity,
+  editorDrafts,
+  type EditorDraft,
+} from "@/components/editor/editorDrafts";
+import {
+  EDITOR_SUBTITLE_TRACK_ID,
+  synchronizeEditorTimelineSubtitles,
+} from "@/components/editor/editorTimelineEngine";
+
+interface Properties {
+  engine: TimelineEngine;
+  session: EditorSession;
+  initialDraft: EditorDraft | null;
+  ready: boolean;
+  duration: number;
+  startTime: number;
+  endTime: number;
+  subtitles: EditorDraft["subtitles"];
+  onReset: () => void;
+}
+
+export function useEditorDraft({
+  engine,
+  session,
+  initialDraft,
+  ready,
+  duration,
+  startTime,
+  endTime,
+  subtitles,
+  onReset,
+}: Properties) {
+  const restored = useRef(false);
+  const discarded = useRef(false);
+  const latest = useRef<EditorDraft | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [restorationComplete, setRestorationComplete] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!ready || restored.current) {
+      return;
+    }
+    restored.current = true;
+    if (initialDraft) {
+      synchronizeEditorTimelineSubtitles(engine, {
+        cues: initialDraft.subtitles.cues,
+      });
+      engine.toggleTrackVisibility(
+        EDITOR_SUBTITLE_TRACK_ID,
+        initialDraft.subtitles.visible,
+      );
+      if (
+        initialDraft.startTime < duration &&
+        initialDraft.endTime <= duration + 0.5
+      ) {
+        engine.setInOutRange(
+          fromSeconds(initialDraft.startTime),
+          fromSeconds(Math.min(initialDraft.endTime, duration)),
+        );
+        engine.setTime(fromSeconds(initialDraft.startTime));
+        setNotice("Draft restored on this device.");
+      } else {
+        setNotice(
+          "Saved range is outside this video. Kept subtitle edits and started a new range.",
+        );
+      }
+    }
+    setRestorationComplete(true);
+  }, [duration, engine, initialDraft, ready]);
+
+  const selectedTrackKey = subtitles.selectedTrackKey;
+  const importedTrackKey = subtitles.importedTrackKey;
+  const enabled = subtitles.enabled;
+  const visible = subtitles.visible;
+  const cues = subtitles.cues;
+  useEffect(() => {
+    if (!ready || !restorationComplete || discarded.current) {
+      return;
+    }
+    const draft: EditorDraft = {
+      version: 1,
+      identity: editorDraftIdentity(session),
+      sessionId: session.id,
+      updatedAt: Date.now(),
+      duration,
+      startTime,
+      endTime,
+      subtitles: { selectedTrackKey, importedTrackKey, enabled, visible, cues },
+    };
+    latest.current = draft;
+    const timeout = setTimeout(() => {
+      if (!editorDrafts.save(draft)) {
+        setNotice(
+          "Draft kept in this tab. Browser storage is unavailable or full; reopening the page may lose edits.",
+        );
+      }
+    }, 250);
+    return () => clearTimeout(timeout);
+  }, [
+    cues,
+    duration,
+    enabled,
+    endTime,
+    importedTrackKey,
+    ready,
+    restorationComplete,
+    selectedTrackKey,
+    session,
+    startTime,
+    visible,
+  ]);
+
+  useEffect(() => {
+    const flush = () => {
+      if (!discarded.current && latest.current) {
+        editorDrafts.save(latest.current);
+      }
+    };
+    window.addEventListener("pagehide", flush);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      flush();
+    };
+  }, []);
+
+  return {
+    notice,
+    reset: () => {
+      discarded.current = true;
+      editorDrafts.remove(session);
+      onReset();
+    },
+  };
+}

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -7,6 +7,7 @@ import {
   useTimelineTracks,
   type TimelineEngine,
 } from "@techsquidtv/canvas-timeline";
+import type { EditorDraft } from "@/components/editor/editorDrafts";
 import type { EditorSession } from "@/lib/editorMedia";
 import {
   selectPreferredSubtitleTrack,
@@ -30,6 +31,7 @@ import {
 } from "@/components/editor/editorTimelineEngine";
 
 interface UseEditorSubtitlesProperties {
+  initialDraft?: EditorDraft | null;
   engine: TimelineEngine;
   session: EditorSession;
   startTime: number;
@@ -39,6 +41,7 @@ interface UseEditorSubtitlesProperties {
 }
 
 export function useEditorSubtitles({
+  initialDraft,
   engine,
   session,
   startTime,
@@ -64,6 +67,13 @@ export function useEditorSubtitles({
     [session.local, session.subtitleTracks],
   );
   const [initialSubtitleSelection] = useState(() => {
+    if (initialDraft) {
+      return {
+        key: initialDraft.subtitles.selectedTrackKey,
+        enabled: initialDraft.subtitles.enabled,
+        initialized: true,
+      };
+    }
     const track = selectPreferredSubtitleTrack(
       subtitleTracks,
       session.selectedSubtitleTrack,
@@ -82,7 +92,7 @@ export function useEditorSubtitles({
   );
   const [importedSubtitleTrackKey, setImportedSubtitleTrackKey] = useState<
     string | null
-  >(null);
+  >(initialDraft?.subtitles.importedTrackKey ?? null);
   const subtitleTrackSelectionInitializedReference = useRef(
     initialSubtitleSelection.initialized,
   );
@@ -358,6 +368,8 @@ export function useEditorSubtitles({
   }, [engine, selectedSubtitleCue]);
 
   return {
+    importedSubtitleTrackKey,
+    subtitleTrackVisible,
     subtitleTracks,
     selectedSubtitleTrack,
     selectedSubtitleTrackKey,

--- a/apps/frontend/src/components/editor/useEditorTimelineMedia.ts
+++ b/apps/frontend/src/components/editor/useEditorTimelineMedia.ts
@@ -499,6 +499,8 @@ export function useEditorTimelineMedia(
     pausePlayback,
     seekToTime,
     getPlaybackTime,
-    metadataReady: exportMedia !== null,
+    // Consumers may restore edits only after metadata has been applied to the
+    // engine; discovery alone still exposes the initial placeholder duration.
+    metadataReady: exportMedia !== null && details.exportMedia === exportMedia,
   };
 }

--- a/apps/frontend/src/routes/local.edit.$sessionId.tsx
+++ b/apps/frontend/src/routes/local.edit.$sessionId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useCanGoBack } from "@tanstack/react-router";
 import { FolderOpen, ShieldCheck, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/auth";
+import { editorDrafts } from "@/components/editor/editorDrafts";
 import EditorScreen from "@/components/editor/EditorScreen";
 import { LocalVideoOpenDialog } from "@/components/local-media/LocalVideoOpenDialog";
 import {
@@ -81,6 +82,12 @@ function LocalEditorRouteComponent() {
         <div className="space-y-2">
           <h1 className="text-lg font-semibold text-foreground">{title}</h1>
           <p className="text-sm leading-6 text-muted-foreground">{message}</p>
+          {editorDrafts.hasSession(sessionId) && (
+            <p className="text-sm leading-6 text-muted-foreground">
+              Your draft is saved on this device. Reopen the same unchanged file
+              to restore its clip range and subtitle edits.
+            </p>
+          )}
         </div>
         <div className="mt-5 flex flex-wrap items-center gap-3">
           {needsPermission && (


### PR DESCRIPTION
Save editor clip ranges, subtitle track choices, cue text/timing, and subtitle visibility across navigation and reload. Restore only after media metadata has reached the timeline, show a restored-draft notice, and offer Reset draft.

Local files match by filename, size, and modification time; browsers that cannot retain file access explain how to reopen the unchanged file. Provider drafts use source/media identity without storing signed media URLs. Storage retains up to 20 recent drafts for 14 days with a size limit, validates saved records, and reports unavailable storage while retaining navigation recovery in the current tab.

Validation: `pnpm preflight` (386 tests), frontend production build, seven storage regression tests, and browser checks covering immediate Back/Forward, reload/reselection, persistent reset, and editing/restoring provider captions without overwriting them from the original subtitle download. Provider responses were mocked.
