### PR TITLE
feat(frontend): edit clip ranges through the media track

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 - **Instant session discovery**: Automatically loads currently playing media from connected <a href="/docs/providers">Plex and Jellyfin providers</a>.
 - **Open local videos**: Open a <a href="/docs/local-videos">local file or direct media URL</a> before or after connecting a provider.
-- **Intuitive timeline editor**: Familiar editing controls for choosing the exact clip range.
+- **Intuitive timeline editor**: Drag the media block to choose your clip, trim either edge, and zoom into subtitle timing across the full video.
 - **Browser transcoding**: Video <a href="/docs/export-settings">export settings</a> are powered by <a href="https://mediabunny.dev/" target="_blank" rel="noreferrer">Mediabunny</a>. GIFs are encoded with <a href="https://github.com/KyleTryon/gifenc" target="_blank" rel="noreferrer">gifenc</a>.
 - **Metadata included**: Video exports can include season, episode, and timing metadata from your source.
 - **Subtitle burn-in**: Burn in <a href="/docs/subtitle-burn-in">supported subtitles</a> with customizable styling and local font support in Chromium.

--- a/apps/frontend/src/components/editor/EditorMediaRange.tsx
+++ b/apps/frontend/src/components/editor/EditorMediaRange.tsx
@@ -1,13 +1,18 @@
 import {
   RangeScrollbar,
   Timeline,
+  fromSeconds,
   useTimelineInOutRangeControl,
   useTimelinePlayback,
   useTimelineScrollLeft,
   useTimelineTrack,
   useTimelineZoomScale,
+  type TimelineEngine,
 } from "@techsquidtv/canvas-timeline";
-import { EDITOR_MEDIA_RANGE_INSET } from "@/components/editor/EditorMediaRangeCanvas";
+import {
+  EDITOR_MEDIA_RANGE_HANDLE_WIDTH,
+  EDITOR_MEDIA_RANGE_INSET,
+} from "@/components/editor/EditorMediaRangeCanvas";
 import { EDITOR_MEDIA_TRACK_ID } from "@/components/editor/editorTimelineEngine";
 import {
   formatTime,
@@ -17,7 +22,7 @@ import {
 // The source clip stays full-length for preview and source timestamp mapping.
 // Its visible row represents the export range, using the same In/Out state as
 // time fields, shortcuts, drafts, and history rather than editing source media.
-export function EditorMediaRange() {
+export function EditorMediaRange({ engine }: { engine: TimelineEngine }) {
   const { setPlayheadTime } = useTimelinePlayback();
   const { rect } = useTimelineTrack(EDITOR_MEDIA_TRACK_ID);
   const scrollLeft = useTimelineScrollLeft();
@@ -53,17 +58,18 @@ export function EditorMediaRange() {
             : formatTime(value)
         }
         onValueChange={({ start, end }, details) => {
+          // Native drags retain the callback from pointerdown. Apply the whole
+          // range atomically so returning to the gesture's start still updates.
+          engine.setInOutRange(fromSeconds(start), fromSeconds(end));
           if (
             details.reason === "thumb-keyboard" ||
             details.reason === "handle-keyboard"
           ) {
-            range.commit([start, end]);
-          } else {
-            range.setValue([start, end]);
+            engine.settle();
           }
         }}
-        onPointerUp={() => range.commit()}
-        onPointerCancel={() => range.commit()}
+        onPointerUp={() => engine.settle()}
+        onPointerCancel={() => engine.settle()}
         style={{
           top: EDITOR_MEDIA_RANGE_INSET,
           height: rect.height - EDITOR_MEDIA_RANGE_INSET * 2,
@@ -78,12 +84,14 @@ export function EditorMediaRange() {
         >
           <RangeScrollbar.Handle
             side="start"
+            style={{ width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)` }}
             role="slider"
             aria-label="Clip start"
             title="Trim clip start"
           />
           <RangeScrollbar.Handle
             side="end"
+            style={{ width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)` }}
             role="slider"
             aria-label="Clip end"
             title="Trim clip end"

--- a/apps/frontend/src/components/editor/EditorMediaRange.tsx
+++ b/apps/frontend/src/components/editor/EditorMediaRange.tsx
@@ -1,0 +1,95 @@
+import {
+  RangeScrollbar,
+  Timeline,
+  useTimelineInOutRangeControl,
+  useTimelinePlayback,
+  useTimelineScrollLeft,
+  useTimelineTrack,
+  useTimelineZoomScale,
+} from "@techsquidtv/canvas-timeline";
+import { EDITOR_MEDIA_RANGE_INSET } from "@/components/editor/EditorMediaRangeCanvas";
+import { EDITOR_MEDIA_TRACK_ID } from "@/components/editor/editorTimelineEngine";
+import {
+  formatTime,
+  MIN_CLIP_SECONDS,
+} from "@/components/editor/editorUtilities";
+
+// The source clip stays full-length for preview and source timestamp mapping.
+// Its visible row represents the export range, using the same In/Out state as
+// time fields, shortcuts, drafts, and history rather than editing source media.
+export function EditorMediaRange() {
+  const { setPlayheadTime } = useTimelinePlayback();
+  const { rect } = useTimelineTrack(EDITOR_MEDIA_TRACK_ID);
+  const scrollLeft = useTimelineScrollLeft();
+  const zoomScale = useTimelineZoomScale();
+  const range = useTimelineInOutRangeControl();
+  const [start, end] = range.value;
+
+  if (!rect) {
+    return null;
+  }
+
+  return (
+    <div
+      className="editor-media-range-row"
+      style={{ top: rect.y, height: rect.height }}
+    >
+      <Timeline.PlayheadArea
+        className="editor-media-range-scrub"
+        title="Scrub source media"
+        onDoubleClick={setPlayheadTime}
+      />
+      <RangeScrollbar.Root
+        className="editor-media-range"
+        min={range.min}
+        max={range.max}
+        minSpan={MIN_CLIP_SECONDS}
+        value={{ start, end }}
+        keyboardStep={range.step}
+        keyboardPageStep={1}
+        getAriaValueText={(value, details) =>
+          details.part === "thumb"
+            ? `${formatTime(start)} to ${formatTime(end)}, duration ${formatTime(end - start)}`
+            : formatTime(value)
+        }
+        onValueChange={({ start, end }, details) => {
+          if (
+            details.reason === "thumb-keyboard" ||
+            details.reason === "handle-keyboard"
+          ) {
+            range.commit([start, end]);
+          } else {
+            range.setValue([start, end]);
+          }
+        }}
+        onPointerUp={() => range.commit()}
+        onPointerCancel={() => range.commit()}
+        style={{
+          top: EDITOR_MEDIA_RANGE_INSET,
+          height: rect.height - EDITOR_MEDIA_RANGE_INSET * 2,
+          width: range.max * zoomScale,
+          transform: `translateX(${-scrollLeft}px)`,
+        }}
+      >
+        <RangeScrollbar.Thumb
+          role="slider"
+          aria-label="Move clip selection"
+          title="Drag to move selection; drag either edge to trim"
+        >
+          <RangeScrollbar.Handle
+            side="start"
+            role="slider"
+            aria-label="Clip start"
+            title="Trim clip start"
+          />
+          <RangeScrollbar.Handle
+            side="end"
+            role="slider"
+            aria-label="Clip end"
+            title="Trim clip end"
+          />
+        </RangeScrollbar.Thumb>
+      </RangeScrollbar.Root>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/editor/EditorMediaRangeCanvas.tsx
+++ b/apps/frontend/src/components/editor/EditorMediaRangeCanvas.tsx
@@ -9,6 +9,7 @@ import { useCallback, useRef } from "react";
 import { EDITOR_MEDIA_TRACK_ID } from "@/components/editor/editorTimelineEngine";
 
 export const EDITOR_MEDIA_RANGE_INSET = 4;
+export const EDITOR_MEDIA_RANGE_HANDLE_WIDTH = 12;
 
 export function EditorMediaRangeCanvas() {
   const { rect, track } = useTimelineTrack(EDITOR_MEDIA_TRACK_ID);
@@ -63,7 +64,10 @@ export function EditorMediaRangeCanvas() {
         ctx.stroke();
         ctx.clip();
 
-        const handleWidth = Math.min(12, selectionWidth / 4);
+        const handleWidth = Math.min(
+          EDITOR_MEDIA_RANGE_HANDLE_WIDTH,
+          selectionWidth / 4,
+        );
         ctx.fillStyle = theme.colors.clip.borderSelected;
         ctx.globalAlpha = 0.25;
         ctx.fillRect(x, y, handleWidth, selectionHeight);

--- a/apps/frontend/src/components/editor/EditorMediaRangeCanvas.tsx
+++ b/apps/frontend/src/components/editor/EditorMediaRangeCanvas.tsx
@@ -1,0 +1,104 @@
+import {
+  TimelineCanvasLayer,
+  resolveTimelineRendererThemeFromElement,
+  toSeconds,
+  useTimelineTrack,
+  type TimelineRendererTheme,
+} from "@techsquidtv/canvas-timeline";
+import { useCallback, useRef } from "react";
+import { EDITOR_MEDIA_TRACK_ID } from "@/components/editor/editorTimelineEngine";
+
+export const EDITOR_MEDIA_RANGE_INSET = 4;
+
+export function EditorMediaRangeCanvas() {
+  const { rect, track } = useTimelineTrack(EDITOR_MEDIA_TRACK_ID);
+  const themeReference = useRef<TimelineRendererTheme | null>(null);
+  const connectCanvas = useCallback((canvas: HTMLCanvasElement | null) => {
+    // Resolve the same CSS theme as CanvasRenderer once, outside the draw loop.
+    themeReference.current = canvas
+      ? resolveTimelineRendererThemeFromElement(canvas)
+      : null;
+  }, []);
+
+  return (
+    <TimelineCanvasLayer
+      ref={connectCanvas}
+      aria-hidden="true"
+      draw={(context) => {
+        const { ctx, state, width, height } = context;
+        const theme = themeReference.current;
+        if (!theme || !rect || !state.duration) {
+          return;
+        }
+
+        const top = Math.max(theme.metrics.rulerHeight, rect.y);
+        const bottom = Math.min(height, rect.y + rect.height);
+        if (bottom <= top) {
+          return;
+        }
+
+        // Replace only the source row's canvas painting. Its full-length clip
+        // remains available to the media adapter, including outside the range.
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(0, top, width, bottom - top);
+        ctx.clip();
+        ctx.fillStyle = theme.colors.background;
+        ctx.fillRect(0, top, width, bottom - top);
+        ctx.fillStyle = theme.colors.track.divider;
+        ctx.fillRect(0, rect.y + rect.height - 1, width, 1);
+
+        const start = state.inPoint ? toSeconds(state.inPoint) : 0;
+        const end = toSeconds(state.outPoint ?? state.duration);
+        const x = start * state.zoomScale - state.scrollLeft;
+        const selectionWidth = (end - start) * state.zoomScale;
+        const y = rect.y + EDITOR_MEDIA_RANGE_INSET;
+        const selectionHeight = rect.height - EDITOR_MEDIA_RANGE_INSET * 2;
+        ctx.beginPath();
+        ctx.roundRect(x, y, selectionWidth, selectionHeight, 4);
+        ctx.fillStyle = theme.colors.clip.bgSelected;
+        ctx.fill();
+        ctx.strokeStyle = theme.colors.clip.borderSelected;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.clip();
+
+        const handleWidth = Math.min(12, selectionWidth / 4);
+        ctx.fillStyle = theme.colors.clip.borderSelected;
+        ctx.globalAlpha = 0.25;
+        ctx.fillRect(x, y, handleWidth, selectionHeight);
+        ctx.fillRect(
+          x + selectionWidth - handleWidth,
+          y,
+          handleWidth,
+          selectionHeight,
+        );
+        ctx.globalAlpha = 1;
+        for (const handleX of [
+          x + handleWidth / 2,
+          x + selectionWidth - handleWidth / 2,
+        ]) {
+          ctx.fillRect(handleX - 1, y + (selectionHeight - 14) / 2, 2, 14);
+        }
+
+        ctx.beginPath();
+        ctx.rect(
+          x + handleWidth,
+          y,
+          Math.max(0, selectionWidth - handleWidth * 2),
+          selectionHeight,
+        );
+        ctx.clip();
+        ctx.fillStyle = theme.colors.clip.text;
+        ctx.font = theme.fonts.clip;
+        ctx.textBaseline = "middle";
+        ctx.fillText(
+          track?.clips[0]?.label ?? "",
+          Math.max(0, x) + 18,
+          y + selectionHeight / 2,
+        );
+        ctx.restore();
+      }}
+    />
+  );
+}

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -41,6 +41,10 @@ import {
 } from "@/components/editor/editorDrafts";
 import { useEditorDraft } from "@/components/editor/useEditorDraft";
 import { useEditorHistory } from "@/components/editor/useEditorHistory";
+import {
+  EDITOR_MAX_ZOOM_SCALE,
+  zoomEditorTimeline,
+} from "@/components/editor/editorTimelineZoom";
 import { EditorEditingTools } from "@/components/editor/EditorEditingTools";
 import { EditorHeader } from "@/components/editor/EditorHeader";
 import { EditorPreview } from "@/components/editor/EditorPreview";
@@ -326,22 +330,31 @@ function EditorScreenContent({
     }
     const padding = Math.min(24, viewportWidth / 4);
     const scale = Math.min(
-      1000,
+      EDITOR_MAX_ZOOM_SCALE,
       (viewportWidth - padding * 2) / (endTime - startTime),
     );
     setZoomScale(scale);
     setScrollLeft(Math.max(0, startTime * scale - padding));
   };
-  const zoomControl = useTimelineZoomControl({ min: 10, max: 1000 });
+  const zoomControl = useTimelineZoomControl({
+    min: 0,
+    max: EDITOR_MAX_ZOOM_SCALE,
+  });
   const hasDuration = timelineMedia.metadataReady && duration > 0;
   const canZoomOut = zoomControl.value > zoomControl.min;
   const canZoomIn = zoomControl.value < zoomControl.max;
   const handleTimelineZoomOut = useCallback(() => {
-    zoomControl.commit(Math.max(zoomControl.min, zoomControl.value / 1.25));
-  }, [zoomControl]);
+    zoomEditorTimeline(
+      engine,
+      Math.max(zoomControl.min, zoomControl.value / 1.25),
+    );
+  }, [engine, zoomControl]);
   const handleTimelineZoomIn = useCallback(() => {
-    zoomControl.commit(Math.min(zoomControl.max, zoomControl.value * 1.25));
-  }, [zoomControl]);
+    zoomEditorTimeline(
+      engine,
+      Math.min(zoomControl.max, zoomControl.value * 1.25),
+    );
+  }, [engine, zoomControl]);
   const handlePreviewTimeCommit = useCallback(
     (nextTime: number) => {
       if (!duration || duration <= 0) {

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -552,7 +552,7 @@ function EditorScreenContent({
     />
   );
   const editorTimeline = hasDuration ? (
-    <EditorTimeline muted={muted} onMutedChange={setMuted} />
+    <EditorTimeline engine={engine} muted={muted} onMutedChange={setMuted} />
   ) : null;
   const timelinePane = (
     <EditorTimelinePane

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -9,6 +9,9 @@ import {
 } from "@techsquidtv/canvas-timeline";
 import { Eye, EyeOff, Volume2, VolumeX } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { EditorMediaRange } from "@/components/editor/EditorMediaRange";
+import { EditorMediaRangeCanvas } from "@/components/editor/EditorMediaRangeCanvas";
+import { EditorViewportScrollbar } from "@/components/editor/EditorViewportScrollbar";
 import {
   EDITOR_MEDIA_TRACK_ID,
   timelineScrollLeftForCenteredTime,
@@ -89,7 +92,7 @@ function EditorTimelineLayers() {
         ))}
       </Timeline.TrackList>
       <Timeline.ClipInteractionLayer />
-      <Timeline.RangeSelector />
+      <EditorMediaRange />
     </>
   );
 }
@@ -136,7 +139,8 @@ export function EditorTimeline({
         </div>
         <div className="min-w-0 flex-1">
           <Timeline.Root className="h-full min-h-editor-timeline-mobile w-full lg:min-h-0">
-            <CanvasRenderer />
+            <CanvasRenderer showInOutPoints={false} />
+            <EditorMediaRangeCanvas />
             <EditorTimelineLayers />
           </Timeline.Root>
         </div>
@@ -144,12 +148,7 @@ export function EditorTimeline({
       <div className="flex shrink-0">
         <div className="w-32 shrink-0 border-t border-r border-editor-border bg-editor-panel-muted/55" />
         <div className="cliparr-timeline-scrollbar-row min-w-0 flex-1 border-t border-editor-border px-2 py-1.5">
-          <Timeline.ViewportScrollbar>
-            <Timeline.ViewportScrollbarThumb>
-              <Timeline.ViewportScrollbarHandle side="start" />
-              <Timeline.ViewportScrollbarHandle side="end" />
-            </Timeline.ViewportScrollbarThumb>
-          </Timeline.ViewportScrollbar>
+          <EditorViewportScrollbar />
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -5,6 +5,7 @@ import {
   useTimelinePlayback,
   useTimelineTracks,
   useTimelineViewport,
+  type TimelineEngine,
   type UseTimelineTrackHeaderResult,
 } from "@techsquidtv/canvas-timeline";
 import { Eye, EyeOff, Volume2, VolumeX } from "lucide-react";
@@ -12,6 +13,7 @@ import { useEffect, useRef } from "react";
 import { EditorMediaRange } from "@/components/editor/EditorMediaRange";
 import { EditorMediaRangeCanvas } from "@/components/editor/EditorMediaRangeCanvas";
 import { EditorViewportScrollbar } from "@/components/editor/EditorViewportScrollbar";
+import { zoomEditorTimeline } from "@/components/editor/editorTimelineZoom";
 import {
   EDITOR_MEDIA_TRACK_ID,
   timelineScrollLeftForCenteredTime,
@@ -78,7 +80,7 @@ function TrackHeaderColumn({ muted, onMutedChange }: EditorTimelineProperties) {
   );
 }
 
-function EditorTimelineLayers() {
+function EditorTimelineLayers({ engine }: { engine: TimelineEngine }) {
   const { tracks } = useTimelineTracks();
 
   return (
@@ -92,7 +94,7 @@ function EditorTimelineLayers() {
         ))}
       </Timeline.TrackList>
       <Timeline.ClipInteractionLayer />
-      <EditorMediaRange />
+      <EditorMediaRange engine={engine} />
     </>
   );
 }
@@ -128,9 +130,37 @@ function CenterViewportOnInPoint() {
 }
 
 export function EditorTimeline({
+  engine,
   muted,
   onMutedChange,
-}: EditorTimelineProperties) {
+}: EditorTimelineProperties & { engine: TimelineEngine }) {
+  const root = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const element = root.current;
+    if (!element) {
+      return;
+    }
+    const zoomAtPointer = (event: WheelEvent) => {
+      if (event.shiftKey || (!event.ctrlKey && !event.metaKey)) {
+        return;
+      }
+      // Intercept before the library's wheel listener, which preserves pixel
+      // scroll offset and can jump far from the current moment on long media.
+      event.preventDefault();
+      event.stopPropagation();
+      zoomEditorTimeline(
+        engine,
+        Math.max(0.01, engine.zoomScale * (1 - event.deltaY * 0.001)),
+        event.clientX - element.getBoundingClientRect().left,
+      );
+    };
+    element.addEventListener("wheel", zoomAtPointer, {
+      capture: true,
+      passive: false,
+    });
+    return () => element.removeEventListener("wheel", zoomAtPointer, true);
+  }, [engine]);
+
   return (
     <div className="cliparr-timeline-v2 flex h-full min-h-0 flex-col bg-editor-panel">
       <div className="flex min-h-0 flex-1">
@@ -138,10 +168,13 @@ export function EditorTimeline({
           <TrackHeaderColumn muted={muted} onMutedChange={onMutedChange} />
         </div>
         <div className="min-w-0 flex-1">
-          <Timeline.Root className="h-full min-h-editor-timeline-mobile w-full lg:min-h-0">
+          <Timeline.Root
+            ref={root}
+            className="h-full min-h-editor-timeline-mobile w-full lg:min-h-0"
+          >
             <CanvasRenderer showInOutPoints={false} />
             <EditorMediaRangeCanvas />
-            <EditorTimelineLayers />
+            <EditorTimelineLayers engine={engine} />
           </Timeline.Root>
         </div>
       </div>

--- a/apps/frontend/src/components/editor/EditorViewportScrollbar.tsx
+++ b/apps/frontend/src/components/editor/EditorViewportScrollbar.tsx
@@ -1,0 +1,174 @@
+import {
+  RangeScrollbar,
+  Timeline,
+  useTimelineViewportRangeControl,
+  type RangeScrollbarHandleSide,
+  type RangeScrollbarValue,
+} from "@techsquidtv/canvas-timeline";
+import { useRef, type PointerEvent, type KeyboardEvent } from "react";
+import {
+  viewportRangeAfterZoomDrag,
+  viewportScrollbarGeometry,
+} from "@/components/editor/editorTimelineZoom";
+
+type ViewportControl = ReturnType<typeof useTimelineViewportRangeControl>;
+
+function ZoomHandle({
+  side,
+  control,
+}: {
+  side: RangeScrollbarHandleSide;
+  control: ViewportControl;
+}) {
+  const drag = useRef<{
+    pointerId: number;
+    clientX: number;
+    range: RangeScrollbarValue;
+  } | null>(null);
+
+  const finishDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (drag.current?.pointerId !== event.pointerId) {
+      return;
+    }
+    drag.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return (
+    <Timeline.ViewportScrollbarHandle
+      side={side}
+      title="Drag inward to zoom in; outward to zoom out"
+      aria-valuemin={
+        side === "start" ? 0 : control.viewStartSeconds + control.range.minSpan
+      }
+      aria-valuemax={
+        side === "start"
+          ? control.viewEndSeconds - control.range.minSpan
+          : control.totalDurationSeconds
+      }
+      aria-valuenow={
+        side === "start" ? control.viewStartSeconds : control.viewEndSeconds
+      }
+      aria-valuetext={
+        side === "start" ? control.startValueText : control.endValueText
+      }
+      style={{ touchAction: "none" }}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        const delta = {
+          ArrowLeft: -10,
+          ArrowRight: 10,
+          PageUp: -120,
+          PageDown: 120,
+        }[event.key];
+        if (delta === undefined) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        control.onValueChange(
+          viewportRangeAfterZoomDrag({
+            range: {
+              start: control.viewStartSeconds,
+              end: control.viewEndSeconds,
+            },
+            side,
+            deltaPixels: delta,
+            minSpan: control.range.minSpan,
+            duration: control.totalDurationSeconds,
+          }),
+          { reason: "handle-keyboard", side },
+        );
+      }}
+      onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+        // Preserve the library's accessible handle while replacing its
+        // full-duration linear pointer sensitivity with proportional zoom.
+        event.preventDefault();
+        event.stopPropagation();
+        if (
+          (event.pointerType !== "touch" && event.button !== 0) ||
+          drag.current
+        ) {
+          return;
+        }
+        event.currentTarget.focus();
+        drag.current = {
+          pointerId: event.pointerId,
+          clientX: event.clientX,
+          range: {
+            start: control.viewStartSeconds,
+            end: control.viewEndSeconds,
+          },
+        };
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event: PointerEvent<HTMLDivElement>) => {
+        const active = drag.current;
+        if (!active || active.pointerId !== event.pointerId) {
+          return;
+        }
+        control.onValueChange(
+          viewportRangeAfterZoomDrag({
+            range: active.range,
+            side,
+            deltaPixels: event.clientX - active.clientX,
+            minSpan: control.range.minSpan,
+            duration: control.totalDurationSeconds,
+          }),
+          { reason: "handle-drag", side },
+        );
+      }}
+      onPointerUp={finishDrag}
+      onPointerCancel={finishDrag}
+      onLostPointerCapture={finishDrag}
+    />
+  );
+}
+
+export function EditorViewportScrollbar() {
+  const control = useTimelineViewportRangeControl();
+  const geometry = viewportScrollbarGeometry({
+    start: control.viewStartSeconds,
+    span: control.viewDurationSeconds,
+    duration: control.totalDurationSeconds,
+    minSpan: control.range.minSpan,
+    viewportWidth: control.viewportWidth,
+  });
+  const panScale =
+    geometry.scrollableDuration > 0
+      ? geometry.scrollableFraction / geometry.scrollableDuration
+      : 0;
+  return (
+    <RangeScrollbar.Root
+      className="timeline-viewport-scrollbar"
+      min={0}
+      max={1}
+      value={geometry.value}
+      keyboardStep={(40 / control.zoomScale) * panScale}
+      keyboardPageStep={control.viewDurationSeconds * 0.8 * panScale}
+      onValueChange={({ start }, details) => {
+        const progress =
+          geometry.scrollableFraction > 0
+            ? Math.min(1, Math.max(0, start / geometry.scrollableFraction))
+            : 0;
+        const viewStart = progress * geometry.scrollableDuration;
+        control.onValueChange(
+          { start: viewStart, end: viewStart + control.viewDurationSeconds },
+          details,
+        );
+      }}
+    >
+      <Timeline.ViewportScrollbarThumb
+        style={{ minWidth: 0 }}
+        aria-valuemin={0}
+        aria-valuemax={geometry.scrollableDuration}
+        aria-valuenow={control.viewStartSeconds}
+        aria-valuetext={control.valueText}
+      >
+        <ZoomHandle side="start" control={control} />
+        <ZoomHandle side="end" control={control} />
+      </Timeline.ViewportScrollbarThumb>
+    </RangeScrollbar.Root>
+  );
+}

--- a/apps/frontend/src/components/editor/editorTimelineEngine.test.ts
+++ b/apps/frontend/src/components/editor/editorTimelineEngine.test.ts
@@ -15,6 +15,7 @@ import {
   timelineScrollLeftForCenteredTime,
 } from "@/components/editor/editorTimelineEngine";
 import type { EditorSession } from "@/lib/editorMedia";
+import { createEditorHistory } from "@/components/editor/editorHistory";
 
 function createSession(overrides: Partial<EditorSession> = {}): EditorSession {
   return {
@@ -32,6 +33,18 @@ function createSession(overrides: Partial<EditorSession> = {}): EditorSession {
 }
 
 void describe("editor timeline engine", () => {
+  void it("shares zoom bounds across controls, from the full movie to subtitle detail", () => {
+    const engine = createEditorTimelineEngine(
+      createSession({ duration: 3600 }),
+    );
+    engine.setViewportWidth(1000);
+    engine.setZoomScale(0.01);
+    assert.equal(engine.zoomScale, 1000 / 3600);
+    engine.setZoomScale(10_000);
+    assert.equal(engine.zoomScale, 1000);
+    assert.equal(toSeconds(engine.getState().duration!), 3600);
+  });
+
   void it("centers a time within the available horizontal scroll range", () => {
     assert.equal(
       timelineScrollLeftForCenteredTime({
@@ -144,6 +157,47 @@ void describe("editor timeline engine", () => {
       toSeconds(engine.getPlaybackStartTime({ respectInOut: true })),
       5,
     );
+  });
+
+  void it("moves the selection as one undoable range without moving source media or subtitles", () => {
+    const engine = createEditorTimelineEngine(createSession());
+    synchronizeEditorTimelineMedia(engine, {
+      duration: 20,
+      sourceStart: 1_700_000_000,
+      initialDuration: 20,
+    });
+    synchronizeEditorTimelineSubtitles(engine, {
+      cues: [
+        { startTime: 2, endTime: 4, text: "Fixed cue", lines: ["Fixed cue"] },
+      ],
+    });
+    const initialTracks = engine.getState().tracks;
+    const history = createEditorHistory(engine);
+
+    history.beginRangeGesture();
+    for (const start of [6, 7, 8, 10]) {
+      engine.setInOutRange(fromSeconds(start), fromSeconds(start + 10));
+    }
+    history.endRangeGesture();
+
+    assert.equal(toSeconds(engine.getState().duration!), 20);
+    assert.equal(toSeconds(engine.maxContentTime), 20);
+    assert.deepEqual(engine.getState().tracks, initialTracks);
+    assert.equal(toSeconds(engine.getState().inPoint!), 10);
+    assert.equal(toSeconds(engine.getState().outPoint!), 20);
+    // The playhead can still inspect source media before the selected clip.
+    engine.updatePlayhead(fromSeconds(1));
+    assert.equal(toSeconds(engine.getTime()), 1);
+
+    history.undo();
+    assert.equal(toSeconds(engine.getState().inPoint!), 5);
+    assert.equal(toSeconds(engine.getState().outPoint!), 15);
+    assert.equal(history.getSnapshot().canUndo, false);
+    history.redo();
+    assert.equal(toSeconds(engine.getState().inPoint!), 10);
+    assert.equal(toSeconds(engine.getState().outPoint!), 20);
+    assert.deepEqual(engine.getState().tracks, initialTracks);
+    history.dispose();
   });
 
   void it("preserves a valid engine-owned range when media metadata is refined", () => {

--- a/apps/frontend/src/components/editor/editorTimelineEngine.ts
+++ b/apps/frontend/src/components/editor/editorTimelineEngine.ts
@@ -8,6 +8,7 @@ import {
   type TimelineEditCommand,
 } from "@techsquidtv/canvas-timeline";
 import { buildInitialClipRange } from "@/components/editor/initialClipRange";
+import { EDITOR_MAX_ZOOM_SCALE } from "@/components/editor/editorTimelineZoom";
 import type { EditorSession } from "@/lib/editorMedia";
 import { normalizeSubtitleCueText } from "@/lib/subtitles/normalizeSubtitleCueText";
 import type { SubtitleCue } from "@/lib/subtitles/types";
@@ -146,6 +147,7 @@ export function createEditorTimelineEngine(session: EditorSession) {
     inPoint: fromSeconds(initialRange.startTime),
     outPoint: fromSeconds(initialRange.endTime),
     zoomScale: DEFAULT_TIMELINE_ZOOM_SCALE,
+    zoomConstraints: { maxZoomScale: EDITOR_MAX_ZOOM_SCALE },
     snapEnabled: false,
     tracks: createEditorTracks(duration, session.title),
   });

--- a/apps/frontend/src/components/editor/editorTimelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/editorTimelineZoom.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { TimelineEngine, fromSeconds } from "@techsquidtv/canvas-timeline";
+import {
+  viewportRangeAfterZoomDrag,
+  viewportScrollbarGeometry,
+  zoomEditorTimeline,
+} from "@/components/editor/editorTimelineZoom";
+
+void test("scrollbar width changes at every zoom step on a long movie", () => {
+  const widths = [1, 2, 4, 8].map((span) => {
+    const geometry = viewportScrollbarGeometry({
+      start: 1800,
+      span,
+      duration: 3600,
+      minSpan: 1,
+      viewportWidth: 1000,
+    });
+    return geometry.value.end - geometry.value.start;
+  });
+  for (let index = 1; index < widths.length; index += 1) {
+    assert.ok(widths[index] - widths[index - 1] > 0.07);
+  }
+});
+
+void test("logarithmic scrollbar navigation still reaches both ends of the movie", () => {
+  for (const progress of [0, 0.5, 1]) {
+    const geometry = viewportScrollbarGeometry({
+      start: progress * 3590,
+      span: 10,
+      duration: 3600,
+      minSpan: 1,
+      viewportWidth: 1000,
+    });
+    assert.ok(
+      Math.abs(geometry.value.start / geometry.scrollableFraction - progress) <
+        1e-10,
+    );
+    assert.ok(geometry.value.start >= 0);
+    assert.ok(geometry.value.end <= 1);
+    if (progress === 1) {
+      assert.equal(geometry.value.end, 1);
+    }
+  }
+  const full = viewportScrollbarGeometry({
+    start: 0,
+    span: 3600,
+    duration: 3600,
+    minSpan: 1,
+    viewportWidth: 1000,
+  });
+  assert.deepEqual(full.value, { start: 0, end: 1 });
+  assert.equal(full.scrollableDuration, 0);
+});
+
+void test("button zoom keeps a visible playhead at its screen position", () => {
+  const engine = new TimelineEngine({
+    tracks: [],
+    duration: fromSeconds(3600),
+    zoomScale: 100,
+    playheadTime: fromSeconds(1803),
+  });
+  engine.setViewportWidth(1000);
+  engine.setScrollLeft(180_000);
+  zoomEditorTimeline(engine, 200);
+  assert.equal(engine.timeToPixel(fromSeconds(1803)), 300);
+  assert.equal(engine.zoomScale, 200);
+});
+
+void test("button zoom keeps the viewport center when the playhead is offscreen", () => {
+  const engine = new TimelineEngine({
+    tracks: [],
+    duration: fromSeconds(3600),
+    zoomScale: 100,
+    playheadTime: fromSeconds(0),
+  });
+  engine.setViewportWidth(1000);
+  engine.setScrollLeft(180_000);
+  zoomEditorTimeline(engine, 200);
+  assert.equal(engine.timeToPixel(fromSeconds(1805)), 500);
+});
+
+void test("zoom drag precision depends on the visible span, not media length", () => {
+  for (const duration of [1800, 3600, 7200]) {
+    assert.deepEqual(
+      viewportRangeAfterZoomDrag({
+        range: { start: 900, end: 920 },
+        side: "end",
+        deltaPixels: -120,
+        minSpan: 1,
+        duration,
+      }),
+      { start: 900, end: 910 },
+    );
+  }
+});
+
+void test("each handle preserves the opposite boundary while zooming", () => {
+  const input = { range: { start: 900, end: 920 }, minSpan: 1, duration: 3600 };
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({ ...input, side: "start", deltaPixels: 120 }),
+    { start: 910, end: 920 },
+  );
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({ ...input, side: "end", deltaPixels: 120 }),
+    { start: 900, end: 940 },
+  );
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({ ...input, side: "end", deltaPixels: 0 }),
+    input.range,
+  );
+});
+
+void test("small drags remain precise at subtitle scale", () => {
+  const range = viewportRangeAfterZoomDrag({
+    range: { start: 900, end: 902 },
+    side: "end",
+    deltaPixels: -1,
+    minSpan: 0.5,
+    duration: 7200,
+  });
+  assert.equal(range.start, 900);
+  assert.ok(range.end > 901.98 && range.end < 902);
+});
+
+void test("zoom stays inside media bounds and respects the minimum visible span", () => {
+  const input = {
+    range: { start: 3590, end: 3600 },
+    minSpan: 1,
+    duration: 3600,
+  };
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({ ...input, side: "end", deltaPixels: 120 }),
+    { start: 3580, end: 3600 },
+  );
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({ ...input, side: "end", deltaPixels: 10_000 }),
+    { start: 0, end: 3600 },
+  );
+  assert.deepEqual(
+    viewportRangeAfterZoomDrag({
+      ...input,
+      side: "start",
+      deltaPixels: 10_000,
+    }),
+    { start: 3599, end: 3600 },
+  );
+});

--- a/apps/frontend/src/components/editor/editorTimelineZoom.test.ts
+++ b/apps/frontend/src/components/editor/editorTimelineZoom.test.ts
@@ -80,6 +80,34 @@ void test("button zoom keeps the viewport center when the playhead is offscreen"
   assert.equal(engine.timeToPixel(fromSeconds(1805)), 500);
 });
 
+void test("pointer zoom preserves the pointed time even when the zoom limit clamps the scale", () => {
+  const engine = new TimelineEngine({
+    tracks: [],
+    duration: fromSeconds(3600),
+    zoomScale: 100,
+    zoomConstraints: { maxZoomScale: 1000 },
+    playheadTime: fromSeconds(1801),
+  });
+  engine.setViewportWidth(1000);
+  engine.setScrollLeft(180_000);
+  zoomEditorTimeline(engine, 2000, 750);
+  assert.equal(engine.zoomScale, 1000);
+  assert.equal(engine.timeToPixel(fromSeconds(1807.5)), 750);
+});
+
+void test("zooming all the way out stays within the full media bounds", () => {
+  const engine = new TimelineEngine({
+    tracks: [],
+    duration: fromSeconds(3600),
+    zoomScale: 100,
+  });
+  engine.setViewportWidth(1000);
+  engine.setScrollLeft(359_000);
+  zoomEditorTimeline(engine, 0.01, 900);
+  assert.equal(engine.zoomScale, 1000 / 3600);
+  assert.equal(engine.getState().scrollLeft, 0);
+});
+
 void test("zoom drag precision depends on the visible span, not media length", () => {
   for (const duration of [1800, 3600, 7200]) {
     assert.deepEqual(

--- a/apps/frontend/src/components/editor/editorTimelineZoom.ts
+++ b/apps/frontend/src/components/editor/editorTimelineZoom.ts
@@ -1,0 +1,91 @@
+import {
+  toSeconds,
+  type TimelineEngine,
+  type RangeScrollbarHandleSide,
+  type RangeScrollbarValue,
+} from "@techsquidtv/canvas-timeline";
+
+export const EDITOR_MAX_ZOOM_SCALE = 1000;
+const ZOOM_DOUBLING_DISTANCE_PIXELS = 120;
+
+export function viewportScrollbarGeometry({
+  start,
+  span,
+  duration,
+  minSpan,
+  viewportWidth,
+}: {
+  start: number;
+  span: number;
+  duration: number;
+  minSpan: number;
+  viewportWidth: number;
+}) {
+  // Logarithmic sizing keeps fine zoom levels visibly distinct without a
+  // fixed-width plateau. Position still covers the entire scrollable media.
+  const minimumWidth = Math.min(1, 56 / Math.max(56, viewportWidth));
+  const zoomFraction =
+    duration > minSpan
+      ? Math.log(Math.max(minSpan, span) / minSpan) /
+        Math.log(duration / minSpan)
+      : 1;
+  const width =
+    minimumWidth + (1 - minimumWidth) * Math.min(1, Math.max(0, zoomFraction));
+  const scrollableDuration = Math.max(0, duration - span);
+  const scrollableFraction = 1 - width;
+  const position =
+    scrollableDuration > 0
+      ? Math.min(1, Math.max(0, start / scrollableDuration))
+      : 0;
+  return {
+    value: {
+      start: position * scrollableFraction,
+      end: position * scrollableFraction + width,
+    },
+    scrollableDuration,
+    scrollableFraction,
+  };
+}
+
+export function zoomEditorTimeline(engine: TimelineEngine, scale: number) {
+  const state = engine.getState();
+  const width = state.viewportWidth ?? 0;
+  if (width <= 0) {
+    return;
+  }
+  const playheadX = engine.timeToPixel(state.playheadTime);
+  const anchorX = playheadX >= 0 && playheadX <= width ? playheadX : width / 2;
+  const anchorTime = engine.pixelToTime(anchorX);
+  engine.setZoomScale(scale);
+  engine.setScrollLeft(
+    Math.max(0, toSeconds(anchorTime) * engine.zoomScale - anchorX),
+  );
+  engine.settle();
+}
+
+// Pointer travel changes the visible span proportionally, so subtitle-scale
+// adjustments have the same precision for a short clip and a feature film.
+export function viewportRangeAfterZoomDrag({
+  range,
+  side,
+  deltaPixels,
+  minSpan,
+  duration,
+}: {
+  range: RangeScrollbarValue;
+  side: RangeScrollbarHandleSide;
+  deltaPixels: number;
+  minSpan: number;
+  duration: number;
+}): RangeScrollbarValue {
+  const direction = side === "start" ? -1 : 1;
+  const scale =
+    2 ** ((direction * deltaPixels) / ZOOM_DOUBLING_DISTANCE_PIXELS);
+  const span = Math.min(
+    duration,
+    Math.max(minSpan, (range.end - range.start) * scale),
+  );
+  const anchoredStart = side === "start" ? range.end - span : range.start;
+  const start = Math.min(Math.max(0, anchoredStart), duration - span);
+  return { start, end: start + span };
+}

--- a/apps/frontend/src/components/editor/editorTimelineZoom.ts
+++ b/apps/frontend/src/components/editor/editorTimelineZoom.ts
@@ -47,14 +47,25 @@ export function viewportScrollbarGeometry({
   };
 }
 
-export function zoomEditorTimeline(engine: TimelineEngine, scale: number) {
+export function zoomEditorTimeline(
+  engine: TimelineEngine,
+  scale: number,
+  anchorPixel?: number,
+) {
   const state = engine.getState();
   const width = state.viewportWidth ?? 0;
   if (width <= 0) {
     return;
   }
   const playheadX = engine.timeToPixel(state.playheadTime);
-  const anchorX = playheadX >= 0 && playheadX <= width ? playheadX : width / 2;
+  const anchorX = Math.min(
+    width,
+    Math.max(
+      0,
+      anchorPixel ??
+        (playheadX >= 0 && playheadX <= width ? playheadX : width / 2),
+    ),
+  );
   const anchorTime = engine.pixelToTime(anchorX);
   engine.setZoomScale(scale);
   engine.setScrollLeft(

--- a/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
+++ b/apps/frontend/src/components/editor/useEditorKeyboardShortcuts.ts
@@ -67,7 +67,7 @@ export function useEditorKeyboardShortcuts({
     const pressedCodes = new Set<string>();
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (isEditorDialogOpen()) {
+      if (event.defaultPrevented || isEditorDialogOpen()) {
         return;
       }
 
@@ -138,7 +138,7 @@ function isInteractiveKeyboardTarget(
     (!historyCommand && Boolean(target.closest("button"))) ||
     Boolean(
       target.closest(
-        'input, textarea, select, [contenteditable="true"], [role="slider"], [role="dialog"], [role="alertdialog"], dialog',
+        'input, textarea, select, [contenteditable="true"], [role="slider"], [role="scrollbar"], [role="dialog"], [role="alertdialog"], dialog',
       ),
     )
   );

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -671,7 +671,6 @@
 }
 
 .editor-media-range .range-scrollbar-handle {
-  width: min(12px, 25%);
   background: transparent;
   touch-action: none;
 }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -596,7 +596,8 @@
   box-shadow: 0 1px 3px color-mix(in oklch, var(--foreground) 28%, transparent);
 }
 
-.cliparr-timeline-v2 {
+.cliparr-timeline-v2,
+.cliparr-timeline-v2 .timeline-root {
   --timeline-panel: var(--editor-panel);
   --timeline-panel-muted: var(--editor-panel-muted);
   --timeline-panel-control: var(--editor-control);
@@ -639,4 +640,53 @@
 
 .cliparr-timeline-scrollbar-row .range-scrollbar {
   min-height: 14px;
+}
+
+.editor-media-range-row {
+  position: absolute;
+  right: 0;
+  left: 0;
+  z-index: 26;
+  overflow: hidden;
+}
+
+.editor-media-range-row .editor-media-range-scrub {
+  height: 100%;
+}
+
+.editor-media-range-row .editor-media-range {
+  z-index: 31;
+  border: 0;
+  background: transparent;
+  pointer-events: none;
+}
+
+.editor-media-range .range-scrollbar-thumb {
+  min-width: 0;
+  overflow: visible;
+  border: 0;
+  background: transparent;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.editor-media-range .range-scrollbar-handle {
+  width: min(12px, 25%);
+  background: transparent;
+  touch-action: none;
+}
+
+.editor-media-range
+  .range-scrollbar-thumb:is(:hover, :active, [data-dragging]) {
+  background: transparent;
+}
+
+.editor-media-range .range-scrollbar-handle:empty::before {
+  content: none;
+}
+
+.editor-media-range
+  :is(.range-scrollbar-thumb, .range-scrollbar-handle):focus-visible {
+  outline: 2px solid var(--editor-accent);
+  outline-offset: 2px;
 }

--- a/apps/www/src/content/docs/editor-shortcuts.mdx
+++ b/apps/www/src/content/docs/editor-shortcuts.mdx
@@ -7,7 +7,7 @@ order: 40
 
 The editor keeps keyboard shortcuts focused on preview playback, range marking, seeking, and timeline navigation so browser, form, and media controls stay predictable.
 
-Shortcuts only control the editor when focus is not inside an interactive control or dialog. They are ignored while typing in inputs, using selects, pressing buttons, adjusting sliders, or working inside export and framegrab dialogs.
+Shortcuts only control the editor when focus is not inside an interactive control or dialog. They are ignored while typing in inputs, using selects, pressing buttons, adjusting sliders or scrollbars, or working inside export and framegrab dialogs.
 
 ## Preview playback
 
@@ -72,3 +72,11 @@ Most editor actions are controlled directly on screen:
 - Scroll the timeline to move horizontally.
 - Use `Ctrl`/`Cmd` + scroll over the timeline to zoom around the pointer.
 - Use the volume slider and mute button to control preview audio.
+
+## Working with long videos
+
+Use the scrollbar body to move through the full source, then drag a scrollbar edge inward to zoom in until subtitle cues are easy to read and adjust. Drag outward to zoom back out. The thumb's width follows the zoom level, while its position tracks where you are in the video; its width continues to change even when only a few seconds are visible.
+
+With the scrollbar body focused, Left and Right Arrow pan a small distance, and Page Up and Page Down pan most of the visible view. With an edge focused, these keys adjust zoom instead. These controls leave the playhead and clip boundaries in place. The zoom buttons keep a visible playhead at its screen position, or keep the center of the view when the playhead is offscreen, until the view reaches a media boundary.
+
+Zoom out to see the entire source when choosing a new moment, or zoom in for subtitle timing. Moving the media block changes only the export range; subtitle cues stay aligned with the source. The `In` and `Out` timecodes remain available for exact boundaries.

--- a/apps/www/src/content/docs/editor-shortcuts.mdx
+++ b/apps/www/src/content/docs/editor-shortcuts.mdx
@@ -62,9 +62,13 @@ Timecode fields accept seconds, minutes and seconds, or hours, minutes, and seco
 
 Most editor actions are controlled directly on screen:
 
-- Drag the timeline selection to move the clip range.
-- Drag selection edges to adjust `In` and `Out`.
+- The timeline always spans the full media duration. The media block represents the selected clip range.
+- Drag the media block to move `In` and `Out` together, keeping the clip length.
+- Drag either block edge to adjust `In` or `Out`. Click the empty media row or ruler to scrub the source.
+- Focus the block or either edge and use arrow keys for precise adjustments; Page Up and Page Down adjust by one second.
 - Use the zoom buttons to change timeline scale.
+- Drag the scrollbar body to navigate the full video. Drag its edges inward to zoom in or outward to zoom out; zoom changes proportionally to the current view, so fine subtitle adjustments stay precise on long videos.
+- Zoom out to fit the full media duration, or zoom in to inspect subtitle timing. Scrollbar handles, zoom buttons, and wheel zoom share the same limits.
 - Scroll the timeline to move horizontally.
 - Use `Ctrl`/`Cmd` + scroll over the timeline to zoom around the pointer.
 - Use the volume slider and mute button to control preview audio.

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -46,4 +46,6 @@ For a persistent setup, keep the same `APP_KEY` and volume across updates.
 
 ## Next steps
 
-When a playable source is available, Cliparr opens the timeline editor. Pick the range you want to save, then export the clip.
+When a playable source is available, Cliparr opens the timeline editor. The timeline spans the full video, and the block labeled with the media title represents the range to export. Drag the block to choose a different moment, or drag either edge to adjust `In` and `Out`.
+
+Use the scrollbar to navigate and zoom into subtitle timing, then export the clip. See [Editor shortcuts](/docs/editor-shortcuts) for precise timecodes, range editing, and long-video navigation.

--- a/apps/www/src/data/product.ts
+++ b/apps/www/src/data/product.ts
@@ -35,7 +35,8 @@ export const features = [
   },
   {
     title: "Intuitive timeline editor",
-    description: "Familiar editing controls for choosing the exact clip range.",
+    description:
+      "Drag the media block to choose your clip, trim either edge, and zoom into subtitle timing across the full video.",
   },
   {
     title: "Browser transcoding",


### PR DESCRIPTION
The media block now represents the export range: drag it to move In and Out together, or drag either edge to trim. The sequence remains the full media duration, and moving the range preserves source timestamps, subtitles, drafts, and undo history. The block shows the media title without duration text. Range updates apply atomically throughout a drag, including when returning to its starting position, and short selections keep separate trim hit areas aligned with the canvas grips.

CanvasRenderer continues to draw the timeline and subtitles, with a canvas layer painting the media range and accessible DOM controls handling interaction. Long-video navigation gains proportional edge zoom, continuously changing scrollbar width, and shared zoom limits. Zoom buttons preserve the visible playhead or viewport center; Ctrl/Cmd-wheel zoom preserves the time under the pointer. Focused scrollbar keys pan or zoom without also seeking playback.

Updated the getting-started guide, long-video navigation and shortcut documentation, homepage feature copy, and synchronized README.

Validation: `pnpm preflight` (formatting, lint, types, knip, server tests, and 244 frontend tests), production app and website builds, and README sync check. Browser checks cover drag reversal on the block and both trim edges, undo/redo, minimum-length hit areas, keyboard isolation, pointer-anchored wheel zoom, and mouse/touch scrollbar zoom on a one-hour timeline with 1,000 subtitles. Source duration, timestamps, and subtitle tracks remain unchanged by range and viewport gestures.

Release follow-up: the existing marketing screenshot and demo recordings still show the previous editor UI and should be refreshed before release.
