### PR TITLE
feat(frontend): replace native controls with styled components

### DIFF
--- a/apps/frontend/src/components/DashboardScreen.tsx
+++ b/apps/frontend/src/components/DashboardScreen.tsx
@@ -1,3 +1,4 @@
+import { ControlTooltip } from "@/components/ui/tooltip";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
@@ -546,16 +547,18 @@ export function DashboardVersionBadge({
 
   if (!latestRelease) {
     return (
-      <span
-        className={DASHBOARD_VERSION_BADGE_CLASS}
-        title={releaseChecksDisabledReason ?? undefined}
-        data-dashboard-version-badge
-        data-dashboard-release-check-disabled={
-          releaseChecksDisabledReason ? true : undefined
-        }
-      >
-        {versionLabel}
-      </span>
+      <ControlTooltip label={releaseChecksDisabledReason ?? undefined}>
+        <span
+          className={DASHBOARD_VERSION_BADGE_CLASS}
+          tabIndex={releaseChecksDisabledReason ? 0 : undefined}
+          data-dashboard-version-badge
+          data-dashboard-release-check-disabled={
+            releaseChecksDisabledReason ? true : undefined
+          }
+        >
+          {versionLabel}
+        </span>
+      </ControlTooltip>
     );
   }
 
@@ -573,7 +576,6 @@ export function DashboardVersionBadge({
             "gap-1.5 border-primary/40 bg-primary/10 text-primary transition-colors hover:bg-primary/15 focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
           )}
           aria-label={`${updateLabel}. View release notes.`}
-          title={updateLabel}
           data-dashboard-version-badge
           data-dashboard-update-available
         >
@@ -824,17 +826,18 @@ export default function DashboardScreen({
               <span className="truncate">Sources</span>
             </button>
             {renderViewerFilterPicker()}
-            <button
-              type="button"
-              onClick={fetchSessions}
-              className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              aria-label="Refresh sessions"
-              title="Refresh"
-            >
-              <RefreshCw
-                className={`h-5 w-5 ${loading || refreshing ? "animate-spin text-primary" : ""}`}
-              />
-            </button>
+            <ControlTooltip label="Refresh">
+              <button
+                type="button"
+                onClick={fetchSessions}
+                className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label="Refresh sessions"
+              >
+                <RefreshCw
+                  className={`h-5 w-5 ${loading || refreshing ? "animate-spin text-primary" : ""}`}
+                />
+              </button>
+            </ControlTooltip>
           </div>
           <MobilePwaInstallNudge />
           <div className="hidden flex-wrap items-center gap-3 sm:flex sm:justify-end">
@@ -855,67 +858,71 @@ export default function DashboardScreen({
               Sources
             </button>
             {renderViewerFilterPicker()}
-            <button
-              type="button"
-              onClick={fetchSessions}
-              className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
-              aria-label="Refresh sessions"
-              title="Refresh"
-            >
-              <RefreshCw
-                className={`w-5 h-5 ${loading || refreshing ? "animate-spin text-primary" : ""}`}
-              />
-            </button>
-            <a
-              href={CLIPARR_WEBSITE_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
-              aria-label="Open Cliparr website"
-              title="Open Cliparr website"
-            >
-              <Globe className="h-5 w-5" />
-            </a>
-            <a
-              href={CLIPARR_GITHUB_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
-              aria-label="View Cliparr on GitHub"
-              title="View Cliparr on GitHub"
-            >
-              <GithubIcon className="h-5 w-5" />
-            </a>
-            <motion.button
-              type="button"
-              onClick={onDisconnect}
-              className={cn(
-                "flex items-center gap-2 rounded-lg text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
-                showViewerFilterControl
-                  ? "h-9 w-9 justify-center p-2"
-                  : "px-4 py-2",
-              )}
-              aria-label="Disconnect"
-              title="Disconnect"
-              whileHover={
-                showViewerFilterControl && !reduceDashboardMotion
-                  ? { y: -1 }
-                  : undefined
-              }
-              whileTap={
-                showViewerFilterControl && !reduceDashboardMotion
-                  ? { scale: 0.985 }
-                  : undefined
-              }
-              transition={
-                reduceDashboardMotion
-                  ? { duration: 0 }
-                  : cliparrMotionTransitions.fast
-              }
-            >
-              <LogOut className="w-4 h-4" />
-              {!showViewerFilterControl && "Disconnect"}
-            </motion.button>
+            <ControlTooltip label="Refresh">
+              <button
+                type="button"
+                onClick={fetchSessions}
+                className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+                aria-label="Refresh sessions"
+              >
+                <RefreshCw
+                  className={`w-5 h-5 ${loading || refreshing ? "animate-spin text-primary" : ""}`}
+                />
+              </button>
+            </ControlTooltip>
+            <ControlTooltip label="Open Cliparr website">
+              <a
+                href={CLIPARR_WEBSITE_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+                aria-label="Open Cliparr website"
+              >
+                <Globe className="h-5 w-5" />
+              </a>
+            </ControlTooltip>
+            <ControlTooltip label="View Cliparr on GitHub">
+              <a
+                href={CLIPARR_GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+                aria-label="View Cliparr on GitHub"
+              >
+                <GithubIcon className="h-5 w-5" />
+              </a>
+            </ControlTooltip>
+            <ControlTooltip label="Disconnect">
+              <motion.button
+                type="button"
+                onClick={onDisconnect}
+                className={cn(
+                  "flex items-center gap-2 rounded-lg text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:outline-none",
+                  showViewerFilterControl
+                    ? "h-9 w-9 justify-center p-2"
+                    : "px-4 py-2",
+                )}
+                aria-label="Disconnect"
+                whileHover={
+                  showViewerFilterControl && !reduceDashboardMotion
+                    ? { y: -1 }
+                    : undefined
+                }
+                whileTap={
+                  showViewerFilterControl && !reduceDashboardMotion
+                    ? { scale: 0.985 }
+                    : undefined
+                }
+                transition={
+                  reduceDashboardMotion
+                    ? { duration: 0 }
+                    : cliparrMotionTransitions.fast
+                }
+              >
+                <LogOut className="w-4 h-4" />
+                {!showViewerFilterControl && "Disconnect"}
+              </motion.button>
+            </ControlTooltip>
           </div>
         </header>
 

--- a/apps/frontend/src/components/MobilePwaInstallNudge.tsx
+++ b/apps/frontend/src/components/MobilePwaInstallNudge.tsx
@@ -1,3 +1,4 @@
+import { ControlTooltip } from "@/components/ui/tooltip";
 import { Download, Share, Smartphone, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -99,15 +100,16 @@ export function MobilePwaInstallNudgeCard({
               : "Open it like an app with a faster, full-screen experience."}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className={cn(iconButtonClasses, "h-8 w-8 shrink-0")}
-          aria-label="Dismiss install prompt"
-          title="Dismiss"
-        >
-          <X className="h-4 w-4" />
-        </button>
+        <ControlTooltip label="Dismiss">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className={cn(iconButtonClasses, "h-8 w-8 shrink-0")}
+            aria-label="Dismiss install prompt"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </ControlTooltip>
       </div>
 
       <div className="mt-3 flex flex-wrap items-center gap-2 pl-12">

--- a/apps/frontend/src/components/editor/EditorControls.tsx
+++ b/apps/frontend/src/components/editor/EditorControls.tsx
@@ -1,9 +1,4 @@
-import {
-  useMemo,
-  type CSSProperties,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import { useMemo, type CSSProperties, type ReactNode } from "react";
 import {
   Camera,
   Pause,
@@ -15,11 +10,7 @@ import {
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { ControlTooltip } from "@/components/ui/tooltip";
 import {
   Drawer,
   DrawerContent,
@@ -65,31 +56,6 @@ interface EditorControlsProperties {
   onSetOutPoint: () => void;
   onClearPoints: () => void;
   onFitSelection: () => void;
-}
-
-function ControlTooltip({
-  label,
-  disabled = false,
-  children,
-}: {
-  label: string;
-  disabled?: boolean;
-  children: ReactElement;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        {disabled ? (
-          <span className="inline-flex" tabIndex={0}>
-            {children}
-          </span>
-        ) : (
-          children
-        )}
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{label}</TooltipContent>
-    </Tooltip>
-  );
 }
 
 export function EditorControls({

--- a/apps/frontend/src/components/editor/EditorExportDialog.tsx
+++ b/apps/frontend/src/components/editor/EditorExportDialog.tsx
@@ -1,4 +1,5 @@
-import { Download } from "lucide-react";
+import { Download, FileText } from "lucide-react";
+import { BouncyAccordion } from "@/components/ui/bouncy-accordion";
 import type {
   ExportFormat,
   ExportResolution,
@@ -185,20 +186,24 @@ export function EditorExportDialog({
               hlsSourceLabel={hlsSourceLabel}
             />
 
-            <details className="rounded-md border border-border bg-card">
-              <summary className="cursor-pointer rounded-md px-3 py-3 text-sm font-medium focus-visible:ring-2 focus-visible:ring-ring">
-                Advanced filename settings
-              </summary>
-              <div className="px-3 pb-3">
-                <EditorFilenameTemplateSection
-                  editingTemplateKind={editingTemplateKind}
-                  onEditingTemplateKindChange={onEditingTemplateKindChange}
-                  fileNameTemplates={fileNameTemplates}
-                  onFileNameTemplateChange={onFileNameTemplateChange}
-                  onResetFileNameTemplate={onResetFileNameTemplate}
-                />
-              </div>
-            </details>
+            <BouncyAccordion
+              items={[
+                {
+                  id: "filename-settings",
+                  title: "Advanced filename settings",
+                  icon: <FileText className="h-4 w-4" />,
+                  description: (
+                    <EditorFilenameTemplateSection
+                      editingTemplateKind={editingTemplateKind}
+                      onEditingTemplateKindChange={onEditingTemplateKindChange}
+                      fileNameTemplates={fileNameTemplates}
+                      onFileNameTemplateChange={onFileNameTemplateChange}
+                      onResetFileNameTemplate={onResetFileNameTemplate}
+                    />
+                  ),
+                },
+              ]}
+            />
           </fieldset>
         </div>
 

--- a/apps/frontend/src/components/editor/EditorMediaRange.tsx
+++ b/apps/frontend/src/components/editor/EditorMediaRange.tsx
@@ -1,3 +1,4 @@
+import { ControlTooltip } from "@/components/ui/tooltip";
 import {
   RangeScrollbar,
   Timeline,
@@ -39,11 +40,12 @@ export function EditorMediaRange({ engine }: { engine: TimelineEngine }) {
       className="editor-media-range-row"
       style={{ top: rect.y, height: rect.height }}
     >
-      <Timeline.PlayheadArea
-        className="editor-media-range-scrub"
-        title="Scrub source media"
-        onDoubleClick={setPlayheadTime}
-      />
+      <ControlTooltip label="Scrub source media">
+        <Timeline.PlayheadArea
+          className="editor-media-range-scrub"
+          onDoubleClick={setPlayheadTime}
+        />
+      </ControlTooltip>
       <RangeScrollbar.Root
         className="editor-media-range"
         min={range.min}
@@ -77,26 +79,30 @@ export function EditorMediaRange({ engine }: { engine: TimelineEngine }) {
           transform: `translateX(${-scrollLeft}px)`,
         }}
       >
-        <RangeScrollbar.Thumb
-          role="slider"
-          aria-label="Move clip selection"
-          title="Drag to move selection; drag either edge to trim"
-        >
-          <RangeScrollbar.Handle
-            side="start"
-            style={{ width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)` }}
-            role="slider"
-            aria-label="Clip start"
-            title="Trim clip start"
-          />
-          <RangeScrollbar.Handle
-            side="end"
-            style={{ width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)` }}
-            role="slider"
-            aria-label="Clip end"
-            title="Trim clip end"
-          />
-        </RangeScrollbar.Thumb>
+        <ControlTooltip label="Drag to move selection; drag either edge to trim">
+          <RangeScrollbar.Thumb role="slider" aria-label="Move clip selection">
+            <ControlTooltip label="Trim clip start">
+              <RangeScrollbar.Handle
+                side="start"
+                style={{
+                  width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)`,
+                }}
+                role="slider"
+                aria-label="Clip start"
+              />
+            </ControlTooltip>
+            <ControlTooltip label="Trim clip end">
+              <RangeScrollbar.Handle
+                side="end"
+                style={{
+                  width: `min(${EDITOR_MEDIA_RANGE_HANDLE_WIDTH}px, 25%)`,
+                }}
+                role="slider"
+                aria-label="Clip end"
+              />
+            </ControlTooltip>
+          </RangeScrollbar.Thumb>
+        </ControlTooltip>
       </RangeScrollbar.Root>
     </div>
   );

--- a/apps/frontend/src/components/editor/EditorScreen.tsx
+++ b/apps/frontend/src/components/editor/EditorScreen.tsx
@@ -1,3 +1,4 @@
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import {
   lazy,
   Suspense,
@@ -152,6 +153,7 @@ function EditorScreenContent({
   const [editorPropertiesOpenSections, setEditorPropertiesOpenSections] =
     useState(loadEditorPropertiesOpenSections);
   const [exportDialogMounted, setExportDialogMounted] = useState(false);
+  const subtitleTrackTriggerReference = useRef<HTMLButtonElement>(null);
   const {
     subtitleTracks,
     selectedSubtitleTrack,
@@ -170,6 +172,9 @@ function EditorScreenContent({
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    subtitleTrackChangePending,
+    confirmSubtitleTrackChange,
+    cancelSubtitleTrackChange,
     selectedSubtitleCue,
     handleSelectedSubtitleTextCommit,
     handleSelectedSubtitleStartCommit,
@@ -604,6 +609,8 @@ function EditorScreenContent({
           providerId={session.source.providerId}
           subtitleTracks={subtitleTracks}
           selectedSubtitleTrackKey={selectedSubtitleTrackKey}
+          subtitleTrackChangePending={subtitleTrackChangePending}
+          subtitleTrackTriggerRef={subtitleTrackTriggerReference}
           onSelectedSubtitleTrackKeyChange={handleSelectedSubtitleTrackChange}
           subtitlesEnabled={subtitleEnabled}
           onSubtitlesEnabledChange={setSubtitleEnabled}
@@ -649,6 +656,15 @@ function EditorScreenContent({
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden bg-editor-workspace text-foreground">
+      <ConfirmationDialog
+        open={subtitleTrackChangePending}
+        title="Replace subtitle cues?"
+        description="Changing subtitle tracks will replace your customized subtitle cues."
+        confirmLabel="Replace cues"
+        onConfirm={confirmSubtitleTrackChange}
+        onCancel={cancelSubtitleTrackChange}
+        finalFocus={subtitleTrackTriggerReference}
+      />
       <EditorHeader
         title={session.title}
         onBack={onBack}

--- a/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
+++ b/apps/frontend/src/components/editor/EditorSubtitlePanel.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+  type RefObject,
+} from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -57,6 +63,8 @@ interface EditorSubtitlePanelProperties {
   providerId?: string;
   subtitleTracks: readonly PlaybackSubtitleTrack[];
   selectedSubtitleTrackKey: string;
+  subtitleTrackChangePending: boolean;
+  subtitleTrackTriggerRef: RefObject<HTMLButtonElement | null>;
   onSelectedSubtitleTrackKeyChange: (value: string) => void;
   subtitlesEnabled: boolean;
   onSubtitlesEnabledChange: (value: boolean) => void;
@@ -85,6 +93,8 @@ export function EditorSubtitlePanel({
   providerId,
   subtitleTracks,
   selectedSubtitleTrackKey,
+  subtitleTrackChangePending,
+  subtitleTrackTriggerRef,
   onSelectedSubtitleTrackKeyChange,
   subtitlesEnabled,
   onSubtitlesEnabledChange,
@@ -207,13 +217,21 @@ export function EditorSubtitlePanel({
                 onValueChange={onSelectedSubtitleTrackKeyChange}
               >
                 <SelectTrigger
+                  ref={subtitleTrackTriggerRef}
                   aria-label="Subtitle track"
                   size="sm"
                   className={editorPropertySelectTriggerClassName()}
                 >
                   <SelectValue placeholder="Select subtitle track" />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent
+                  onCloseAutoFocus={(event) => {
+                    // The confirmation owns focus while it is open.
+                    if (subtitleTrackChangePending) {
+                      event.preventDefault();
+                    }
+                  }}
+                >
                   <SelectGroup>
                     <SelectLabel>Subtitle Tracks</SelectLabel>
                     <SelectItem value="none">No subtitles</SelectItem>

--- a/apps/frontend/src/components/editor/EditorTimeline.tsx
+++ b/apps/frontend/src/components/editor/EditorTimeline.tsx
@@ -1,3 +1,4 @@
+import { ControlTooltip } from "@/components/ui/tooltip";
 import {
   CanvasRenderer,
   Timeline,
@@ -43,35 +44,41 @@ function TrackHeaderColumn({ muted, onMutedChange }: EditorTimelineProperties) {
           {(header: UseTimelineTrackHeaderResult) => (
             <div className="flex h-full min-w-0 flex-1 items-center gap-2">
               {track.id === EDITOR_MEDIA_TRACK_ID ? (
-                <button
-                  type="button"
-                  onClick={() => onMutedChange(!muted)}
-                  title={muted ? "Unmute preview" : "Mute preview"}
-                  aria-label={muted ? "Unmute preview" : "Mute preview"}
-                  aria-pressed={muted}
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+                <ControlTooltip
+                  label={muted ? "Unmute preview" : "Mute preview"}
                 >
-                  {muted ? (
-                    <VolumeX aria-hidden="true" className="h-3.5 w-3.5" />
-                  ) : (
-                    <Volume2 aria-hidden="true" className="h-3.5 w-3.5" />
-                  )}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => onMutedChange(!muted)}
+                    aria-label={muted ? "Unmute preview" : "Mute preview"}
+                    aria-pressed={muted}
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+                  >
+                    {muted ? (
+                      <VolumeX aria-hidden="true" className="h-3.5 w-3.5" />
+                    ) : (
+                      <Volume2 aria-hidden="true" className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </ControlTooltip>
               ) : (
-                <button
-                  type="button"
-                  onClick={() => header.setVisible(!header.visible)}
-                  title={header.visible ? "Hide Sub 1" : "Show Sub 1"}
-                  aria-label={header.visible ? "Hide Sub 1" : "Show Sub 1"}
-                  aria-pressed={!header.visible}
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+                <ControlTooltip
+                  label={header.visible ? "Hide Sub 1" : "Show Sub 1"}
                 >
-                  {header.visible ? (
-                    <Eye aria-hidden="true" className="h-3.5 w-3.5" />
-                  ) : (
-                    <EyeOff aria-hidden="true" className="h-3.5 w-3.5" />
-                  )}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => header.setVisible(!header.visible)}
+                    aria-label={header.visible ? "Hide Sub 1" : "Show Sub 1"}
+                    aria-pressed={!header.visible}
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-editor-border bg-editor-control text-muted-foreground transition-colors hover:bg-editor-control-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-editor-accent/35 focus-visible:outline-none"
+                  >
+                    {header.visible ? (
+                      <Eye aria-hidden="true" className="h-3.5 w-3.5" />
+                    ) : (
+                      <EyeOff aria-hidden="true" className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </ControlTooltip>
               )}
               <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                 {header.label}

--- a/apps/frontend/src/components/editor/EditorViewportScrollbar.tsx
+++ b/apps/frontend/src/components/editor/EditorViewportScrollbar.tsx
@@ -1,3 +1,4 @@
+import { ControlTooltip } from "@/components/ui/tooltip";
 import {
   RangeScrollbar,
   Timeline,
@@ -37,92 +38,95 @@ function ZoomHandle({
   };
 
   return (
-    <Timeline.ViewportScrollbarHandle
-      side={side}
-      title="Drag inward to zoom in; outward to zoom out"
-      aria-valuemin={
-        side === "start" ? 0 : control.viewStartSeconds + control.range.minSpan
-      }
-      aria-valuemax={
-        side === "start"
-          ? control.viewEndSeconds - control.range.minSpan
-          : control.totalDurationSeconds
-      }
-      aria-valuenow={
-        side === "start" ? control.viewStartSeconds : control.viewEndSeconds
-      }
-      aria-valuetext={
-        side === "start" ? control.startValueText : control.endValueText
-      }
-      style={{ touchAction: "none" }}
-      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-        const delta = {
-          ArrowLeft: -10,
-          ArrowRight: 10,
-          PageUp: -120,
-          PageDown: 120,
-        }[event.key];
-        if (delta === undefined) {
-          return;
+    <ControlTooltip label="Drag inward to zoom in; outward to zoom out">
+      <Timeline.ViewportScrollbarHandle
+        side={side}
+        aria-valuemin={
+          side === "start"
+            ? 0
+            : control.viewStartSeconds + control.range.minSpan
         }
-        event.preventDefault();
-        event.stopPropagation();
-        control.onValueChange(
-          viewportRangeAfterZoomDrag({
+        aria-valuemax={
+          side === "start"
+            ? control.viewEndSeconds - control.range.minSpan
+            : control.totalDurationSeconds
+        }
+        aria-valuenow={
+          side === "start" ? control.viewStartSeconds : control.viewEndSeconds
+        }
+        aria-valuetext={
+          side === "start" ? control.startValueText : control.endValueText
+        }
+        style={{ touchAction: "none" }}
+        onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+          const delta = {
+            ArrowLeft: -10,
+            ArrowRight: 10,
+            PageUp: -120,
+            PageDown: 120,
+          }[event.key];
+          if (delta === undefined) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          control.onValueChange(
+            viewportRangeAfterZoomDrag({
+              range: {
+                start: control.viewStartSeconds,
+                end: control.viewEndSeconds,
+              },
+              side,
+              deltaPixels: delta,
+              minSpan: control.range.minSpan,
+              duration: control.totalDurationSeconds,
+            }),
+            { reason: "handle-keyboard", side },
+          );
+        }}
+        onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+          // Preserve the library's accessible handle while replacing its
+          // full-duration linear pointer sensitivity with proportional zoom.
+          event.preventDefault();
+          event.stopPropagation();
+          if (
+            (event.pointerType !== "touch" && event.button !== 0) ||
+            drag.current
+          ) {
+            return;
+          }
+          event.currentTarget.focus();
+          drag.current = {
+            pointerId: event.pointerId,
+            clientX: event.clientX,
             range: {
               start: control.viewStartSeconds,
               end: control.viewEndSeconds,
             },
-            side,
-            deltaPixels: delta,
-            minSpan: control.range.minSpan,
-            duration: control.totalDurationSeconds,
-          }),
-          { reason: "handle-keyboard", side },
-        );
-      }}
-      onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
-        // Preserve the library's accessible handle while replacing its
-        // full-duration linear pointer sensitivity with proportional zoom.
-        event.preventDefault();
-        event.stopPropagation();
-        if (
-          (event.pointerType !== "touch" && event.button !== 0) ||
-          drag.current
-        ) {
-          return;
-        }
-        event.currentTarget.focus();
-        drag.current = {
-          pointerId: event.pointerId,
-          clientX: event.clientX,
-          range: {
-            start: control.viewStartSeconds,
-            end: control.viewEndSeconds,
-          },
-        };
-        event.currentTarget.setPointerCapture(event.pointerId);
-      }}
-      onPointerMove={(event: PointerEvent<HTMLDivElement>) => {
-        const active = drag.current;
-        if (!active || active.pointerId !== event.pointerId) {
-          return;
-        }
-        control.onValueChange(
-          viewportRangeAfterZoomDrag({
-            range: active.range,
-            side,
-            deltaPixels: event.clientX - active.clientX,
-            minSpan: control.range.minSpan,
-            duration: control.totalDurationSeconds,
-          }),
-          { reason: "handle-drag", side },
-        );
-      }}
-      onPointerUp={finishDrag}
-      onPointerCancel={finishDrag}
-      onLostPointerCapture={finishDrag}
-    />
+          };
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event: PointerEvent<HTMLDivElement>) => {
+          const active = drag.current;
+          if (!active || active.pointerId !== event.pointerId) {
+            return;
+          }
+          control.onValueChange(
+            viewportRangeAfterZoomDrag({
+              range: active.range,
+              side,
+              deltaPixels: event.clientX - active.clientX,
+              minSpan: control.range.minSpan,
+              duration: control.totalDurationSeconds,
+            }),
+            { reason: "handle-drag", side },
+          );
+        }}
+        onPointerUp={finishDrag}
+        onPointerCancel={finishDrag}
+        onLostPointerCapture={finishDrag}
+      />
+    </ControlTooltip>
   );
 }
 

--- a/apps/frontend/src/components/editor/useEditorSubtitles.ts
+++ b/apps/frontend/src/components/editor/useEditorSubtitles.ts
@@ -90,6 +90,9 @@ export function useEditorSubtitles({
   const [selectedSubtitleTrackKey, setSelectedSubtitleTrackKey] = useState(
     initialSubtitleSelection.key,
   );
+  const [pendingSubtitleTrackKey, setPendingSubtitleTrackKey] = useState<
+    string | null
+  >(null);
   const [importedSubtitleTrackKey, setImportedSubtitleTrackKey] = useState<
     string | null
   >(initialDraft?.subtitles.importedTrackKey ?? null);
@@ -241,20 +244,8 @@ export function useEditorSubtitles({
     setSubtitleEnabled(subtitleTrackSupportsBurnIn(preferredSubtitleTrack));
   }, [session.selectedSubtitleTrack, subtitleTracks]);
 
-  const handleSelectedSubtitleTrackChange = useCallback(
+  const applySubtitleTrackChange = useCallback(
     (value: string) => {
-      if (
-        value !== "none" &&
-        value !== importedSubtitleTrackKey &&
-        subtitleCues.length > 0 &&
-        globalThis.window !== undefined &&
-        !globalThis.confirm(
-          "Changing subtitle tracks will replace your customized subtitle cues. Continue?",
-        )
-      ) {
-        return;
-      }
-
       subtitleTrackSelectionChangedByUserReference.current = true;
       setSelectedSubtitleTrackKey(value);
       clearSubtitleError();
@@ -272,14 +263,32 @@ export function useEditorSubtitles({
         Boolean(nextTrack && subtitleTrackSupportsBurnIn(nextTrack)),
       );
     },
-    [
-      clearSubtitleError,
-      importedSubtitleTrackKey,
-      resetSubtitleCues,
-      subtitleCues.length,
-      subtitleTracks,
-    ],
+    [clearSubtitleError, resetSubtitleCues, subtitleTracks],
   );
+
+  const handleSelectedSubtitleTrackChange = useCallback(
+    (value: string) => {
+      if (
+        value !== "none" &&
+        value !== importedSubtitleTrackKey &&
+        subtitleCues.length > 0
+      ) {
+        setPendingSubtitleTrackKey(value);
+        return;
+      }
+
+      applySubtitleTrackChange(value);
+    },
+    [applySubtitleTrackChange, importedSubtitleTrackKey, subtitleCues.length],
+  );
+
+  function confirmSubtitleTrackChange() {
+    if (pendingSubtitleTrackKey === null) {
+      return;
+    }
+    applySubtitleTrackChange(pendingSubtitleTrackKey);
+    setPendingSubtitleTrackKey(null);
+  }
 
   const handleSelectedSubtitleTextCommit = useCallback(
     (text: string) => {
@@ -385,6 +394,9 @@ export function useEditorSubtitles({
     clippedSubtitleCues,
     subtitleExportSummary,
     handleSelectedSubtitleTrackChange,
+    subtitleTrackChangePending: pendingSubtitleTrackKey !== null,
+    confirmSubtitleTrackChange,
+    cancelSubtitleTrackChange: () => setPendingSubtitleTrackKey(null),
     selectedSubtitleCue,
     handleSelectedSubtitleTextCommit,
     handleSelectedSubtitleStartCommit,

--- a/apps/frontend/src/components/frontendWorkflow.test.ts
+++ b/apps/frontend/src/components/frontendWorkflow.test.ts
@@ -412,30 +412,36 @@ void test("renders dashboard version badge as a release link when an update is a
 
 void test("renders dashboard dev version badge with disabled update checks", () => {
   const markup = renderToStaticMarkup(
-    createElement(DashboardVersionBadge, {
-      versionLabel: "dev",
-      latestRelease: null,
-      releaseChecksDisabledReason:
-        "Local development build; release update checks are disabled",
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardVersionBadge, {
+        versionLabel: "dev",
+        latestRelease: null,
+        releaseChecksDisabledReason:
+          "Local development build; release update checks are disabled",
+      }),
+    ),
   );
 
   assert.match(markup, /data-dashboard-version-badge/);
   assert.match(markup, /data-dashboard-release-check-disabled="true"/);
   assert.match(markup, />dev</);
-  assert.match(
-    markup,
-    /Local development build; release update checks are disabled/,
-  );
+  assert.match(markup, /tabindex="0"/);
+  assert.doesNotMatch(markup, / title=/);
 });
 
 void test("renders mobile PWA install nudge for native install state", () => {
   const markup = renderToStaticMarkup(
-    createElement(MobilePwaInstallNudgeCard, {
-      mode: "native",
-      onDismiss: () => {},
-      onInstall: () => {},
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(MobilePwaInstallNudgeCard, {
+        mode: "native",
+        onDismiss: () => {},
+        onInstall: () => {},
+      }),
+    ),
   );
 
   assert.match(markup, /Add Cliparr to your home screen/);
@@ -445,11 +451,15 @@ void test("renders mobile PWA install nudge for native install state", () => {
 
 void test("hides mobile PWA install nudge by default", () => {
   const markup = renderToStaticMarkup(
-    createElement(MobilePwaInstallNudgeCard, {
-      mode: "hidden",
-      onDismiss: () => {},
-      onInstall: () => {},
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(MobilePwaInstallNudgeCard, {
+        mode: "hidden",
+        onDismiss: () => {},
+        onInstall: () => {},
+      }),
+    ),
   );
 
   assert.equal(markup, "");
@@ -457,13 +467,17 @@ void test("hides mobile PWA install nudge by default", () => {
 
 void test("does not render dashboard PWA nudge in default server markup", () => {
   const markup = renderToStaticMarkup(
-    createElement(DashboardScreen, {
-      activeViewTransitionSessionId: null,
-      onSelectSession: () => {},
-      onOpenLocalVideo: () => {},
-      onOpenSources: () => {},
-      onDisconnect: () => {},
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardScreen, {
+        activeViewTransitionSessionId: null,
+        onSelectSession: () => {},
+        onOpenLocalVideo: () => {},
+        onOpenSources: () => {},
+        onDisconnect: () => {},
+      }),
+    ),
   );
 
   assert.doesNotMatch(markup, /Add Cliparr to your home screen/);
@@ -471,13 +485,17 @@ void test("does not render dashboard PWA nudge in default server markup", () => 
 
 void test("reserves dashboard playback card space before sessions load", () => {
   const markup = renderToStaticMarkup(
-    createElement(DashboardScreen, {
-      activeViewTransitionSessionId: null,
-      onSelectSession: () => {},
-      onOpenLocalVideo: () => {},
-      onOpenSources: () => {},
-      onDisconnect: () => {},
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardScreen, {
+        activeViewTransitionSessionId: null,
+        onSelectSession: () => {},
+        onOpenLocalVideo: () => {},
+        onOpenSources: () => {},
+        onDisconnect: () => {},
+      }),
+    ),
   );
 
   assert.match(markup, /data-dashboard-loading-grid/);
@@ -492,13 +510,17 @@ void test("reserves dashboard playback card space before sessions load", () => {
 
 void test("reserves dashboard version badge space before health loads", () => {
   const markup = renderToStaticMarkup(
-    createElement(DashboardScreen, {
-      activeViewTransitionSessionId: null,
-      onSelectSession: () => {},
-      onOpenLocalVideo: () => {},
-      onOpenSources: () => {},
-      onDisconnect: () => {},
-    }),
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(DashboardScreen, {
+        activeViewTransitionSessionId: null,
+        onSelectSession: () => {},
+        onOpenLocalVideo: () => {},
+        onOpenSources: () => {},
+        onDisconnect: () => {},
+      }),
+    ),
   );
 
   assert.match(markup, /data-dashboard-version-badge/);
@@ -507,7 +529,13 @@ void test("reserves dashboard version badge space before health loads", () => {
 
 void test("renders mobile PWA install nudge on the initial eligible browser pass", () => {
   withMobilePwaBrowserEnvironment(() => {
-    const markup = renderToStaticMarkup(createElement(MobilePwaInstallNudge));
+    const markup = renderToStaticMarkup(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(MobilePwaInstallNudge),
+      ),
+    );
 
     assert.match(markup, /Add Cliparr to your home screen/);
     assert.match(markup, /data-pwa-install-mode="ios"/);

--- a/apps/frontend/src/components/sources/SourcesDialog.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialog.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { DialogWindow } from "@/components/ui/dialog";
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import {
   SourceCard,
   SourcesConnectSection,
@@ -70,7 +71,10 @@ export default function SourcesDialog({
     saveSourceEdits,
     toggleSourceEnabled,
     checkSource,
-    deleteSource,
+    sourceToRemove,
+    requestSourceRemoval,
+    cancelSourceRemoval,
+    confirmSourceRemoval,
     updateDraftName,
     updateDraftBaseUrl,
   } = useSourcesState({
@@ -195,7 +199,7 @@ export default function SourcesDialog({
               onSave={() => saveSourceEdits(source)}
               onToggleEnabled={() => toggleSourceEnabled(source)}
               onRefresh={() => checkSource(source)}
-              onRemove={() => deleteSource(source)}
+              onRemove={() => requestSourceRemoval(source)}
             />
           </motion.div>
         ))}
@@ -212,6 +216,14 @@ export default function SourcesDialog({
       portalClassName="p-4 sm:p-6"
       popupClassName="h-full max-w-6xl rounded-lg"
     >
+      <ConfirmationDialog
+        open={isOpen && sourceToRemove !== null}
+        title="Remove source?"
+        description={`Remove ${sourceToRemove?.name ?? "this source"}? It can be reconnected later.`}
+        confirmLabel="Remove source"
+        onCancel={cancelSourceRemoval}
+        onConfirm={() => void confirmSourceRemoval()}
+      />
       <SourcesDialogHeader
         counts={counts}
         forceAddSourceOpen={forceAddSourceOpen}

--- a/apps/frontend/src/components/sources/SourcesDialogSections.tsx
+++ b/apps/frontend/src/components/sources/SourcesDialogSections.tsx
@@ -12,11 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utilities";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { ControlTooltip } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -35,29 +31,6 @@ import type { MediaSource, ProviderSession } from "@/providers/types";
 import { formatProviderName } from "@/components/providers/ProviderGlyph";
 import SourceConnectPanel from "@/components/sources/SourceConnectPanel";
 import type { Feedback, SourceFilter } from "@/components/sources/sourcesTypes";
-
-function TooltipWrap({
-  message,
-  children,
-}: {
-  message: string | null;
-  children: React.ReactElement;
-}) {
-  if (!message) {
-    return children;
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-flex" tabIndex={0}>
-          {children}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top">{message}</TooltipContent>
-    </Tooltip>
-  );
-}
 
 interface SourceCounts {
   all: number;
@@ -274,7 +247,7 @@ export function SourcesDialogHeader({
               {showConnectPanel ? "Hide" : "Add Source"}
             </button>
           )}
-          <TooltipWrap message={reloadDisabledReason}>
+          <ControlTooltip disabled side="top" label={reloadDisabledReason}>
             <button
               type="button"
               onClick={onReloadList}
@@ -289,8 +262,8 @@ export function SourcesDialogHeader({
               />
               Reload
             </button>
-          </TooltipWrap>
-          <TooltipWrap message={refreshAllDisabledReason}>
+          </ControlTooltip>
+          <ControlTooltip disabled side="top" label={refreshAllDisabledReason}>
             <button
               type="button"
               onClick={onRefreshAll}
@@ -308,7 +281,7 @@ export function SourcesDialogHeader({
               />
               Refresh All
             </button>
-          </TooltipWrap>
+          </ControlTooltip>
           <button
             type="button"
             onClick={onClose}
@@ -721,7 +694,11 @@ export function SourceCard({
       </AnimatePresence>
 
       <div className="mt-4 flex flex-wrap gap-2">
-        <TooltipWrap message={canSaveEdits ? null : saveDisabledReason}>
+        <ControlTooltip
+          disabled
+          side="top"
+          label={canSaveEdits ? null : saveDisabledReason}
+        >
           <button
             type="button"
             onClick={() => void onSave()}
@@ -730,7 +707,7 @@ export function SourceCard({
           >
             Save Changes
           </button>
-        </TooltipWrap>
+        </ControlTooltip>
         <div
           className={joinClassNames(
             "inline-flex h-8 items-center gap-3 rounded-md border border-border bg-card px-3 text-xs font-medium normal-case tracking-normal text-foreground transition-opacity",
@@ -738,7 +715,7 @@ export function SourceCard({
           )}
         >
           <span>{source.enabled ? "Enabled" : "Disabled"}</span>
-          <TooltipWrap message={busyDisabledReason}>
+          <ControlTooltip disabled side="top" label={busyDisabledReason}>
             <Switch
               aria-label={`${source.enabled ? "Disable" : "Enable"} ${
                 source.name
@@ -747,9 +724,9 @@ export function SourceCard({
               disabled={isBusy}
               onCheckedChange={() => void onToggleEnabled()}
             />
-          </TooltipWrap>
+          </ControlTooltip>
         </div>
-        <TooltipWrap message={busyDisabledReason}>
+        <ControlTooltip disabled side="top" label={busyDisabledReason}>
           <button
             type="button"
             onClick={() => void onRefresh()}
@@ -764,8 +741,8 @@ export function SourceCard({
             />
             Refresh
           </button>
-        </TooltipWrap>
-        <TooltipWrap message={busyDisabledReason}>
+        </ControlTooltip>
+        <ControlTooltip disabled side="top" label={busyDisabledReason}>
           <button
             type="button"
             onClick={() => void onRemove()}
@@ -775,7 +752,7 @@ export function SourceCard({
             <Trash2 className="h-4 w-4" />
             Remove
           </button>
-        </TooltipWrap>
+        </ControlTooltip>
       </div>
     </article>
   );

--- a/apps/frontend/src/components/sources/useSourcesState.ts
+++ b/apps/frontend/src/components/sources/useSourcesState.ts
@@ -53,6 +53,9 @@ export function useSourcesState({
   const [error, setError] = useState("");
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [showAddSource, setShowAddSource] = useState(false);
+  const [sourceToRemove, setSourceToRemove] = useState<MediaSource | null>(
+    null,
+  );
   const latestLoadRequestIdReference = useRef(0);
   const isOpenReference = useRef(isOpen);
   const sourceLogger = useMemo(
@@ -285,13 +288,12 @@ export function useSourcesState({
     );
   }
 
-  async function deleteSource(source: MediaSource) {
-    const confirmed = globalThis.confirm(
-      `Remove ${source.name}? It can be reconnected later.`,
-    );
-    if (!confirmed) {
+  async function confirmSourceRemoval() {
+    const source = sourceToRemove;
+    if (!source || !isOpenReference.current) {
       return;
     }
+    setSourceToRemove(null);
 
     await runSourceAction(
       source,
@@ -387,6 +389,7 @@ export function useSourcesState({
   useEffect(() => {
     if (!isOpen) {
       setShowAddSource(false);
+      setSourceToRemove(null);
       return;
     }
 
@@ -464,7 +467,10 @@ export function useSourcesState({
     saveSourceEdits,
     toggleSourceEnabled,
     checkSource,
-    deleteSource,
+    sourceToRemove,
+    requestSourceRemoval: setSourceToRemove,
+    cancelSourceRemoval: () => setSourceToRemove(null),
+    confirmSourceRemoval,
     updateDraftName,
     updateDraftBaseUrl,
   };

--- a/apps/frontend/src/components/ui/bouncy-accordion.tsx
+++ b/apps/frontend/src/components/ui/bouncy-accordion.tsx
@@ -1,0 +1,179 @@
+/*
+ * Bouncy Accordion adapted from https://beui.dev/r/bouncy-accordion/raw
+ * MIT License — Copyright (c) 2026 Saurabh Chauhan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { ChevronDown } from "lucide-react";
+import { motion, useReducedMotion, type Transition } from "motion/react";
+import { useId, useState, type ReactNode } from "react";
+import { cliparrMotionTransitions } from "@/lib/motionPresets";
+import { cn } from "@/lib/utilities";
+
+interface BouncyAccordionItem {
+  id: string;
+  title: ReactNode;
+  description: ReactNode;
+  icon?: ReactNode;
+  disabled?: boolean;
+}
+
+interface BouncyAccordionProperties {
+  items: readonly BouncyAccordionItem[];
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+  collapsible?: boolean;
+  className?: string;
+}
+
+const rowTransition = {
+  type: "spring",
+  duration: 0.55,
+  bounce: 0.38,
+} satisfies Transition;
+
+const contentOpenTransition = {
+  type: "spring",
+  duration: 0.58,
+  bounce: 0.32,
+} satisfies Transition;
+
+const contentCloseTransition = {
+  type: "spring",
+  duration: 0.46,
+  bounce: 0.26,
+} satisfies Transition;
+
+const chevronTransition = {
+  type: "spring",
+  duration: 0.42,
+  bounce: 0.28,
+} satisfies Transition;
+
+export function BouncyAccordion({
+  items,
+  value,
+  defaultValue = null,
+  onValueChange,
+  collapsible = true,
+  className,
+}: BouncyAccordionProperties) {
+  const reducedMotion = useReducedMotion();
+  const baseId = useId();
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const activeValue = value === undefined ? internalValue : value;
+  const activeIndex = items.findIndex((item) => item.id === activeValue);
+
+  function toggleItem(id: string) {
+    if (activeValue === id && !collapsible) {
+      return;
+    }
+    const nextValue = activeValue === id ? null : id;
+    if (value === undefined) {
+      setInternalValue(nextValue);
+    }
+    onValueChange?.(nextValue);
+  }
+
+  return (
+    <div className={cn("w-full min-w-0", className)}>
+      {items.map((item, index) => {
+        const open = item.id === activeValue;
+        const contentTransition = open
+          ? contentOpenTransition
+          : contentCloseTransition;
+        const previousIsOpen = activeIndex === index - 1;
+        const startsGroup = open || index === 0 || previousIsOpen;
+        const endsGroup =
+          open || index === items.length - 1 || activeIndex === index + 1;
+        const contentId = `${baseId}-${item.id}-content`;
+        const triggerId = `${baseId}-${item.id}-trigger`;
+
+        return (
+          <motion.div
+            key={item.id}
+            layout={reducedMotion ? false : "position"}
+            initial={false}
+            transition={reducedMotion ? { duration: 0 } : rowTransition}
+            data-state={open ? "open" : "closed"}
+            className={cn(
+              "border border-border bg-card text-card-foreground",
+              startsGroup ? "rounded-t-md" : "border-t-0",
+              endsGroup && "rounded-b-md",
+              index > 0 && (open || previousIsOpen) && "mt-3",
+              item.disabled && "opacity-60",
+            )}
+          >
+            <button
+              id={triggerId}
+              type="button"
+              disabled={item.disabled}
+              aria-expanded={open}
+              aria-controls={contentId}
+              onClick={() => toggleItem(item.id)}
+              className="flex min-h-11 w-full items-center gap-2 rounded-md px-3 py-3 text-left text-sm font-medium transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {item.icon && (
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-muted-foreground"
+                >
+                  {item.icon}
+                </span>
+              )}
+              <span className="min-w-0 flex-1">{item.title}</span>
+              <motion.span
+                aria-hidden="true"
+                initial={false}
+                animate={{ rotate: open ? 180 : 0 }}
+                transition={reducedMotion ? { duration: 0 } : chevronTransition}
+                className="shrink-0 text-muted-foreground"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </motion.span>
+            </button>
+            <motion.div
+              id={contentId}
+              role="region"
+              aria-labelledby={triggerId}
+              aria-hidden={!open}
+              inert={!open}
+              initial={false}
+              animate={{ height: open ? "auto" : 0 }}
+              transition={reducedMotion ? { duration: 0 } : contentTransition}
+              className="overflow-hidden"
+            >
+              <motion.div
+                initial={false}
+                animate={{ opacity: open ? 1 : 0 }}
+                transition={
+                  reducedMotion
+                    ? { duration: 0 }
+                    : cliparrMotionTransitions.fast
+                }
+                className="px-3 pb-3"
+              >
+                {item.description}
+              </motion.div>
+            </motion.div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/confirmation-dialog.tsx
+++ b/apps/frontend/src/components/ui/confirmation-dialog.tsx
@@ -1,0 +1,56 @@
+import { useRef, type ComponentProps } from "react";
+import { DialogFooter, DialogWindow } from "@/components/ui/dialog";
+import {
+  primaryButtonClasses,
+  secondaryButtonClasses,
+} from "@/components/ui/control-styles";
+
+export function ConfirmationDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  finalFocus,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  finalFocus?: ComponentProps<typeof DialogWindow>["finalFocus"];
+}) {
+  const cancelReference = useRef<HTMLButtonElement>(null);
+
+  return (
+    <DialogWindow
+      open={open}
+      onClose={onCancel}
+      title={title}
+      description={description}
+      closeLabel="Cancel confirmation"
+      initialFocus={cancelReference}
+      finalFocus={finalFocus}
+    >
+      <DialogFooter className="p-4">
+        <button
+          ref={cancelReference}
+          type="button"
+          className={`${secondaryButtonClasses} min-h-11 sm:min-h-9`}
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={`${primaryButtonClasses} min-h-11 sm:min-h-9`}
+          onClick={onConfirm}
+        >
+          {confirmLabel}
+        </button>
+      </DialogFooter>
+    </DialogWindow>
+  );
+}

--- a/apps/frontend/src/components/ui/tooltip.tsx
+++ b/apps/frontend/src/components/ui/tooltip.tsx
@@ -52,4 +52,64 @@ function TooltipContent({
   );
 }
 
+interface ControlTooltipProperties {
+  label?: string | null;
+  disabled?: boolean;
+  children: React.ReactElement;
+  side?: React.ComponentProps<typeof TooltipContent>["side"];
+}
+
+export function ControlTooltip({ label, ...props }: ControlTooltipProperties) {
+  return label ? (
+    <LabeledControlTooltip label={label} {...props} />
+  ) : (
+    props.children
+  );
+}
+
+function LabeledControlTooltip({
+  label,
+  disabled = false,
+  children,
+  side = "bottom",
+}: ControlTooltipProperties & { label: string }) {
+  const [open, setOpen] = React.useState(false);
+  const nestedTriggerReference = React.useRef(false);
+
+  function trackTrigger(event: React.SyntheticEvent<HTMLElement>) {
+    const target = event.target;
+    const nested =
+      target instanceof Element &&
+      target.closest('[data-slot="tooltip-trigger"]') !== event.currentTarget;
+    nestedTriggerReference.current = nested;
+    if (nested) {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <Tooltip
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen && !nestedTriggerReference.current);
+      }}
+    >
+      <TooltipTrigger
+        asChild
+        onFocusCapture={trackTrigger}
+        onPointerMoveCapture={trackTrigger}
+      >
+        {disabled ? (
+          <span className="inline-flex" tabIndex={0}>
+            {children}
+          </span>
+        ) : (
+          children
+        )}
+      </TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/www/src/components/BaseLayout.astro
+++ b/apps/www/src/components/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import { ClientRouter, fade } from "astro:transitions";
+import SiteTooltips from "@/components/SiteTooltips.astro";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import { site } from "@/data/product";
@@ -169,7 +170,7 @@ const structuredDataItems = [
               "aria-pressed",
               theme === "dark" ? "true" : "false",
             );
-            button.setAttribute("title", `Switch to ${nextTheme} theme`);
+            button.setAttribute("data-tooltip", `Switch to ${nextTheme} theme`);
             button.setAttribute("data-theme-toggle-state", theme);
             button.setAttribute("data-theme-source", source);
           });
@@ -243,5 +244,6 @@ const structuredDataItems = [
       <slot />
     </main>
     <Footer />
+    <SiteTooltips />
   </body>
 </html>

--- a/apps/www/src/components/CommandBlock.astro
+++ b/apps/www/src/components/CommandBlock.astro
@@ -93,7 +93,7 @@ const groupId = `command-${hashCommandBlockId(
                   aria-label="Copy command"
                   class="command-copy-button"
                   data-command-copy
-                  title="Copy command"
+                  data-tooltip="Copy command"
                   type="button"
                 >
                   <svg
@@ -175,7 +175,7 @@ const groupId = `command-${hashCommandBlockId(
           aria-label="Copy command"
           class="command-copy-button"
           data-command-copy
-          title="Copy command"
+          data-tooltip="Copy command"
           type="button"
         >
           <svg
@@ -301,11 +301,11 @@ const groupId = `command-${hashCommandBlockId(
     await writeClipboardText(code.trimEnd());
     button.dataset.copyState = "copied";
     button.setAttribute("aria-label", "Copied");
-    button.title = "Copied";
+    button.dataset.tooltip = "Copied";
 
     window.setTimeout(() => {
       button.setAttribute("aria-label", "Copy command");
-      button.title = "Copy command";
+      button.dataset.tooltip = "Copy command";
       delete button.dataset.copyState;
     }, 1600);
   }
@@ -325,11 +325,11 @@ const groupId = `command-${hashCommandBlockId(
         void copyCommand(item).catch(() => {
           item.dataset.copyState = "failed";
           item.setAttribute("aria-label", "Copy failed");
-          item.title = "Copy failed";
+          item.dataset.tooltip = "Copy failed";
 
           window.setTimeout(() => {
             item.setAttribute("aria-label", "Copy command");
-            item.title = "Copy command";
+            item.dataset.tooltip = "Copy command";
             delete item.dataset.copyState;
           }, 1600);
         });

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -34,7 +34,7 @@ const mobileMenuId = "site-mobile-menu";
         type="button"
         data-theme-toggle
         aria-label="Toggle color theme"
-        title="Toggle color theme"
+        data-tooltip="Toggle color theme"
         class="focus-ring inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       >
         <svg
@@ -118,7 +118,7 @@ const mobileMenuId = "site-mobile-menu";
         type="button"
         data-theme-toggle
         aria-label="Toggle color theme"
-        title="Toggle color theme"
+        data-tooltip="Toggle color theme"
         class="focus-ring inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       >
         <svg

--- a/apps/www/src/components/SiteTooltips.astro
+++ b/apps/www/src/components/SiteTooltips.astro
@@ -1,0 +1,151 @@
+<div
+  id="site-tooltip"
+  role="tooltip"
+  hidden
+  class="fixed z-[60] w-max max-w-[min(18rem,calc(100vw-1rem))] rounded-md border border-border bg-popover px-3 py-2 text-xs leading-relaxed text-popover-foreground shadow-md"
+>
+</div>
+
+<script>
+  // Delegate events so tooltips also work after Astro navigation and React updates.
+  let activeTrigger: HTMLElement | null = null;
+  let dismissedTrigger: HTMLElement | null = null;
+  let showTimer: ReturnType<typeof setTimeout> | undefined;
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  const labelObserver = new MutationObserver(updateTooltip);
+  const tooltipId = "site-tooltip";
+  const tooltip = () => document.getElementById(tooltipId);
+  const triggerFor = (target: EventTarget | null) =>
+    target instanceof Element
+      ? target.closest<HTMLElement>("[data-tooltip]")
+      : null;
+
+  function hideTooltip() {
+    clearTimeout(showTimer);
+    clearTimeout(hideTimer);
+    labelObserver.disconnect();
+    const content = tooltip();
+    if (content) content.hidden = true;
+    if (activeTrigger) {
+      const descriptions = (
+        activeTrigger.getAttribute("aria-describedby") ?? ""
+      )
+        .split(/\s+/)
+        .filter((id) => id && id !== tooltipId);
+      if (descriptions.length) {
+        activeTrigger.setAttribute("aria-describedby", descriptions.join(" "));
+      } else {
+        activeTrigger.removeAttribute("aria-describedby");
+      }
+    }
+    activeTrigger = null;
+  }
+
+  function updateTooltip() {
+    const trigger = activeTrigger;
+    const content = tooltip();
+    if (!trigger?.isConnected || !trigger.dataset.tooltip || !content) {
+      hideTooltip();
+      return;
+    }
+    content.textContent = trigger.dataset.tooltip;
+    const bounds = trigger.getBoundingClientRect();
+    const gap = 8;
+    const left = Math.max(
+      gap,
+      Math.min(
+        bounds.left + (bounds.width - content.offsetWidth) / 2,
+        window.innerWidth - content.offsetWidth - gap,
+      ),
+    );
+    const top =
+      bounds.bottom + content.offsetHeight + gap * 2 > window.innerHeight
+        ? Math.max(gap, bounds.top - content.offsetHeight - gap)
+        : bounds.bottom + gap;
+    content.style.left = `${left}px`;
+    content.style.top = `${top}px`;
+  }
+
+  function showTooltip(trigger: HTMLElement, delay: number) {
+    clearTimeout(hideTimer);
+    if (trigger === activeTrigger || trigger === dismissedTrigger) return;
+    hideTooltip();
+    activeTrigger = trigger;
+    showTimer = setTimeout(() => {
+      const content = tooltip();
+      if (!content) {
+        hideTooltip();
+        return;
+      }
+      content.hidden = false;
+      updateTooltip();
+      if (activeTrigger !== trigger) return;
+      const descriptions = trigger.getAttribute("aria-describedby");
+      trigger.setAttribute(
+        "aria-describedby",
+        [descriptions, tooltipId].filter(Boolean).join(" "),
+      );
+      labelObserver.observe(trigger, {
+        attributes: true,
+        attributeFilter: ["data-tooltip"],
+      });
+    }, delay);
+  }
+
+  document.addEventListener("pointerover", (event) => {
+    if (event.pointerType === "touch") return;
+    if (event.target === tooltip()) {
+      clearTimeout(hideTimer);
+      return;
+    }
+    const trigger = triggerFor(event.target);
+    if (trigger) showTooltip(trigger, 250);
+  });
+
+  document.addEventListener("pointerout", (event) => {
+    const trigger = triggerFor(event.target);
+    if (
+      event.relatedTarget instanceof Node &&
+      trigger?.contains(event.relatedTarget)
+    )
+      return;
+    if (trigger === dismissedTrigger) dismissedTrigger = null;
+    if (event.relatedTarget === tooltip()) return;
+    if (activeTrigger?.contains(document.activeElement)) return;
+    if (
+      activeTrigger &&
+      (trigger === activeTrigger || event.target === tooltip())
+    ) {
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(hideTooltip, 100);
+    }
+  });
+
+  document.addEventListener("focusin", (event) => {
+    const trigger = triggerFor(event.target);
+    if (trigger) showTooltip(trigger, 0);
+  });
+  document.addEventListener("focusout", (event) => {
+    const trigger = triggerFor(event.target);
+    if (
+      event.relatedTarget instanceof Node &&
+      trigger?.contains(event.relatedTarget)
+    )
+      return;
+    if (trigger === dismissedTrigger) dismissedTrigger = null;
+    if (trigger === activeTrigger) hideTooltip();
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      dismissedTrigger = activeTrigger;
+      hideTooltip();
+    }
+  });
+  document.addEventListener("pointerdown", hideTooltip);
+  document.addEventListener("scroll", hideTooltip, true);
+  window.addEventListener("resize", hideTooltip);
+  document.addEventListener("astro:before-swap", () => {
+    hideTooltip();
+    dismissedTrigger = null;
+  });
+</script>

--- a/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
+++ b/apps/www/src/components/convert/ConvertPwaInstallPrompt.tsx
@@ -90,7 +90,7 @@ export function ConvertPwaInstallPromptView({
           disabled={prompting}
           className="focus-ring inline-flex h-8 items-center justify-center gap-2 rounded-md border border-border bg-background px-3 text-xs font-semibold uppercase tracking-[var(--tracking-caps-sm)] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
           aria-label="Install Cliparr Convert"
-          title="Install Cliparr Convert"
+          data-tooltip="Install Cliparr Convert"
           data-convert-pwa-install-mode="native"
           data-convert-pwa-form-factor="desktop"
         >
@@ -130,7 +130,7 @@ export function ConvertPwaInstallPromptView({
           onClick={onDismiss}
           className="focus-ring inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           aria-label="Dismiss install prompt"
-          title="Dismiss"
+          data-tooltip="Dismiss"
         >
           <X className="h-4 w-4" />
         </button>

--- a/apps/www/src/pages/blog/index.astro
+++ b/apps/www/src/pages/blog/index.astro
@@ -34,7 +34,7 @@ const posts = ((await getCollection("blog")) as BlogEntry[]).toSorted(
           class="focus-ring mt-1 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground no-underline transition-colors hover:bg-accent hover:text-foreground"
           href="/blog/rss.xml"
           aria-label="Subscribe to the Cliparr blog RSS feed"
-          title="RSS feed"
+          data-tooltip="RSS feed"
         >
           <RssIcon class="h-4 w-4" />
         </a>


### PR DESCRIPTION
Replace the export dialog’s native filename disclosure with a spring accordion, and replace browser confirmations and native tooltips with controls styled to match Cliparr’s colors, spacing, and corner radius.

- Source removal and subtitle replacement use a shared confirmation dialog. Cancel and Escape preserve existing data, with explicit focus handoff from the subtitle selector and restoration after dismissal.
- App tooltips share one wrapper, support disabled controls, and show only the nearest tooltip on nested timeline handles. Website tooltips support keyboard focus, Escape dismissal, live labels, and Astro navigation.
- The filename accordion preserves form state, hides collapsed fields from keyboard navigation, and respects reduced-motion preferences.

Validation: `pnpm preflight` on Node 24; frontend and website production builds; browser checks for desktop/mobile layouts, confirm/cancel behavior, selector focus, nested tooltips, timeline keyboard/pointer dragging, tooltip timer cleanup, and live labels.
