### PR TITLE
fix(frontend): simplify provider onboarding

### DIFF
--- a/apps/frontend/src/components/provider-connect/ProviderConnectFlow.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectFlow.tsx
@@ -3,9 +3,7 @@ import { ArrowRight, Check, ExternalLink, Server } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utilities";
 import {
-  ProviderBadge,
   ProviderConnectError,
-  ProviderOption,
   ProviderStatusMessage,
   providerPresentation,
 } from "@/components/provider-connect/ProviderConnectFlowSections";
@@ -133,16 +131,10 @@ export default function ProviderConnectFlow({
     }
 
     return (
-      <div className="flex h-full flex-col justify-between gap-6">
-        <div className="space-y-4">
-          <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            A new tab will open for sign-in.
-          </div>
-
-          <div className="rounded-2xl border border-border bg-card px-4 py-4 text-sm text-muted-foreground">
-            Add more sources later from Sources.
-          </div>
-        </div>
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">
+          A new tab will open for sign-in.
+        </p>
 
         <div className="space-y-4">
           <button
@@ -158,7 +150,7 @@ export default function ProviderConnectFlow({
           </button>
 
           <p className="text-center text-xs leading-6 text-muted-foreground">
-            You can switch providers any time.
+            Add more servers later from Sources.
           </p>
         </div>
       </div>
@@ -176,9 +168,7 @@ export default function ProviderConnectFlow({
       Boolean(developmentJellyfinUrl) &&
       serverUrl.trim() === developmentJellyfinUrl;
 
-    const formClasses = isScreen
-      ? "flex h-full flex-col justify-between gap-6"
-      : "space-y-3";
+    const formClasses = isScreen ? "flex flex-col gap-5" : "space-y-3";
 
     return (
       <form
@@ -267,7 +257,7 @@ export default function ProviderConnectFlow({
             </div>
           )}
 
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-4 @sm:grid-cols-2">
             <label className="block text-xs font-medium uppercase tracking-[var(--tracking-caps-lg)] text-muted-foreground">
               Username
               <input
@@ -384,15 +374,12 @@ export default function ProviderConnectFlow({
 
     return (
       <>
-        <div className="flex items-start gap-4">
-          {isScreen ? (
-            <ProviderBadge
-              providerId={provider.id}
-              name={provider.name}
-              selected={true}
-              large
-            />
-          ) : (
+        {isScreen ? (
+          <p className="text-sm leading-6 text-muted-foreground">
+            {providerDetails.summary}
+          </p>
+        ) : (
+          <div className="flex items-start gap-4">
             <div className="rounded-md border border-border bg-card p-2">
               <ProviderGlyph
                 providerId={provider.id}
@@ -401,31 +388,31 @@ export default function ProviderConnectFlow({
                 fallbackClassName="text-primary"
               />
             </div>
-          )}
-          <div>
-            <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
-              {providerDetails.eyebrow}
-            </p>
-            <h3
-              className={cn(
-                "mt-1 font-semibold tracking-tight text-foreground",
-                isScreen ? "text-2xl" : "text-base",
-              )}
-            >
-              {provider.name}
-            </h3>
-            <p
-              className={cn(
-                "mt-2 text-sm text-muted-foreground",
-                isScreen ? "leading-6" : "leading-5",
-              )}
-            >
-              {providerDetails.summary}
-            </p>
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
+                {providerDetails.eyebrow}
+              </p>
+              <h3
+                className={cn(
+                  "mt-1 font-semibold tracking-tight text-foreground",
+                  isScreen ? "text-2xl" : "text-base",
+                )}
+              >
+                {provider.name}
+              </h3>
+              <p
+                className={cn(
+                  "mt-2 text-sm text-muted-foreground",
+                  isScreen ? "leading-6" : "leading-5",
+                )}
+              >
+                {providerDetails.summary}
+              </p>
+            </div>
           </div>
-        </div>
+        )}
 
-        <div className={cn("mt-6", isScreen && "flex-1")}>
+        <div className="mt-4">
           {provider.auth === "pin"
             ? renderPinContent(provider)
             : renderCredentialsContent(provider)}
@@ -433,31 +420,6 @@ export default function ProviderConnectFlow({
 
         {renderAuthProgress(provider)}
       </>
-    );
-  }
-
-  function renderScreenSelectedProvider() {
-    if (!selectedProvider) {
-      return null;
-    }
-
-    const innerContent = renderSelectedProviderContent(selectedProvider);
-
-    return (
-      <div className="relative min-h-152 overflow-hidden rounded-3xl border border-border bg-background/80 shadow-xl">
-        <AnimatePresence mode="wait" initial={false}>
-          <motion.div
-            key={selectedProvider.id}
-            initial={{ opacity: 0, x: 16, scale: 0.985 }}
-            animate={{ opacity: 1, x: 0, scale: 1 }}
-            exit={{ opacity: 0, x: -16, scale: 0.985 }}
-            transition={{ duration: 0.22, ease: "easeOut" }}
-            className="absolute inset-0 flex flex-col overflow-y-auto overscroll-contain p-5 [scrollbar-gutter:stable] sm:p-6"
-          >
-            {innerContent}
-          </motion.div>
-        </AnimatePresence>
-      </div>
     );
   }
 
@@ -490,21 +452,10 @@ export default function ProviderConnectFlow({
       );
     }
 
-    if (isScreen) {
-      return (
-        <ProviderConnectScreenLayout
-          providers={providers}
-          selectedProvider={selectedProvider ?? undefined}
-          authenticating={authenticating}
-          authenticatingProviderId={providerId}
-          onSelectProvider={handleSelectProvider}
-          renderSelectedProvider={renderScreenSelectedProvider}
-        />
-      );
-    }
-
     return (
-      <ProviderConnectPanelLayout
+      <ProviderConnectTabsLayout
+        isScreen={isScreen}
+        authenticating={authenticating}
         providers={providers}
         selectedProviderId={selectedProvider?.id ?? providers[0]?.id ?? ""}
         onSelectProvider={handleSelectProvider}
@@ -524,29 +475,29 @@ export default function ProviderConnectFlow({
 
   return (
     <>
-      {error ? (
-        <ProviderConnectError error={error} isScreen={isScreen} />
-      ) : (
-        <div className="mb-5 min-h-19" />
-      )}
+      <ProviderConnectError error={error} isScreen={isScreen} />
       {renderContent()}
     </>
   );
 }
 
-interface ProviderConnectPanelLayoutProperties {
+interface ProviderConnectTabsLayoutProperties {
+  isScreen: boolean;
+  authenticating: boolean;
   providers: ProviderDefinition[];
   selectedProviderId: string;
   onSelectProvider: (providerId: string) => void;
   renderProviderContent: (provider: ProviderDefinition) => ReactNode;
 }
 
-function ProviderConnectPanelLayout({
+function ProviderConnectTabsLayout({
+  isScreen,
+  authenticating,
   providers,
   selectedProviderId,
   onSelectProvider,
   renderProviderContent,
-}: ProviderConnectPanelLayoutProperties) {
+}: ProviderConnectTabsLayoutProperties) {
   return (
     <Tabs
       value={selectedProviderId}
@@ -559,11 +510,9 @@ function ProviderConnectPanelLayout({
       }}
       className="space-y-3"
     >
-      <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-md)] text-muted-foreground">
-        Choose A Provider
-      </p>
-
       <TabsList
+        springIndicator
+        aria-label="Media provider"
         className="grid w-full"
         style={{
           gridTemplateColumns: `repeat(${providers.length}, minmax(0, 1fr))`,
@@ -573,7 +522,8 @@ function ProviderConnectPanelLayout({
           <TabsTab
             key={provider.id}
             value={provider.id}
-            className="min-w-0 px-2"
+            disabled={authenticating}
+            className="min-h-11 min-w-0 px-2"
           >
             <ProviderGlyph
               providerId={provider.id}
@@ -586,11 +536,21 @@ function ProviderConnectPanelLayout({
       </TabsList>
 
       <TabsPanels
-        mode="layout"
-        className="cliparr-editor-scrollbar h-source-provider-panel overflow-y-auto rounded-lg border border-border bg-background p-4"
+        mode="static"
+        className={cn(
+          "@container",
+          isScreen
+            ? "pt-2 sm:rounded-lg sm:border sm:border-border sm:bg-background sm:p-4"
+            : "cliparr-editor-scrollbar h-source-provider-panel overflow-y-auto rounded-lg border border-border bg-background p-4",
+        )}
       >
         {providers.map((provider) => (
-          <TabsPanel key={provider.id} value={provider.id} className="h-full">
+          <TabsPanel
+            animated={false}
+            key={provider.id}
+            value={provider.id}
+            className={isScreen ? undefined : "h-full"}
+          >
             {renderProviderContent(provider)}
           </TabsPanel>
         ))}
@@ -602,107 +562,19 @@ function ProviderConnectPanelLayout({
 function ProviderConnectScreenLoadingLayout() {
   return (
     <div
-      className="grid gap-6 lg:grid-cols-provider-connect"
+      className="space-y-3"
       aria-hidden="true"
       data-provider-connect-loading-layout
     >
-      <div className="space-y-3">
-        <div className="h-3 w-36 rounded bg-background" />
-        <div className="rounded-2xl border border-border bg-background px-4 py-4">
-          <div className="flex items-start gap-4">
-            <div className="h-11 w-11 rounded-2xl bg-card" />
-            <div className="min-w-0 flex-1 space-y-3">
-              <div className="h-3 w-28 rounded bg-card" />
-              <div className="h-5 w-32 rounded bg-card" />
-              <div className="h-4 w-full rounded bg-card" />
-            </div>
-          </div>
-        </div>
-        <div className="rounded-2xl border border-border bg-background px-4 py-4">
-          <div className="flex items-start gap-4">
-            <div className="h-11 w-11 rounded-2xl bg-card" />
-            <div className="min-w-0 flex-1 space-y-3">
-              <div className="h-3 w-32 rounded bg-card" />
-              <div className="h-5 w-36 rounded bg-card" />
-              <div className="h-4 w-full rounded bg-card" />
-            </div>
-          </div>
-        </div>
-      </div>
-
+      <div className="h-13 rounded-md border border-border bg-background" />
       <div
-        className="relative min-h-152 overflow-hidden rounded-3xl border border-border bg-background/80 shadow-xl"
+        className="space-y-4 pt-2 sm:rounded-lg sm:border sm:border-border sm:bg-background sm:p-4"
         data-provider-connect-selected-skeleton
       >
-        <div className="absolute inset-0 flex flex-col p-5 sm:p-6">
-          <div className="flex items-start gap-4">
-            <div className="h-12 w-12 rounded-2xl bg-card" />
-            <div className="min-w-0 flex-1 space-y-3">
-              <div className="h-3 w-32 rounded bg-card" />
-              <div className="h-7 w-40 rounded bg-card" />
-              <div className="h-4 w-full rounded bg-card" />
-              <div className="h-4 w-2/3 rounded bg-card" />
-            </div>
-          </div>
-          <div className="mt-6 flex flex-1 flex-col justify-between gap-6">
-            <div className="space-y-4">
-              <div className="h-18 rounded-2xl border border-border bg-card" />
-              <div className="h-18 rounded-2xl border border-border bg-card" />
-            </div>
-            <div className="space-y-4">
-              <div className="h-12 rounded-2xl bg-primary/10" />
-              <div className="mx-auto h-3 w-44 rounded bg-card" />
-            </div>
-          </div>
-        </div>
+        <div className="h-5 w-3/4 rounded bg-card" />
+        <div className="h-5 w-1/2 rounded bg-card" />
+        <div className="h-12 rounded-xl bg-primary/10" />
       </div>
-    </div>
-  );
-}
-
-interface ProviderConnectScreenLayoutProperties {
-  providers: ProviderDefinition[];
-  selectedProvider: ProviderDefinition | undefined;
-  authenticating: boolean;
-  authenticatingProviderId: string;
-  onSelectProvider: (providerId: string) => void;
-  renderSelectedProvider: () => ReactNode;
-}
-
-function ProviderConnectScreenLayout({
-  providers,
-  selectedProvider,
-  authenticating,
-  authenticatingProviderId,
-  onSelectProvider,
-  renderSelectedProvider,
-}: ProviderConnectScreenLayoutProperties) {
-  return (
-    <div className="grid gap-6 lg:grid-cols-provider-connect">
-      <motion.div
-        initial={{ opacity: 0, x: -12 }}
-        animate={{ opacity: 1, x: 0 }}
-        transition={{ duration: 0.24, ease: "easeOut" }}
-        className="space-y-3"
-      >
-        <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-3xl)] text-muted-foreground">
-          Choose A Provider
-        </p>
-
-        {providers.map((provider) => (
-          <ProviderOption
-            key={provider.id}
-            provider={provider}
-            selectedProvider={selectedProvider}
-            authenticating={authenticating}
-            authenticatingProviderId={authenticatingProviderId}
-            variant="screen"
-            onSelect={onSelectProvider}
-          />
-        ))}
-      </motion.div>
-
-      {renderSelectedProvider()}
     </div>
   );
 }

--- a/apps/frontend/src/components/provider-connect/ProviderConnectFlowSections.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectFlowSections.tsx
@@ -1,7 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import { cn } from "@/lib/utilities";
 import type { ProviderDefinition } from "@/providers/types";
-import { ProviderGlyph } from "@/components/providers/ProviderGlyph";
 
 export function providerPresentation(
   provider: ProviderDefinition,
@@ -35,37 +34,6 @@ export function providerPresentation(
   }
 }
 
-export function ProviderBadge({
-  providerId,
-  name,
-  selected,
-  large = false,
-  compact = false,
-}: {
-  providerId: string;
-  name: string;
-  selected: boolean;
-  large?: boolean;
-  compact?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        compact ? "rounded-md p-2" : "rounded-2xl p-3",
-        "transition-colors",
-        selected ? "bg-primary/15" : "bg-card",
-      )}
-    >
-      <ProviderGlyph
-        providerId={providerId}
-        providerName={name}
-        className={large ? "h-6 w-6" : "h-5 w-5"}
-        fallbackClassName={selected ? "text-primary" : "text-muted-foreground"}
-      />
-    </div>
-  );
-}
-
 export function ProviderConnectError({
   error,
   isScreen,
@@ -86,7 +54,7 @@ export function ProviderConnectError({
   }
 
   return (
-    <div className="mb-5 min-h-19">
+    <div className="mb-4">
       <AnimatePresence mode="wait">
         <motion.div
           key={error}
@@ -121,125 +89,5 @@ export function ProviderStatusMessage({
     >
       {children}
     </div>
-  );
-}
-
-export function ProviderOption({
-  provider,
-  selectedProvider,
-  authenticating,
-  authenticatingProviderId,
-  variant,
-  onSelect,
-}: {
-  provider: ProviderDefinition;
-  selectedProvider?: ProviderDefinition;
-  authenticating: boolean;
-  authenticatingProviderId: string;
-  variant: "panel" | "screen";
-  onSelect: (providerId: string) => void;
-}) {
-  const isScreen = variant === "screen";
-  const details = providerPresentation(provider, variant);
-  const isSelected = provider.id === selectedProvider?.id;
-  const isBusy = authenticating && authenticatingProviderId === provider.id;
-  let selectedClassName = "border-border bg-background hover:bg-accent/60";
-  if (isSelected) {
-    selectedClassName = isScreen
-      ? "border-primary/40 bg-primary/10 shadow-lg"
-      : "border-primary/30 bg-primary/10";
-  }
-
-  const commonProperties = {
-    type: "button" as const,
-    onClick: () => onSelect(provider.id),
-    disabled: authenticating && !isBusy,
-    className: cn(
-      "w-full border text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-      isScreen ? "rounded-2xl px-4 py-4" : "rounded-lg px-3 py-3",
-      selectedClassName,
-    ),
-  };
-
-  const content = (
-    <div className={cn("flex items-start", isScreen ? "gap-4" : "gap-3")}>
-      <ProviderBadge
-        providerId={provider.id}
-        name={provider.name}
-        selected={isSelected}
-        compact={!isScreen}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-muted-foreground">
-              {details.eyebrow}
-            </p>
-            <h2
-              className={cn(
-                "mt-1 font-semibold text-foreground",
-                isScreen ? "text-lg" : "text-sm",
-              )}
-            >
-              {provider.name}
-            </h2>
-          </div>
-          {isScreen ? (
-            <span
-              aria-hidden={!isSelected}
-              className={cn(
-                "rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-ui-label font-medium uppercase tracking-[var(--tracking-caps-lg)] text-primary",
-                !isSelected && "invisible",
-              )}
-            >
-              Selected
-            </span>
-          ) : (
-            <span
-              aria-hidden={!isSelected}
-              className={cn(
-                "rounded-md border border-primary/20 bg-primary/10 px-2 py-1 text-ui-micro font-semibold uppercase tracking-[var(--tracking-caps-md)] text-primary",
-                !isSelected && "invisible",
-              )}
-            >
-              Selected
-            </span>
-          )}
-        </div>
-        <p
-          className={cn(
-            "mt-2 text-sm text-muted-foreground",
-            isScreen ? "leading-6" : "leading-5",
-          )}
-        >
-          {details.summary}
-        </p>
-        <p
-          aria-hidden={!isBusy}
-          className={cn(
-            "mt-3 h-4 text-xs font-medium uppercase tracking-[var(--tracking-caps-xl)] text-primary",
-            !isBusy && "invisible",
-          )}
-        >
-          In progress
-        </p>
-      </div>
-    </div>
-  );
-
-  if (!isScreen) {
-    return <button {...commonProperties}>{content}</button>;
-  }
-
-  return (
-    <motion.button
-      layout
-      whileHover={authenticating && !isBusy ? undefined : { y: -2 }}
-      whileTap={authenticating && !isBusy ? undefined : { scale: 0.995 }}
-      transition={{ duration: 0.16, ease: "easeOut" }}
-      {...commonProperties}
-    >
-      {content}
-    </motion.button>
   );
 }

--- a/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
+++ b/apps/frontend/src/components/provider-connect/ProviderConnectScreen.tsx
@@ -13,15 +13,15 @@ export default function ProviderConnectScreen({
   onOpenLocalVideo,
 }: Properties) {
   return (
-    <div className="flex min-h-screen items-start justify-center bg-background p-4 pt-6 text-foreground sm:items-center">
-      <div className="relative w-full max-w-5xl overflow-hidden rounded-4xl border border-border bg-card text-card-foreground shadow-2xl">
+    <div className="flex min-h-screen items-start justify-center bg-background text-foreground sm:p-4 sm:pt-12">
+      <div className="relative w-full max-w-2xl overflow-hidden text-card-foreground sm:rounded-4xl sm:border sm:border-border sm:bg-card sm:shadow-2xl">
         <div className="pointer-events-none absolute inset-0">
           <div className="absolute inset-x-0 top-0 h-40 bg-linear-to-b from-primary/10 via-secondary/5 to-transparent" />
           <div className="absolute -left-10 top-24 h-40 w-40 rounded-full bg-secondary/10 blur-3xl" />
           <div className="absolute -right-10 top-16 h-44 w-44 rounded-full bg-primary/10 blur-3xl" />
         </div>
 
-        <div className="relative border-b border-border px-6 py-8 sm:px-8">
+        <div className="relative border-b border-border px-5 py-6 sm:px-8 sm:py-8">
           <div className="mb-5 flex items-center justify-center">
             <img
               src="/logo-light.svg"
@@ -40,31 +40,28 @@ export default function ProviderConnectScreen({
           </p>
         </div>
 
-        <div className="relative grid gap-6 px-6 py-6 sm:px-8 lg:grid-cols-2">
-          <section className="rounded-2xl border border-border bg-background/60 p-5">
-            <FolderOpen
-              className="mb-3 h-6 w-6 text-primary"
-              aria-hidden="true"
-            />
-            <h2 className="text-lg font-semibold">Open a file</h2>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Choose a video on this device and start trimming. Local files need
-              no account or provider connection.
-            </p>
+        <div className="relative space-y-6 px-5 py-6 sm:px-8 sm:py-5">
+          <section className="flex flex-wrap items-center justify-between gap-4 sm:rounded-2xl sm:border sm:border-border sm:bg-background/60 sm:p-5">
+            <div className="min-w-0 flex-1 basis-56">
+              <h2 className="text-lg font-semibold">Open a video</h2>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                Choose a file on this device. No account needed.
+              </p>
+            </div>
             <button
               type="button"
               onClick={onOpenLocalVideo}
-              className={`${primaryButtonClasses} mt-5`}
+              className={`${primaryButtonClasses} min-h-11 shrink-0`}
             >
               <FolderOpen className="h-4 w-4" />
               Open Video
             </button>
           </section>
-          <section className="min-w-0 rounded-2xl border border-border bg-background/60 p-5">
-            <h2 className="text-lg font-semibold">Connect a provider</h2>
+          <section className="min-w-0 border-t border-border pt-6 sm:rounded-2xl sm:border sm:bg-background/60 sm:p-5">
+            <h2 className="text-lg font-semibold">Connect Plex or Jellyfin</h2>
             <p className="mt-2 mb-5 text-sm leading-6 text-muted-foreground">
-              Connect Plex or Jellyfin, then play a video there to find it in
-              Cliparr and create a clip.
+              Connect your server, then play a video in Plex or Jellyfin to find
+              it here and start clipping.
             </p>
             <ProviderConnectFlow variant="screen" onConnected={onConnected} />
           </section>

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -1,5 +1,10 @@
 import { Tabs as BaseTabs } from "@base-ui/react/tabs";
-import { motion, type HTMLMotionProps, type Transition } from "motion/react";
+import {
+  motion,
+  useReducedMotion,
+  type HTMLMotionProps,
+  type Transition,
+} from "motion/react";
 import * as React from "react";
 import { cn } from "@/lib/utilities";
 
@@ -10,6 +15,7 @@ type TabsListProperties = Omit<
 > & {
   className?: string;
   indicatorClassName?: string;
+  springIndicator?: boolean;
 };
 type TabsTabProperties = Omit<
   React.ComponentProps<typeof BaseTabs.Tab>,
@@ -22,7 +28,7 @@ type TabsPanelsProperties = Omit<
   "children" | "transition"
 > & {
   children: React.ReactNode;
-  mode?: "auto-height" | "layout";
+  mode?: "auto-height" | "layout" | "static";
   transition?: Transition;
 };
 type TabsPanelProperties = Omit<
@@ -31,7 +37,19 @@ type TabsPanelProperties = Omit<
 > & {
   className?: string;
   transition?: Transition;
+  animated?: boolean;
 };
+
+const SpringIndicatorContext = React.createContext<{
+  id: string;
+  className?: string;
+} | null>(null);
+const indicatorTransition = {
+  type: "spring",
+  stiffness: 170,
+  damping: 24,
+  mass: 1.2,
+} as const;
 
 const tabsPanelsTransition = {
   type: "spring",
@@ -55,34 +73,51 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsRootProperties>(function Tabs(
 
 const TabsList = React.forwardRef<HTMLDivElement, TabsListProperties>(
   function TabsList(
-    { className, indicatorClassName, children, ...props },
+    {
+      className,
+      indicatorClassName,
+      springIndicator = false,
+      children,
+      ...props
+    },
     ref,
   ) {
+    const id = React.useId();
+    const indicator = React.useMemo(
+      () => (springIndicator ? { id, className: indicatorClassName } : null),
+      [id, indicatorClassName, springIndicator],
+    );
     return (
-      <BaseTabs.List
-        ref={ref}
-        className={cn(
-          "relative isolate inline-flex overflow-hidden rounded-md border border-border bg-background p-1",
-          className,
-        )}
-        {...props}
-      >
-        <BaseTabs.Indicator
-          renderBeforeHydration
+      <SpringIndicatorContext.Provider value={indicator}>
+        <BaseTabs.List
+          ref={ref}
           className={cn(
-            "absolute z-0 rounded-[var(--radius-control)] bg-primary transition-[top,left,width,height] duration-200 ease-out",
-            "top-[var(--active-tab-top)] left-[var(--active-tab-left)] h-[var(--active-tab-height)] w-[var(--active-tab-width)]",
-            indicatorClassName,
+            "relative isolate inline-flex overflow-hidden rounded-md border border-border bg-background p-1",
+            className,
           )}
-        />
-        {children}
-      </BaseTabs.List>
+          {...props}
+        >
+          {!springIndicator && (
+            <BaseTabs.Indicator
+              renderBeforeHydration
+              className={cn(
+                "absolute z-0 rounded-[var(--radius-control)] bg-primary transition-[top,left,width,height] duration-200 ease-out",
+                "top-[var(--active-tab-top)] left-[var(--active-tab-left)] h-[var(--active-tab-height)] w-[var(--active-tab-width)]",
+                indicatorClassName,
+              )}
+            />
+          )}
+          {children}
+        </BaseTabs.List>
+      </SpringIndicatorContext.Provider>
     );
   },
 );
 
 const TabsTab = React.forwardRef<HTMLElement, TabsTabProperties>(
-  function TabsTab({ className, ...props }, ref) {
+  function TabsTab({ className, children, render, ...props }, ref) {
+    const indicator = React.useContext(SpringIndicatorContext);
+    const reducedMotion = useReducedMotion();
     return (
       <BaseTabs.Tab
         ref={ref}
@@ -90,8 +125,35 @@ const TabsTab = React.forwardRef<HTMLElement, TabsTabProperties>(
           "relative z-10 inline-flex h-8 items-center justify-center gap-2 rounded-[var(--radius-control)] px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none data-[active]:text-primary-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-55",
           className,
         )}
+        render={
+          indicator
+            ? (tabProperties, state) => (
+                <button {...tabProperties}>
+                  {state.active && (
+                    <motion.span
+                      aria-hidden="true"
+                      layoutId={reducedMotion ? undefined : indicator.id}
+                      initial={false}
+                      transition={
+                        reducedMotion ? { duration: 0 } : indicatorTransition
+                      }
+                      className={cn(
+                        "pointer-events-none absolute inset-0 rounded-[var(--radius-control)] bg-primary",
+                        indicator.className,
+                      )}
+                    />
+                  )}
+                  <span className="relative z-10 inline-flex min-w-0 items-center justify-center gap-2">
+                    {children}
+                  </span>
+                </button>
+              )
+            : render
+        }
         {...props}
-      />
+      >
+        {children}
+      </BaseTabs.Tab>
     );
   },
 );
@@ -130,6 +192,14 @@ const TabsPanels = React.forwardRef<HTMLDivElement, TabsPanelsProperties>(
       return () => observer.disconnect();
     }, [children, mode]);
 
+    if (mode === "static") {
+      return (
+        <motion.div ref={ref} className={className} {...props}>
+          {children}
+        </motion.div>
+      );
+    }
+
     if (mode === "layout") {
       return (
         <motion.div
@@ -160,9 +230,19 @@ const TabsPanels = React.forwardRef<HTMLDivElement, TabsPanelsProperties>(
 
 const TabsPanel = React.forwardRef<HTMLDivElement, TabsPanelProperties>(
   function TabsPanel(
-    { className, transition = tabsPanelTransition, ...props },
+    { className, transition = tabsPanelTransition, animated = true, ...props },
     ref,
   ) {
+    const reducedMotion = useReducedMotion();
+    if (!animated || reducedMotion) {
+      return (
+        <BaseTabs.Panel
+          ref={ref}
+          className={cn("outline-none", className)}
+          {...props}
+        />
+      );
+    }
     return (
       <BaseTabs.Panel
         ref={ref}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -463,10 +463,6 @@
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
-@utility grid-cols-provider-connect {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.12fr);
-}
-
 @utility grid-cols-editor-export {
   grid-template-columns:
     minmax(0, 1fr)


### PR DESCRIPTION
The onboarding page squeezed provider selection and login into nested desktop columns, causing overlapping badges, narrow credential fields, and oversized empty cards. Replace that layout with a compact local-file section and full-width provider tabs, and flatten mobile sections so forms use the available width.

Use an opt-in spring selection indicator while keeping provider panels static. Anchor the page so changing providers does not move the tabs, retain Base UI keyboard behavior, and respect reduced-motion preferences. Remove obsolete provider cards and layout styles.

Validation: full `pnpm preflight` (396 tests), frontend build, and live desktop/mobile browser checks for both providers, field widths and overflow, keyboard activation, and the local-file dialog.
